### PR TITLE
In inject_productions, offset the timestamp of the injected fact for the ejected cmd.

### DIFF
--- a/r_exec/pgm_overlay.cpp
+++ b/r_exec/pgm_overlay.cpp
@@ -458,7 +458,9 @@ bool InputLessPGMOverlay::inject_productions() {
 
       // Build a fact of the command and inject it in stdin. Give the fact an uncertainty range since we don't know when
       // it will be executed. Otherwise a fact with zero duration may not overlap a fact, making predictions fail.
-      Code *fact = new Fact(command, now, now + Utils::GetBasePeriod(), 1, 1);
+      // We offset the beginning of the uncertainty range by 2*GetTimeTolerance() (the same as SYNC_HOLD)
+      // so that CTPX::reduce will not fail due to "cause in sync with the premise".
+      Code *fact = new Fact(command, now + 2 * Utils::GetTimeTolerance(), now + Utils::GetBasePeriod(), 1, 1);
       View *view = new View(View::SYNC_ONCE, now, 1, 1, _Mem::Get()->get_stdin(), getView()->get_host(), fact); // SYNC_ONCE, sln=1, res=1,
       _Mem::Get()->inject(view);
 


### PR DESCRIPTION
When `InputLessPGMOverlay::inject_productions` ejects a command from a program, it injects a fact of the ejected command. Currently, the beginning of the fact's uncertainty period is "now". But we want the pattern extractor to be able to use this injected fact as the "cause" when building a model. 

Note that pong.2.replicode is able to build a model using a fact of `(mk.val b speed_y 0.0001 1)` as the cause. This is because it is [injected with SYNC_HOLD](https://github.com/IIIM-IS/replicode/blob/e96479b99e98e7b71749b08108c99a58430bb1a8/Test/V1.2/pong.2.replicode#L63). When the autofocus controller makes a copy of this fact, SYNC_HOLD means that it [offsets the beginning of the uncertainty period](https://github.com/IIIM-IS/replicode/blob/e54e877e914772c2b1688da1d7ea32b4fb92630d/r_exec/auto_focus.cpp#L182) by 2 times the time tolerance (20 milliseconds):

    uint64 offset = 2 * Utils::GetTimeTolerance();

This is important because the pattern extractor will [reject an input](https://github.com/IIIM-IS/replicode/blob/cde840d45a73c2826f7564d8a41b2732ed2ea88f/r_exec/pattern_extractor.cpp#L833) as a cause if it is synchronous with the target (such as the current position):

    if (Utils::Synchronous(cause.input->get_after(),target->get_after())) // cause in sync with the premise: ignore.
      continue;

When the autofocus controller for SYNC_HOLD adds an offset of 2 times the time tolerance, it prevents the fact from being synchronous, and so it is not rejected and the pattern extractor can build a model. When `inject_productions` injects the fact of the ejected command, we need to do the same as the autofocus controller. This pull request adds the same offset of `2 * Utils::GetTimeTolerance()`.
