### PR TITLE
In Decompiler::decompile_references, use the OID in the object name

### DIFF
--- a/r_comp/decompiler.cpp
+++ b/r_comp/decompiler.cpp
@@ -215,9 +215,15 @@ namespace	r_comp{
 			}else{
 			
 				c=metadata->get_class(sys_object->code[0].asOpcode());
-				last_object_ID=object_ID_per_class[c];
-				object_ID_per_class[c]=last_object_ID+1;
-				s=c->str_opcode + std::to_string(last_object_ID);
+				if (sys_object->oid != 0xFFFFFFFF)
+					// Use the object's OID.
+					s = c->str_opcode + "_" + std::to_string(sys_object->oid);
+				else {
+					// Create a name with a unique ID.
+					last_object_ID = object_ID_per_class[c];
+					object_ID_per_class[c] = last_object_ID + 1;
+					s = c->str_opcode + std::to_string(last_object_ID);
+				}
 			}
 
 			object_names[i]=s;


### PR DESCRIPTION
The decompiler output shows object names with unique numbers. For example:

    success7:(success fact13 1) |[]

    87 fact13:(fact pred0 0s:500ms:0us 0s:500ms:0us 1 1) |[]

But fact13 was actually assigned OID 87 by the runtime. This is shown on the second line, and this OID also appears in the runtime trace output. So it can be confusing that it is assigned an identifier fact13 (especially if the runtime also assigned OID 13 to a different fact).

This pull request changes the decompiler to use the object's OID if the runtime assigned it. The above now shows:

    success7:(success fact_87 1) |[]

    87 fact_87:(fact pred0 0s:500ms:0us 0s:500ms:0us 1 1) |[]


