### PR TITLE
Use "settings.xml" if the first command line argument is omitted

### DIFF
--- a/Test/Test.cpp
+++ b/Test/Test.cpp
@@ -276,7 +276,8 @@ int32	main(int	argc,char	**argv){
 	core::Time::Init(1000);
 
 	Settings	settings;
-	if(!settings.load(argv[1]))
+	const char* file_name = (argc >= 2 ? argv[1] : "settings.xml");
+	if(!settings.load(file_name))
 		return	1;
 
 	std::cout<<"> compiling ...\n";


### PR DESCRIPTION
This pull request resolves issue #38. It only sets a default "settings.xml" for the first command line argument if it is omitted. The code already doesn't use the second command line argument "decompiled.txt" if it is omitted, 