### PR TITLE
preprocessor: Fix memory leak in RepliStruct::process

### DIFF
--- a/r_comp/preprocessor.cpp
+++ b/r_comp/preprocessor.cpp
@@ -675,6 +675,8 @@ int32	RepliStruct::process(){
 				tempStruct = (*iter); 
 				// insert new structures 
 				args.insert(++iter, newStruct->args.begin(), newStruct->args.end());
+				// The args have been copied out of newStruct. We are finished with it.
+				delete newStruct;
 				// reinit iterator and find location again
 				iter = args.begin();
 				iterEnd = args.end();


### PR DESCRIPTION
The call to loadReplicodeFile creates newStruct. We need to delete it when finished with it.
(This is not a severe memory leak since this object is only created when processing a few !load directives. But it should be fixed.)