### PR TITLE
In the change pattern extractor, check sharing bindings with the target as well as consequent.

### DIFF
--- a/r_exec/pattern_extractor.cpp
+++ b/r_exec/pattern_extractor.cpp
@@ -802,7 +802,7 @@ void CTPX::reduce(r_exec::View *input) {
   r_code::list<Input>::const_iterator i;
   for (i = inputs_.begin(); i != inputs_.end();) {
 
-    if (!end_bm->intersect(i->bindings_) || // discard inputs that do not share values with the target or consequent.
+    if (!(target_bindings_->intersect(i->bindings_) || end_bm->intersect(i->bindings_)) || // discard inputs that do not share values with the target or consequent.
       i->input_->get_after() >= consequent->get_after()) // discard inputs not younger than the consequent.
       i = inputs_.erase(i);
     else


### PR DESCRIPTION
The change pattern extractor tries to filter the set of possible inputs to only those that are relevant to the model being built. The inputs are accumulated by the the auto focus controller.  (A change targeted pattern extractor (CTPX) is in distinction from a goal targeted pattern extractor (GTPX) and a prediction targeted pattern extractor (PTPX).) The change pattern extractor considers a premise and consequent which are both facts for the same object that has a value that changes. In many cases, the value that changes is a number such as the speed of a ball. But below we consider the case where the value is an object such as the state of an object like "liquid" or "gas", where the object links to other relevant facts. The related relevant facts about "liquid" and "gas" may need to be part of the model that predicts when something changes state from a liquid to a gas. This is why the pattern extractor should consider facts relevant to both the premise and the consequent.

This process is done in `CTPX::reduce`. As part of this process, it filters out inputs that do not share a binding with the consequent:

    if (!end_bm->intersect(i->bindings) ...

(`end_bm` is the bindings for the consequent.) This is sufficient if the value of the fact in the consequent is a number (which has no links to other objects). But if the value of the fact is an object with references to other objects, then the value of the consequent may be an object which refers to relevant objects which are different from the value of the premise (aka target). In this case, the model builder also needs to include inputs related to the value of the premise. This can be done by also checking the premise bindings, to filter out inputs that do not share a binding with either the premise or the consequent:

    if (!(target_bindings->intersect(i->bindings) || end_bm->intersect(i->bindings)) ...

(`target_bindings` is the bindings of the premise, aka target.)