### PR TITLE
In BindingMap::abstract_fact, fix getting fwd_after_index and fwd_before_index

### DIFF
--- a/r_exec/binding_map.cpp
+++ b/r_exec/binding_map.cpp
@@ -417,8 +417,9 @@ namespace	r_exec{
 
 		if(fwd_after_index==-1){
 
-			fwd_after_index=map.size()-2;
-			fwd_before_index=fwd_after_index+1;
+			// Get the indexes that were put into the fact by abstract_member().
+			fwd_after_index = fact->code(FACT_AFTER).asIndex();
+			fwd_before_index = fact->code(FACT_BEFORE).asIndex();
 		}
 
 		return	fact;


### PR DESCRIPTION
`BindingMap::abstract_fact` is used to build the LHS and RHS facts of a model. For each fact, if the `fwd_after_index` has not been assigned yet, then it needs to add the timings to the fact. It [calls `abstract_member`](https://github.com/IIIM-IS/replicode/blob/9ed44eb47e947da074b367c2f519bd0daccbd70f/r_exec/binding_map.cpp#L412-L413):

    abstract_member(original, FACT_AFTER, fact, FACT_AFTER, extent_index);
    abstract_member(original, FACT_BEFORE, fact, FACT_BEFORE, extent_index);

These set `fact->code(FACT_AFTER)` and `fact->code(FACT_BEFORE)` to value pointers which point to the appropriate index in the binding map. If the binding map already has an entry with the needed value then its index is used, otherwise a new binding map entry is added. 

Normally, there are two cases:

1. `fwd_after_index` has been assigned, in which case the binding map already has entries for both after and before timings.
2. `fwd_after_index` has not been assigned, in which case values for both after and before timings need to be added to the binding map.

In the second case, the [following code](https://github.com/IIIM-IS/replicode/blob/9ed44eb47e947da074b367c2f519bd0daccbd70f/r_exec/binding_map.cpp#L418-L422) behaves correctly:

    if (fwd_after_index == -1) {
      fwd_after_index = map.size() - 2;
      fwd_before_index = fwd_after_index + 1;
    }

`fwd_after_index` has not been assigned yet (it is -1) so both after and before timings were added to the binding map by `abstract_member`, so that `fwd_after_index` and `fwd_before_index` are the last two indexes in the binding map. But there is third case. The following is a learned model while running an example in real time mode. (The guards are irrelevant for this example and are omitted.)

    (mdl [v0: v1: v2:]
    []
       (fact (cmd move_y_plus [v3:] :) v4: v2: : :)
       (fact (mk.val v3: position v5: :) v2: v6: : :))

The timings in the LHS are `v4` and `v2` and the timings on the RHS are `v2` and `v6`. Notice that they share the variable `v2`, which is unusual. After processing the LHS an entry is created in the binding map at index 2 for the "before timing" of `v2`. But not for the "after timing" so that 
`fwd_after_index` is still unassigned. When `BindingMap::abstract_fact` processes the RHS, it only adds one entry, not two as the code assumes. Therefore, it is not necessarily true that `fwd_after_index` is `map.size() - 2`. The rest of replicode assumes (without checking) that the value at the `fwd_after_index` is a time stamp. If `fwd_after_index` is set incorrectly, it can point to other values which can cause a crash when interpreted as a time stamp.

The solution is simple. The purpose of `abstract_member` is to set `fact->code(FACT_AFTER)` and `fact->code(FACT_BEFORE)` to the appropriate index in the binding map, regardless of whether it needs to add a new binding map entry or re-use an existing one. Therefore, this pull request changes the code to set `fwd_after_index` and `fwd_before_index` from the values assigned by `abstract_member`.