### PR TITLE
Added settings "enable_assumptions"

### DIFF
--- a/Test/Test.cpp
+++ b/Test/Test.cpp
@@ -342,7 +342,8 @@ int32	main(int	argc,char	**argv){
 					settings.ntf_mk_resilience,
 					settings.goal_pred_success_resilience,
 					settings.probe_level,
-					settings.trace_levels);
+					settings.trace_levels,
+					settings.enable_assumptions);
 
 		uint32	stdin_oid;
 		std::string	stdin_symbol("stdin");

--- a/Test/settings.h
+++ b/Test/settings.h
@@ -125,6 +125,7 @@ public:
 	//Run.
 	core::uint32	run_time;
 	core::uint32	probe_level;
+	bool			enable_assumptions;
 	bool			get_models;
 	bool			decompile_models;
 	bool			ignore_named_models;
@@ -264,9 +265,11 @@ public:
 
 			const	char	*_run_time=run.getAttribute("run_time");
 			const	char	*_probe_level=run.getAttribute("probe_level");
+			const	char	*_enable_assumptions=run.getAttribute("enable_assumptions");
 			
 			run_time=atoi(_run_time);
 			probe_level=atoi(_probe_level);
+			enable_assumptions=(strcmp(_enable_assumptions,"yes")==0);
 			
 			core::XMLNode	models=run.getChildNode("Models");
 			if(!!models){

--- a/Test/settings.xml
+++ b/Test/settings.xml
@@ -39,7 +39,7 @@
       test_objects="no"
     />
   </Debug>
-  <Run run_time="10080" probe_level="2">
+  <Run run_time="10000" probe_level="2" enable_assumptions="yes">
     <Models
       get_models="yes"
       decompile_models="yes"
@@ -86,6 +86,7 @@ Debug
 Run
   run_time: in ms.
   probe_level: any probe set to a level >= this level will not be executed. 0 means no probe will be executed.
+  enable_assumptions: yes or no to enable injecting assumptions.
   Models
     same as for Debug/Image.
 -->

--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -2078,6 +2078,9 @@ namespace	r_exec{
 
 	void	PrimaryMDLController::assume(_Fact	*input){
 
+		if (!_Mem::Get()->get_enable_assumptions())
+			// Assumptions are disabled in the global settings.
+			return;
 		if(is_requirement()	||	is_reuse()	||	is_cmd())
 			return;
 

--- a/r_exec/mem.cpp
+++ b/r_exec/mem.cpp
@@ -115,7 +115,8 @@ namespace	r_exec{
 						uint32	ntf_mk_res,
 						uint32	goal_pred_success_res,
 						uint32	probe_level,
-						uint32	traces){
+						uint32	traces,
+						bool	enable_assumptions){
 
 		this->base_period=base_period;
 
@@ -143,6 +144,7 @@ namespace	r_exec{
 		this->goal_pred_success_res=goal_pred_success_res;
 
 		this->probe_level=probe_level;
+		this->enable_assumptions=enable_assumptions;
 
 		reduction_job_count=time_job_count=0;
 		reduction_job_avg_latency=_reduction_job_avg_latency=0;

--- a/r_exec/mem.h
+++ b/r_exec/mem.h
@@ -140,6 +140,7 @@ namespace	r_exec{
 
 		// Parameters::Run.
 		uint32	probe_level;
+		bool	enable_assumptions;
 
 		PipeNN<P<_ReductionJob>,1024>	*reduction_job_queue;
 		PipeNN<P<TimeJob>,1024>			*time_job_queue;
@@ -222,9 +223,11 @@ namespace	r_exec{
 					uint32	ntf_mk_res,
 					uint32	goal_pred_success_res,
 					uint32	probe_level,
-					uint32	traces);
+					uint32	traces,
+					bool	enable_assumptions);
 
 		uint64	get_probe_level()						const{	return	probe_level;	}
+		bool	get_enable_assumptions()				const{	return	enable_assumptions;	}
 		float32	get_mdl_inertia_sr_thr()				const{	return	mdl_inertia_sr_thr;	}
 		uint32	get_mdl_inertia_cnt_thr()				const{	return	mdl_inertia_cnt_thr;	}
 		float32	get_tpx_dsr_thr()						const{	return	tpx_dsr_thr;	}


### PR DESCRIPTION
The runtime can generates assumptions. A false assumption can cause a prediction failure for a model and lower its confidence. We want the ability to disable this behavior.

This pull request adds a parameter "enable_assumptions" in settings.xml. By default, it is "yes" to keep the current behavior. If the user sets it to "no", then PrimaryMDLController::assume() does nothing.