### PR TITLE
In predict, check if is_invalidated before accessing controllers.

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1433,6 +1433,9 @@ namespace	r_exec{
 
 		if(is_requirement()){
 
+			if (is_invalidated())
+				// Another thread has invalidated this controller which clears the controllers.
+				return;
 			PrimaryMDLController	*c=(PrimaryMDLController	*)controllers[RHSController];	// rhs controller: in the same view.
 			c->store_requirement(production,this,chaining_was_allowed,simulation);				// if not simulation, stores also in the secondary controller.
 #ifdef WITH_DEBUG_OID
@@ -2262,6 +2265,9 @@ namespace	r_exec{
 		
 		if(is_requirement()){	// store in the rhs controller, even if primary (to allow rating in any case).
 
+			if (is_invalidated())
+				// Another thread has invalidated this controller which clears the controllers.
+				return;
 			((MDLController	*)controllers[RHSController])->store_requirement(production,this,chaining_was_allowed,false);
 			return;
 		}


### PR DESCRIPTION
In `PrimaryMDLController::predict`, if the model is a requirement, the controller [accesses the controllers array](https://github.com/IIIM-IS/replicode/blob/9ed44eb47e947da074b367c2f519bd0daccbd70f/r_exec/mdl_controller.cpp#L1436) to get the RHS controller. But another thread may have invalidated the controller. For example, if another thread registers a prediction failure then it may call [`kill_views()`](https://github.com/IIIM-IS/replicode/blob/9ed44eb47e947da074b367c2f519bd0daccbd70f/r_exec/mdl_controller.cpp#L2085), which [calls `invalidate()`](https://github.com/IIIM-IS/replicode/blob/9ed44eb47e947da074b367c2f519bd0daccbd70f/r_exec/mdl_controller.cpp#L2175), which [clears the controllers array](https://github.com/IIIM-IS/replicode/blob/dd0227e5e338c7bd77be3fe49288d12714af8eb0/r_exec/hlp_controller.cpp#L103). 

Therefore, when the thread running `PrimaryMDLController::predict` accesses the controllers array, it may be empty causing a crash due to subscript out of range. This bug is easily reproducible in an example which creates models and then invalidates them due to too many prediction failures. This pull request changes `PrimaryMDLController::predict` to check if the controller is invalidated before accessing its controllers array. Also do a similar check in `SecondaryMDLController::predict`.