### PR TITLE
_GMonitor: In store_simulated_outcome, store in the correct array.

### DIFF
--- a/r_exec/g_monitor.cpp
+++ b/r_exec/g_monitor.cpp
@@ -109,7 +109,7 @@ namespace	r_exec{
 				sim_successes.mandatory_solutions.push_back(std::pair<P<Goal>,P<Sim> >(affected_goal,sim));
 				break;
 			case	SIM_OPTIONAL:
-				sim_successes.mandatory_solutions.push_back(std::pair<P<Goal>,P<Sim> >(affected_goal,sim));
+				sim_successes.optional_solutions.push_back(std::pair<P<Goal>,P<Sim> >(affected_goal,sim));
 				break;
 			default:
 				break;
@@ -118,7 +118,7 @@ namespace	r_exec{
 
 			switch(sim->mode){
 			case	SIM_MANDATORY:
-				sim_failures.optional_solutions.push_back(std::pair<P<Goal>,P<Sim> >(affected_goal,sim));
+				sim_failures.mandatory_solutions.push_back(std::pair<P<Goal>,P<Sim> >(affected_goal,sim));
 				break;
 			case	SIM_OPTIONAL:
 				sim_failures.optional_solutions.push_back(std::pair<P<Goal>,P<Sim> >(affected_goal,sim));


### PR DESCRIPTION
`_GMonitor::store_simulated_outcome` is used to store the simulated outcome based on success/failure and mandatory/optional. But the code path for success and optional stores in `sim_successes.mandatory_solutions`, not in `optional_solutions`. Likewise, the code path for failure and mandatory stores in `sim_failures.optional_solutions`, not in `mandatory_solutions`.

This is presumably a copy/paste error. This pull request fixes to store in the correct array.