### PR TITLE
pong.2.replicode: Remove unused code.

### DIFF
--- a/Test/V1.2/pong.2.replicode
+++ b/Test/V1.2/pong.2.replicode
@@ -19,12 +19,20 @@ b:(ent 1)
 ;;;;;;;;;;;;;;;;;;;;;
 ;; Top-level model ;;
 
-m_run_0:(mdl |[] []
-   (fact (mk.val b: position_y : :) t0: t1: ::)
-   (fact run t0: t1: ::); drive.
-|[]
-|[]
-[stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 1 forever primary nil 1]]
+m_run_0:(mdl 
+|[]; template arguments
+[]; LHS and RHS patterns of the model
+   (fact (mk.val b: position_y : :) t0: t1: ::); LHS
+   (fact run t0: t1: ::);                 drive. RHS
+|[]; forward guards
+|[]; backward guards
+[stdin drives]; output groups
+1; strength of the model
+1; number of evidences
+1; success rate
+0; derivative of the success rate
+1; psln_tr (saliency change propagation threshold)
+) [[SYNC_ONCE now 1 forever primary nil 1]]
 
 ;;;;;;;;;;;;;;;;;;;;;;
 ;; input generators ;;


### PR DESCRIPTION
Correct me if I'm wrong, but the code that this pull request removes from pong.2 is not used. The purpose of the program is to steadily update position_y. b_is_a_ball, blue_color, etc. are defined but not used. And while the m_speak model is not used, it had some nice comments which I moved to the definition of m_run. If you think the code should be kept, feel free to reject this pull request.

(A little more context. Thor pointed me to this test program as a way to learn how values are updated. I spent too much time looking at the other code before I realized it is an unused remnant from another example, and confusing. Quite confusing.)