### PR TITLE
HLPOverlay: In check_fwd_timings, only evaluate if needed.

### DIFF
--- a/r_exec/hlp_overlay.cpp
+++ b/r_exec/hlp_overlay.cpp
@@ -175,12 +175,25 @@ namespace	r_exec{
 			}
 		}
 
-		if(!evaluate(guard_set_index+fwd_before_guard_index))
-			return	false;
+		if(!bindings->has_fwd_before()) {
+			// We need to evaluate forward before.
+			if (fwd_before_guard_index == -1)
+				// None of the backward guards assigns the variable for forward before.
+				return false;
+			if(!evaluate(guard_set_index+fwd_before_guard_index))
+				return	false;
+		}
 		if(bindings->get_fwd_before()<=Now())
 			return	false;
-		if(!evaluate(guard_set_index+fwd_after_guard_index))
-			return	false;
+
+		if(!bindings->has_fwd_after()) {
+			// We need to evaluate forward after.
+			if (fwd_after_guard_index == -1)
+				// None of the backward guards assigns the variable for forward after.
+				return false;
+			if(!evaluate(guard_set_index+fwd_after_guard_index))
+				return	false;
+		}
 
 		return	true;
 	}


### PR DESCRIPTION
During backward chaining, `HLPOverlay::check_fwd_timings` evaluates the assignment of the variables for the timestamps of a mode's LHS (the "forward" timings). For example:

    (mdl [v0: v1: v2:]
    []
       (fact (mk.val v3: speed_y v4: :) v5: v6: : :)
       (fact (mk.val v3: position_y v7: :) v2: v8: : :)
    []
       v2:(add v1 0s:100ms:0us)
       v8:(add v2 0s:100ms:0us)
       v7:(add v0 (mul v4 0s:100ms:0us))
    []
       v1:(sub v2 0s:100ms:0us)
       v2:(sub v8 0s:100ms:0us)
       v5:(sub v2 0s:80ms:0us)
       v6:(sub v8 0s:80ms:0us)
       v4:(div (sub v7 v0) 0s:100ms:0us)
    ...

The forward timings are `v5` and `v6` in the LHS `(fact (mk.val v3: speed_y v4: :) v5: v6: : :)`. (Even though these are the "forward" timings, they are assigned in the "backward" guards.) `check_fwd_timings` first [scans the backward guards](https://github.com/IIIM-IS/replicode/blob/74abe9b97312772dd856f50cf2fc0a765688e1fe/r_exec/hlp_overlay.cpp#L164-L176) to find the indexes `fwd_after_guard_index` and `fwd_before_guard_index` of the code that assigns the variables. It then binds the variables by evaluating the expressions for the [after timestamp](https://github.com/IIIM-IS/replicode/blob/74abe9b97312772dd856f50cf2fc0a765688e1fe/r_exec/hlp_overlay.cpp#L182) and [before timestamp](https://github.com/IIIM-IS/replicode/blob/74abe9b97312772dd856f50cf2fc0a765688e1fe/r_exec/hlp_overlay.cpp#L178), such as `v5:(sub v2 0s:80ms:0us)` and `v6:(sub v8 0s:80ms:0us)`.

The problem is that some models don't have backward guards, for example:

    (mdl |[]
    []
       (fact (cmd set_speed_y [v0: v1:] 1) v2: v3: 1 1)
       (fact (mk.val v0: speed_y v1: :) v2: v3: ::)
    |[]; empty set of forward guards
    |[]; empty set of backward guards
    ...

In this example, the forward timings are `v2` and `v3`. But the set of backward guards is empty, so there are no guards to assign the variables, and the indexes `fwd_after_guard_index` and `fwd_before_guard_index` have their default value of -1. Yet, `check_fwd_timings` does not check this and attempts to evaluate anyway. In this case, we are lucky. Because the index is -1, it just happens to point to the previous expression which is the empty set of forward guards, and the evaluate method simply skips it. In this case, during backward chaining, `v2` and `v3` are already evaluated from the RHS expression `(fact (mk.val v0: speed_y v1: :) v2: v3: ::)`, so backward guard expressions are not needed. In short, the forward timing variables are already bound, so we are lucky. But this will not be true in every case, and can cause unexpected behavior, and may account for some of the intermittent crashes if attempting to evaluate code at a random index.

This pull request changes `check_fwd_timings` to only evaluate the variables if they are not bound yet, using the methods `has_fwd_after()` and `has_fwd_before()`. If the variable is already bound, it doesn't matter whether an assignment expression was found in the backward guards. But if it is not bound, we need to check if the index is -1 (meaning that an expression was not found) and return false for a failed match.