### PR TITLE
model_base: Fix bug in check_existence to erase from white_list

### DIFF
--- a/r_exec/model_base.cpp
+++ b/r_exec/model_base.cpp
@@ -267,12 +267,12 @@ namespace	r_exec{
 		{
 			copy = *m;
 			copy.touch_time = Now();
-			black_list.erase(*m);
-			black_list.insert(copy);
+			white_list.erase(*m);
+			white_list.insert(copy);
 
 			//(*m).touch_time=Now();   // jm
 			mdlCS.leave();
-			return	(*m).mdl;
+			return	copy.mdl;
 		}
 		_Mem::Get()->pack_hlp(e.mdl);
 		white_list.insert(e);
@@ -303,11 +303,11 @@ namespace	r_exec{
 
 			copy = *m;
 			copy.touch_time = Now();
-			black_list.erase(*m);
-			black_list.insert(copy);
+			white_list.erase(*m);
+			white_list.insert(copy);
 
 			//(*m).touch_time=Now();  //jm
-			_m0=(*m).mdl;
+			_m0=copy.mdl;
 			Code	*rhs=m1->get_reference(m1->code(m1->code(MDL_OBJS).asIndex()+2).asIndex());
 			Code	*im0=rhs->get_reference(0);
 			im0->set_reference(0,_m0);	// change imdl m0 into imdl _m0.
@@ -330,12 +330,12 @@ namespace	r_exec{
 		if(m!=white_list.end()){
 			copy = *m;
 			copy.touch_time = Now();
-			black_list.erase(*m);
-			black_list.insert(copy);
+			white_list.erase(*m);
+			white_list.insert(copy);
 
 			//(*m).touch_time=Now();  //jm
 			mdlCS.leave();
-			_m1=(*m).mdl;
+			_m1=copy.mdl;
 			return;
 		}
 		if(_m0==m0){


### PR DESCRIPTION
When the code was updated to compile with the new Visual Studio, the following code in model_base was changed because the m iterator is const and it can't be used the change touch_time.

https://github.com/IIIM-IS/replicode/commit/e54e877e914772c2b1688da1d7ea32b4fb92630d#diff-1f360b855338f35a07b07c1f6d6c9999

But there is a copy/paste error. In the first check, black_list needs to be updated. But in the second check white_list needs to be updated. Also, once the list is changed, the m pointer is invalid, so further access needs to be done through the copy.
