### PR TITLE
CSTController: In reduce, in the overalys loop, increment the iterator

### DIFF
--- a/r_exec/cst_controller.cpp
+++ b/r_exec/cst_controller.cpp
@@ -376,8 +376,10 @@ namespace	r_exec{
 				else{
 
 					match=((CSTOverlay	*)*o)->reduce(input,offspring);
-					if(offspring)
+					if(offspring) {
 						overlays.push_front(offspring);
+						++o;
+					}
 					else	if(match)	// full match: no offspring.
 						o=overlays.erase(o);
 					else


### PR DESCRIPTION
CSTController::reduce has a loop to check all the overlays. In March 2012, it had the [following code](https://github.com/IIIM-IS/replicode/blob/a518d819c7ab1595c6dc7b1945a65f5553bb753f/r_exec/cst_controller.cpp#L261):

    for (o = overlays.begin(); o != overlays.end();) {
      ...
      offspring=((CSTOverlay *)*o)->reduce(input);
      ++o;
      if (offspring)
        overlays.push_front(offspring);
    }

After calling the overlay reduce method, it always increments the iterator, including if there is an offspring. But in the next [commit of July 2, 2012](https://github.com/IIIM-IS/replicode/commit/fc5961a4fa9f44d40298381bbdf86f314a9f26ab#diff-0ff725f0ae881cefbad0064fc2eac950R318) the overlay reduce method was changed to return a Boolean match value and to return the overlay by reference argument:

    for (o = overlays.begin(); o != overlays.end();) {
      ...
      match = ((CSTOverlay *)*o)->reduce(input,offspring);
      if (offspring)
        overlays.push_front(offspring);
      else if (match)  // full match: no offspring.
        o=overlays.erase(o);
      else
        ++o;
    }
	
After calling the overlay reduce method, if there is an offspring it doesn't increment the iterator. So, it does another pass of the loop where the iterator has the same value. It calls the reduce method again of the same overlay. This time, the overlay has already processed the input, so it sets `offspring` to `NULL` and returns a false match. In this case, it simply calls `++o` to increment the iterator. So the effect is the same as if it (correctly) increments the iterator after calling reduce for the first time.

This pull request increments the iterator if the overlay reduce returns an offspring:

      if (offspring) {
        overlays.push_front(offspring);
        ++o;
      }


