### PR TITLE
HLPOverlay: In scan_variable, rename local variable 'index'

### DIFF
--- a/r_exec/hlp_overlay.cpp
+++ b/r_exec/hlp_overlay.cpp
@@ -240,8 +240,8 @@ namespace	r_exec{
 		uint16	guard_count=code[guard_set_index].getAtomCount();
 		for(uint16	i=1;i<=guard_count;++i){
 
-			uint16	index=guard_set_index+i;
-			Atom	a=code[index];
+			uint16	guard_index=guard_set_index+i;
+			Atom	a=code[guard_index];
 			switch(a.getDescriptor()){
 			case	Atom::ASSIGN_PTR:
 				if(a.asIndex()==index)


### PR DESCRIPTION
The method `HLPOverlay::scan_variable` has a parameter `index`:

    HLPOverlay::scan_variable(uint16 index)

The method makes a local variable to hold the index of the guard it is examining. But it is given the same name:

    uint16 index = guard_set_index + i;
    Atom a = code[index];

This is clearly a typo, as it masks the parameter `index` when it is checked:

      if (a.asIndex() == index)

This pull request fixes this bug by renaming the local variable to `guard_index`.