### PR TITLE
HLPBindingMap: In match_bwd_timings, added param use_f_pattern_timings

### DIFF
--- a/r_exec/binding_map.cpp
+++ b/r_exec/binding_map.cpp
@@ -1136,19 +1136,23 @@ namespace	r_exec{
 		map[bwd_before_index]=new	StructureValue(this,reference_fact,reference_fact->code(FACT_BEFORE).asIndex());
 	}
 
-	bool	HLPBindingMap::match_bwd_timings(const	_Fact	*f_object,const	_Fact	*f_pattern){
+	bool	HLPBindingMap::match_bwd_timings(const	_Fact	*f_object,const	_Fact	*f_pattern, bool use_f_pattern_timings){
 
-		return	match_timings(get_bwd_after(),get_bwd_before(),f_object->get_after(),f_object->get_before(),bwd_after_index,bwd_before_index);
+		if (use_f_pattern_timings)
+			return match_timings
+			  (f_pattern->get_after(), f_pattern->get_before(), f_object->get_after(), f_object->get_before(), bwd_after_index, bwd_before_index);
+		else
+			return	match_timings(get_bwd_after(),get_bwd_before(),f_object->get_after(),f_object->get_before(),bwd_after_index,bwd_before_index);
 	}
 
-	bool	HLPBindingMap::match_bwd_strict(const	_Fact	*f_object,const	_Fact	*f_pattern){
+	bool	HLPBindingMap::match_bwd_strict(const	_Fact	*f_object,const	_Fact	*f_pattern, bool use_f_pattern_timings){
 
 		if(match_object(f_object->get_reference(0),f_pattern->get_reference(0))){
 
 			if(f_object->code(0)!=f_pattern->code(0))
 				return	false;
 
-			return	match_bwd_timings(f_object,f_pattern);
+			return	match_bwd_timings(f_object,f_pattern, use_f_pattern_timings);
 		}else
 			return	false;
 	}

--- a/r_exec/binding_map.h
+++ b/r_exec/binding_map.h
@@ -296,7 +296,7 @@ namespace	r_exec{
 		int16	bwd_after_index;
 		int16	bwd_before_index;
 
-		bool	match_bwd_timings(const	_Fact	*f_object,const	_Fact	*f_pattern);
+		bool	match_bwd_timings(const	_Fact	*f_object,const	_Fact	*f_pattern, bool use_f_pattern_timings = false);
 
 		bool	need_binding(Code	*pattern)	const;
 		void	init_from_pattern(const	Code	*source,int16	position);	// first source is f->obj.
@@ -318,7 +318,7 @@ namespace	r_exec{
 		void	reset_bwd_timings(_Fact	*reference_fact);	// idem for the last 2 unbound variables (i.e. timings of the second pattern in a mdl).
 
 		MatchResult	match_bwd_lenient(const	_Fact	*f_object,const	_Fact	*f_pattern);	// use for facts when we are lenient about fact vs |fact.
-		bool	match_bwd_strict(const	_Fact	*f_object,const	_Fact	*f_pattern);		// use for facts when we need sharp match.
+		bool	match_bwd_strict(const	_Fact	*f_object,const	_Fact	*f_pattern, bool use_f_pattern_timings = false);		// use for facts when we need sharp match.
 
 		bool has_bwd_after() const { return bwd_after_index >= 0 && map.size() > bwd_after_index && 
 		  map[bwd_after_index]->get_code() != NULL; }


### PR DESCRIPTION
In [`HLPBindingMap::match_bwd_timings`](https://github.com/IIIM-IS/replicode/blob/481abc782ba757fcc514c6abf1dadc25959b54f6/r_exec/binding_map.cpp#L1139), the parameter `f_pattern` is not used. Instead it uses the values stored in the binding map at `bwd_after_index` and `bwd_before_index`. However, some code passes in a value object for `f_pattern` and may need `match_bwd_timings` to use it.

As agreed, this pull request adds an optional parameter `use_f_pattern_timings`, default false. If set to true, then `match_bwd_timings` uses the timings in the `f_pattern` parameter. (No code has yet been committed to set this parameter true, so there is no change to the behavior of Replicode. But the change allows for testing.)