### PR TITLE
CSTController::reduce: Fix bug to check for icst while backchaining

### DIFF
--- a/r_exec/cst_controller.cpp
+++ b/r_exec/cst_controller.cpp
@@ -349,11 +349,12 @@ namespace	r_exec{
 		if(goal	&&	goal->is_self_goal()	&&	!goal->is_drive()){	// goal is g->f->target.
 
 			_Fact	*goal_target=goal->get_target();	// handle only icst.
-			if(goal_target->code(0).asOpcode()==Opcodes::ICst	&&	goal_target->get_reference(0)==getObject()){	// f is f->icst; produce as many sub-goals as there are patterns in the cst.
+			Code	*target_ihlp = goal_target->get_reference(0);
+			if(target_ihlp->code(0).asOpcode()==Opcodes::ICst	&&	target_ihlp->get_reference(0)==getObject()){	// f is f->icst; produce as many sub-goals as there are patterns in the cst.
 
 				if(!get_requirement_count()){	// models will attempt to produce the icst
 
-					P<HLPBindingMap>	bm=new	HLPBindingMap(bm);
+					P<HLPBindingMap>	bm=new	HLPBindingMap(bindings);
 					bm->init_from_f_ihlp(goal_target);
 					if(evaluate_bwd_guards(bm))	// leaves the controller constant: no need to protect; bm may be updated.
 						abduce(bm,input->object);


### PR DESCRIPTION
In a [major commit](https://github.com/IIIM-IS/replicode/commit/3c5b9be5f935d6783fb1d35d74ca7d19ad4be186#diff-0ff725f0ae881cefbad0064fc2eac950R236) on Feb 10, 2012, the use of binding maps was changed in many places. `CSTController::reduce` has code to check if the goal is for an icst. It was changed from:

    Code *target = goal->get_reference(0)->get_reference(0);
	if (target->code(0).asOpcode() == Opcodes::ICST ...

to:

    _Fact *goal_target=goal->get_reference(0);
	if (goal_target->code(0).asOpcode() == Opcodes::ICst ...

This introduced a bug because there should be one more `get_reference(0)` before checking `code(0).asOpcode()`. With this bug, the if statement is always false and does not create any subgoals while backchaining through a cst.

Inside the if block (which never executes because it is always false), this commit also adds:

    P<BindingMap> bm = new BindingMap(bm);

This is clearly a typo because the `bm` in `new BindingMap(bm)` is uninitialized. It should be `bindings` as in many other similar places.

This pull request fixes these bugs so that Replicode correctly creates cst subgoals while backchaining.