### PR TITLE
Compiler: Allow a local reference to an expression

### DIFF
--- a/r_comp/compiler.cpp
+++ b/r_comp/compiler.cpp
@@ -891,7 +891,7 @@ return_false:
 		if(symbol_expr_set(r)){
 
 			UNORDERED_MAP<std::string,Reference>::iterator	it=local_references.find(r);
-			if(it!=local_references.end()	&&	(t==ANY	||	(t!=ANY	&&	it->second._class.type==t))){
+			if(it!=local_references.end()	&&	(t==ANY || it->second._class.type==ANY	||	(t!=ANY	&&	it->second._class.type==t))){
 
 				index=it->second.index;
 				return	true;


### PR DESCRIPTION
The following code compiles OK. It is part of a pgm. 'g' refers to a previously-defined goal and `after` refers to a previously-defined time stamp.

    (inj []
       (fact g t1:(+ after 10000us) (+ after 10000us) 1 1)
       [SYNC_ONCE t1 1 forever primary nil]

Note that the add expression `(+ after 10000us)` is labeled with `t1`, which is used on the next line for the view. Note also that the add expression is repeated. We would prefer to use `t1` for the second copy of the expression:

    (inj []
       (fact g t1:(+ after 10000us) t1 1 1)
       [SYNC_ONCE t1 1 forever primary nil]

But this code does not compile, and Replicode quits unexpectedly. The problem is that the compiler knows that the second and third arguments to a fact have type TIMESTAMP. Here is [the code](https://github.com/IIIM-IS/replicode/blob/e20ad5f4fb08d9e1152b386ba99f6f62a940991f/r_comp/compiler.cpp#L1424) which checks the type of an operator:

    if (t != ANY && it->second.type != ANY && it->second.type != t))

(The expression is true if the check fails.)`t` is the expected type of the expression, in this case TIMESTAMP. And `it->second.type` is the return type of the operator. The check `it->second.type != t` would enforce that these are the same type, but it is enforced only if `it->second.type != ANY`. Since the return type of the add operator is ANY, the expected type `t` is ignored and the check succeeds.

When `t1` is used as a local reference, it should behave the same way, but it doesn't. The `local_reference` method finds the expression that `t1` refers to and performs [a similar check](https://github.com/IIIM-IS/replicode/blob/e20ad5f4fb08d9e1152b386ba99f6f62a940991f/r_comp/compiler.cpp#L1424):

    if (t == ANY || (t != ANY && it->second._class.type == t))

(In this case, the expression is true if the check succeeds.) Again, `t` is the expected type of the expression, TIMESTAMP. And `it->second._class.type` is the type of the referenced expression, in this case ANY for the add expression. Note that it only allows the expected type `t` to be ANY, but doesn't allow the type of the referenced expression to be ANY. (It would be allowed if the add expression were used directly.)

This pull request adds `|| it->second._class.type==ANY` to allow the type of the referenced expression to be ANY. With this change, the use of `t1` above works as expected.

    if (t == ANY || it->second._class.type==ANY || (t != ANY && it->second._class.type == t))
