### PR TITLE
HLPBindingMap: Fix bug for making the StructureValue for the time stamps.

### DIFF
--- a/r_exec/binding_map.cpp
+++ b/r_exec/binding_map.cpp
@@ -1005,8 +1005,9 @@ namespace	r_exec{
 			}
 		}
 
-		map[fwd_after_index]=new	StructureValue(this,f_ihlp,FACT_AFTER);	// valuate timings; fwd_after_index is already known.
-		map[fwd_before_index]=new	StructureValue(this,f_ihlp,FACT_BEFORE);
+		// Valuate timings; fwd_after_index is already known. We know that time stamps are I_PTR to the time stamp structure.
+		map[fwd_after_index]=new	StructureValue(this,f_ihlp,f_ihlp->code(FACT_AFTER).asIndex());
+		map[fwd_before_index]=new	StructureValue(this,f_ihlp,f_ihlp->code(FACT_BEFORE).asIndex());
 	}
 
 	Fact	*HLPBindingMap::build_f_ihlp(Code	*hlp,uint16	opcode,bool	wr_enabled)	const{


### PR DESCRIPTION
HLPBindingMap::init_from_f_ihlp creates a StructureValue for each time stamp in the fact. For example:

    map[fwd_after_index] = new StructureValue(this, f_ihlp, FACT_AFTER);

The StructureValue gets a copy of `f_ihlp->code(FACT_AFTER)` which is an I_PTR to code(6). Later, when this map entry is valuated, the I_PTR to code(6) is copied into localtion code(6), causing a loop. Thus, the code above is a bug. Instead it should create a StructureValue with the actual time stamp structure which is pointed to by the I_PTR:

    map[fwd_after_index] = new StructureValue(this, f_ihlp, f_ihlp->code(FACT_AFTER).asIndex());

(This bug didn't appear before because init_from_f_ihlp is only called when backward chaining through an icst, and for other reasons, backward chaining through an icst wasn't working either.)