### PR TITLE
Open code files as binary to process line endings properly.

### DIFF
--- a/r_comp/preprocessor.cpp
+++ b/r_comp/preprocessor.cpp
@@ -760,7 +760,7 @@ RepliStruct	*RepliStruct::loadReplicodeFile(const	std::string	&filename){
 	// Mark this file as loaded.
 	LoadedFilePaths.push_back(filename);
 
-	std::ifstream loadStream(filename.c_str());
+	std::ifstream loadStream(filename.c_str(), std::ios::binary | ios::in);
 	if (loadStream.bad() || loadStream.fail() || loadStream.eof()) {
 		newRoot->error += "Load: File '" + filename + "' cannot be read! ";
 		loadStream.close();

--- a/r_exec/init.cpp
+++ b/r_exec/init.cpp
@@ -127,7 +127,7 @@ namespace	r_exec{
 
 	bool	Compile(const	char	*filename,std::string	&error,bool	compile_metadata){
 
-		std::ifstream	source_code(filename);
+		std::ifstream	source_code(filename, std::ios::binary | ios::in);
 		if(!source_code.good()){
 
 			error="unable to load file ";


### PR DESCRIPTION
The preprocessor already has code to handle line endings with LF or CR/LF:
https://github.com/IIIM-IS/replicode/blob/5525338a37bc6ecc4db965d9f83cd8d68e17c5f1/r_comp/preprocessor.cpp#L182

But if the file is opened as text, then CR/LF is converted to just LF. This would be OK, except that the parser tries to seek backwards over the previously-read byte, but seeking backwords doesn't "uncovert" line endings and seeks to the wrong place, resulting in apparent syntax errors in the file:
https://github.com/IIIM-IS/replicode/blob/5525338a37bc6ecc4db965d9f83cd8d68e17c5f1/r_comp/preprocessor.cpp#L135

Since the parser already handles different line endings, the easiest solution is to open the code files as binary so that line ending characters are read as-is.

(This issue made me lose at least a day. I downloaded a code file from GitHub and my browser chose how to save the line endings on WIndows. In my code editor it looked normal, but Replicode reported syntax errors as explained above. Opening the files as binary solved it and could save others a lot of trouble.)