### PR TITLE
In operator add and sub, cast float to int64 before math with timestamp.

### DIFF
--- a/r_exec/operator.cpp
+++ b/r_exec/operator.cpp
@@ -292,7 +292,7 @@ namespace	r_exec{
 
 				if(lhs[0]!=Atom::PlusInfinity()){
 
-					index=context.setTimestampResult(Utils::GetTimestamp(&rhs[0])+lhs[0].asFloat());
+					index=context.setTimestampResult(Utils::GetTimestamp(&rhs[0])+(int64)lhs[0].asFloat());
 					return	true;
 				}
 			}
@@ -306,7 +306,7 @@ namespace	r_exec{
 
 				if(rhs[0]!=Atom::PlusInfinity()){
 
-					index=context.setTimestampResult(Utils::GetTimestamp(&lhs[0])+rhs[0].asFloat());
+					index=context.setTimestampResult(Utils::GetTimestamp(&lhs[0])+(int64)rhs[0].asFloat());
 					return	true;
 				}
 			}
@@ -352,7 +352,7 @@ namespace	r_exec{
 
 				if(rhs[0]!=Atom::PlusInfinity()){
 
-					index=context.setTimestampResult(Utils::GetTimestamp(&lhs[0])-rhs[0].asFloat());
+					index=context.setTimestampResult(Utils::GetTimestamp(&lhs[0])-(int64)rhs[0].asFloat());
 					return	true;
 				}
 			}


### PR DESCRIPTION
This pull request resolves issue #42. The add and sub operators allow one operand to be a float32 and the other operand to be a timestamp which is uint64. But C++ automatically casts the uint64 timestamp to a float32 before adding or subtracting. The result is float32, which is converted to a uint64 timestamp value. But the (hidden) automatic conversion of the uint64 operand to float32 loses precision.

This pull request is to cast the float32 operand to int64 before adding or subtracting with uint64, to prevent the loss of precision.