### PR TITLE
GMonitor: In commit, use best_sol to call abduce

### DIFF
--- a/r_exec/g_monitor.cpp
+++ b/r_exec/g_monitor.cpp
@@ -214,7 +214,7 @@ namespace	r_exec{
 
 		if(best_sol){
 
-			((PrimaryMDLController	*)(*sol).second->sol)->abduce(bindings,best_sol->super_goal,best_sol->opposite,goal_target->get_cfd());
+			((PrimaryMDLController	*)best_sol->sol)->abduce(bindings,best_sol->super_goal,best_sol->opposite,goal_target->get_cfd());
 
 			for(sol=sim_successes.mandatory_solutions.begin();sol!=sim_successes.mandatory_solutions.end();++sol)	// commit to all mandatory solutions.
 				((PrimaryMDLController	*)(*sol).second->sol)->abduce(bindings,(*sol).second->super_goal,(*sol).second->opposite,goal_target->get_cfd());


### PR DESCRIPTION
In `GMonitor::commit`, `sol` is an iterator variable used in the loop to compute `best_sol`. After the loop, it needs to [use `best_sol` to call `abduce`](https://github.com/IIIM-IS/replicode/blob/ff11870e5accb52ab893cfd54cb9638e5d737a6a/r_exec/g_monitor.cpp#L217):

    ((PrimaryMDLController *)(*sol).second->sol)->abduce
      (bindings,best_sol->super_goal,best_sol->opposite,goal_target->get_cfd());

But it uses `(*sol).second` , where `sol` is the iterator variable which is only valid inside the loop. At this point in the code, it points past the end of the array which was searched. If accessed, it can crash due to an access violation. This may be a copy/paste error from [the line which follows it](https://github.com/IIIM-IS/replicode/blob/ff11870e5accb52ab893cfd54cb9638e5d737a6a/r_exec/g_monitor.cpp#L219-L220) where `sol` is correctly used as an iterator variable inside the loop.

This pull request changes `(*sol).second` to `best_sol`.