### PR TITLE
Revert unneeded pull request #32.

### DIFF
--- a/CorrelatorTest/CorrelatorTest.cpp
+++ b/CorrelatorTest/CorrelatorTest.cpp
@@ -111,7 +111,7 @@ void	decompile(r_comp::Decompiler	&decompiler,r_comp::Image	*image,uint64	time_o
 #else
 	std::cout<<"\ndecompiling ...\n";
 	std::ostringstream	decompiled_code;
-	uint32	object_count=decompiler.decompile(image,&decompiled_code,time_offset,false,false);
+	uint32	object_count=decompiler.decompile(image,&decompiled_code,time_offset,false);
 	std::cout<<"... done\n";
 	std::cout<<"\n\nDECOMPILATION\n\n"<<decompiled_code.str()<<std::endl;
 	std::cout<<"Image taken at: "<<Time::ToString_year(image->timestamp)<<std::endl<<std::endl;

--- a/Test/Test.cpp
+++ b/Test/Test.cpp
@@ -213,7 +213,7 @@ void test_many_injections(r_exec::_Mem	*mem, uint32 sampling_period_ms, uint32 n
 	}
 }
 
-void	decompile(Decompiler	&decompiler,r_comp::Image	*image,uint64	time_offset,bool	ignore_named_objects, bool	decompiled_show_oid){
+void	decompile(Decompiler	&decompiler,r_comp::Image	*image,uint64	time_offset,bool	ignore_named_objects){
 
 #ifdef	DECOMPILE_ONE_BY_ONE
 	uint32	object_count=decompiler.decompile_references(image);
@@ -235,7 +235,7 @@ void	decompile(Decompiler	&decompiler,r_comp::Image	*image,uint64	time_offset,bo
 	}
 #else
 	std::ostringstream	decompiled_code;
-	uint32	object_count=decompiler.decompile(image,&decompiled_code,time_offset,ignore_named_objects,decompiled_show_oid);
+	uint32	object_count=decompiler.decompile(image,&decompiled_code,time_offset,ignore_named_objects);
 	//uint32	object_count=image->code_segment.objects.size();
 	std::cout<<"\n\n> DECOMPILATION\n\n"<<decompiled_code.str()<<std::endl;
 	std::cout<<"> image taken at: "<<Time::ToString_year(image->timestamp)<<std::endl;
@@ -264,7 +264,7 @@ void	write_to_file(r_comp::Image	*image,std::string	&image_path,Decompiler	*deco
 		r_comp::Image			*_i=new	r_comp::Image();
 		_i->load(img);
 
-		decompile(*decompiler,_i,time_offset,false,false);
+		decompile(*decompiler,_i,time_offset,false);
 		delete	_i;
 
 		delete	img;
@@ -401,12 +401,12 @@ int32	main(int	argc,char	**argv){
 					outfile.open(settings.decompilation_file_path.c_str(),std::ios_base::trunc);
 					std::streambuf	*coutbuf=std::cout.rdbuf(outfile.rdbuf()); 
 
-					decompile(decompiler,image,starting_time,settings.ignore_named_objects,settings.decompiled_show_oid);
+					decompile(decompiler,image,starting_time,settings.ignore_named_objects);
 					
 					std::cout.rdbuf(coutbuf);
 					outfile.close(); 
 				}else
-					decompile(decompiler,image,starting_time,settings.ignore_named_objects,settings.decompiled_show_oid);
+					decompile(decompiler,image,starting_time,settings.ignore_named_objects);
 			}
 			delete	image;
 			//std::cout<<"get_image(): "<<probe.us()<<"us"<<std::endl;
@@ -430,12 +430,12 @@ int32	main(int	argc,char	**argv){
 					outfile.open(argv[2],std::ios_base::trunc);
 					std::streambuf	*coutbuf=std::cout.rdbuf(outfile.rdbuf()); 
 
-					decompile(decompiler,image,starting_time,settings.ignore_named_models,settings.decompiled_show_oid);
+					decompile(decompiler,image,starting_time,settings.ignore_named_models);
 					
 					std::cout.rdbuf(coutbuf);
 					outfile.close(); 
 				}else
-					decompile(decompiler,image,starting_time,settings.ignore_named_models,settings.decompiled_show_oid);
+					decompile(decompiler,image,starting_time,settings.ignore_named_models);
 			}
 			delete	image;
 			//std::cout<<"get_models(): "<<probe.us()<<"us"<<std::endl;

--- a/Test/settings.h
+++ b/Test/settings.h
@@ -118,7 +118,6 @@ public:
 	bool			decompile_to_file;
 	std::string		decompilation_file_path;
 	bool			ignore_named_objects;
-	bool			decompiled_show_oid;
 	bool			write_objects;
 	std::string		objects_path;
 	bool			test_objects;
@@ -236,7 +235,6 @@ public:
 				const	char	*_decompile_to_file=objects.getAttribute("decompile_to_file");
 				decompilation_file_path=objects.getAttribute("decompilation_file_path");
 				const	char	*_ignore_named_objects=objects.getAttribute("ignore_named_objects");
-				const	char	*_decompiled_show_oid=objects.getAttribute("decompiled_show_oid");
 				const	char	*_write_objects=objects.getAttribute("write_objects");
 				const	char	*_test_objects=objects.getAttribute("test_objects");
 
@@ -244,7 +242,6 @@ public:
 				decompile_objects=(strcmp(_decompile_objects,"yes")==0);
 				decompile_to_file=(strcmp(_decompile_to_file,"yes")==0);
 				ignore_named_objects=(strcmp(_ignore_named_objects,"yes")==0);
-				decompiled_show_oid=(_decompiled_show_oid==NULL ? false : strcmp(_decompiled_show_oid,"yes")==0);
 				write_objects=(strcmp(_write_objects,"yes")==0);
 				if(write_objects){
 

--- a/Test/settings.xml
+++ b/Test/settings.xml
@@ -34,7 +34,6 @@
       decompile_to_file="yes"
       decompilation_file_path="decompiled_objects.txt"
       ignore_named_objects="yes"
-      decompiled_show_oid="no"
       write_objects="no"
       objects_path="../Test/objects.replicode.image"
       test_objects="no"
@@ -82,7 +81,6 @@ Debug
     decompile_image: yes or no.
     decompile_to_file: yes or no.
     ignore_named_objects: yes or no; if yes, objects provided by the deveoper are not decompiled.
-    decompiled_show_oid: yes or no; if yes, after the decompiled object, show its OID as a comment.
     write_image: yes or no.
     test_image: yes or no (yes: reads back and decompiles).
 Run

--- a/r_comp/decompiler.cpp
+++ b/r_comp/decompiler.cpp
@@ -141,7 +141,6 @@ namespace	r_comp{
 
 		partial_decompilation=false;
 		ignore_named_objects=false;
-		decompiled_show_oid=false;
 
 		//	Load the renderers;
 		for(uint16	i=0;i<metadata->classes_by_opcodes.size();++i){
@@ -172,10 +171,9 @@ namespace	r_comp{
 		}
 	}
 
-	uint32	Decompiler::decompile(r_comp::Image		*image,std::ostringstream	*stream,uint64	time_offset,bool	ignore_named_objects, bool	decompiled_show_oid){
+	uint32	Decompiler::decompile(r_comp::Image		*image,std::ostringstream	*stream,uint64	time_offset,bool	ignore_named_objects){
 
 		this->ignore_named_objects=ignore_named_objects;
-		this->decompiled_show_oid=decompiled_show_oid;
 
 		uint32	object_count=decompile_references(image);
 
@@ -189,7 +187,6 @@ namespace	r_comp{
 
 		partial_decompilation=true;
 		ignore_named_objects=true;
-		decompiled_show_oid=false;
 		this->imported_objects=imported_objects;
 
 		uint32	object_count=decompile_references(image);
@@ -310,8 +307,6 @@ namespace	r_comp{
 		}else
 			*out_stream<<" |[]";
 		write_indent(0);
-		if (decompiled_show_oid)
-			*out_stream << "; OID: " << sys_object->oid << NEWLINE;
 		write_indent(0);
 	}
 

--- a/r_comp/decompiler.h
+++ b/r_comp/decompiler.h
@@ -136,7 +136,6 @@ namespace	r_comp{
 
 		bool						partial_decompilation;	// used when decompiling on-the-fly.
 		bool						ignore_named_objects;
-		bool						decompiled_show_oid;
 		UNORDERED_SET<uint16>		named_objects;
 		std::vector<SysObject	*>	imported_objects;	// referenced objects added to the image that were not in the original list of objects to be decompiled.
 	public:
@@ -147,8 +146,7 @@ namespace	r_comp{
 		uint32	decompile(	r_comp::Image		*image,
 							std::ostringstream	*stream,
 							uint64				time_offset,
-							bool				ignore_named_objects,
-							bool				decompiled_show_oid);		// decompiles the whole image; returns the number of objects.
+							bool				ignore_named_objects);		// decompiles the whole image; returns the number of objects.
 		uint32	decompile(	r_comp::Image				*image,
 							std::ostringstream			*stream,
 							uint64						time_offset,


### PR DESCRIPTION
Reverting pull request #32 . It turns out that setting `ignore_named_objects="no"` also shows the OID. So, a separate option for `decompiled_show_oid` is not needed.