### PR TITLE
HLPOverlay: In scan_variable, fix bug for checking the ASSIGN_PTR index

### DIFF
--- a/r_exec/hlp_overlay.cpp
+++ b/r_exec/hlp_overlay.cpp
@@ -244,8 +244,8 @@ namespace	r_exec{
 			Atom	a=code[guard_index];
 			switch(a.getDescriptor()){
 			case	Atom::ASSIGN_PTR:
-				if(a.asIndex()==index)
-					return	scan_location(a.asAssignmentIndex());
+				if(a.asAssignmentIndex()==index)
+					return	scan_location(a.asIndex());
 				break;
 			}
 		}


### PR DESCRIPTION
The `HLPOverlay::scan_variable` method examines each of the backward guards and checks if the assignment variable can be bound. For example, in this model,

    (mdl
    ; ...
    []
       v1:(sub v2 0s:100ms:0us)
    ; ...

the backward guard assigns the variable `v1`. Here is the code in `HLPOverlay::scan_variable`:

    for (uint16 i=1; i<=guard_count; ++i) {
      uint16 guard_index = guard_set_index + i;
      Atom a=code[guard_index];
      switch (a.getDescriptor()) {
      case Atom::ASSIGN_PTR:
        if (a.asIndex() == index)
          return scan_location(a.asAssignmentIndex());
        break;
      }
    }

The variable `a` is the code for the assignment `v1:(sub v2 0s:100ms:0us)`. The check `if (a.asIndex() == index)` is supposed to check if it is the assignment for `v1`, where `index` is 1. But `a.asIndex()` gives the index of the code for `(sub v2 0s:100ms:0us)`. It should be `a.asAssignmentIndex()` which gives the index of the assignment variable.

Likewise, the call to `scan_location(a.asAssignmentIndex())` should pass the index for the code to scan. So, this should pass `a.asIndex()`. It seems that this and the previous were reversed by mistake. This pull request these fixes. 