### PR TITLE
HLPBindingMap: In init_from_f_ihlp, need to increment i.

### DIFF
--- a/r_exec/binding_map.cpp
+++ b/r_exec/binding_map.cpp
@@ -985,6 +985,7 @@ namespace	r_exec{
 		for(uint32	j=first_index;j<map.size();++j){	// valuate args.
 
 			if(j==fwd_after_index	||	j==fwd_before_index)
+				// The forward timestamps don't appear in the args set, so skip.
 				continue;
 
 			Atom	atom=ihlp->code(val_set_index+i);
@@ -1003,6 +1004,9 @@ namespace	r_exec{
 				map[j]=new	AtomValue(this,atom);
 				break;
 			}
+
+			// Increment to look at the next value in the args set in the ihlp.
+			++i;
 		}
 
 		// Valuate timings; fwd_after_index is already known. We know that time stamps are I_PTR to the time stamp structure.


### PR DESCRIPTION
The method `HLPBindingMap::init_from_f_ihlp` binds the variables in a model or composite state from an imdl or icst, which contain values in the set of template arguments and the set of output arguments. The [first loop](https://github.com/IIIM-IS/replicode/blob/9d634b6131f8a669d4e9dcf2dbade0e509e86ff3/r_exec/binding_map.cpp#L967) binds from the set of template arguments. For example, variables `v0` and `v1` are bound from index 0 and 1 in the set of template arguments.

Binding from the set of output arguments is more complicated for two reasons. First, the values start at index 0 in the set of output arguments, but they are bound to variables `v2`, `v3`, etc. which do not start at index 0. Second, the timestamps of the LHS fact are not considered to be output values, so they must be skipped. For these reasons, in the [second loop](https://github.com/IIIM-IS/replicode/blob/9d634b6131f8a669d4e9dcf2dbade0e509e86ff3/r_exec/binding_map.cpp#L967) iterator `j` iterates over the variables to be bound (after the template variables). But a second iterator `i` is the index of the values in the set of output arguments, which should be incremented except when `j` is the [index of a timestamp in the LHS fact](https://github.com/IIIM-IS/replicode/blob/9d634b6131f8a669d4e9dcf2dbade0e509e86ff3/r_exec/binding_map.cpp#L967).

Although the code sets up the iterator `i`, it is never incremented, and so the value of the first output argument is always used. This pull request fixes this bug by incrementing `i` at the end of the loop (after checking if `j` is the index of a timestamp in the LHS fact).