### PR TITLE
Rename sim_time_horizon to sim_time_horizon_factor.

### DIFF
--- a/Test/Test.cpp
+++ b/Test/Test.cpp
@@ -331,7 +331,7 @@ int32	main(int	argc,char	**argv){
 					settings.tpx_dsr_thr,
 					settings.min_sim_time_horizon,
 					settings.max_sim_time_horizon,
-					settings.sim_time_horizon,
+					settings.sim_time_horizon_factor,
 					settings.tpx_time_horizon,
 					settings.perf_sampling_period,
 					settings.float_tolerance,

--- a/Test/settings.h
+++ b/Test/settings.h
@@ -99,7 +99,7 @@ public:
 	core::float32	tpx_dsr_thr;
 	core::uint32	min_sim_time_horizon;
 	core::uint32	max_sim_time_horizon;
-	core::float32	sim_time_horizon;
+	core::float32	sim_time_horizon_factor;
 	core::uint32	tpx_time_horizon;
 	core::uint32	perf_sampling_period;
 	core::float32	float_tolerance;
@@ -178,7 +178,7 @@ public:
 			const	char	*_tpx_dsr_thr=system.getAttribute("tpx_dsr_thr");
 			const	char	*_min_sim_time_horizon=system.getAttribute("min_sim_time_horizon");
 			const	char	*_max_sim_time_horizon=system.getAttribute("max_sim_time_horizon");
-			const	char	*_sim_time_horizon=system.getAttribute("sim_time_horizon");
+			const	char	*_sim_time_horizon_factor=system.getAttribute("sim_time_horizon_factor");
 			const	char	*_tpx_time_horizon=system.getAttribute("tpx_time_horizon");
 			const	char	*_perf_sampling_period=system.getAttribute("perf_sampling_period");
 			const	char	*_float_tolerance=system.getAttribute("float_tolerance");
@@ -191,7 +191,7 @@ public:
 			tpx_dsr_thr=atof(_tpx_dsr_thr);
 			min_sim_time_horizon=atoi(_min_sim_time_horizon);
 			max_sim_time_horizon=atoi(_max_sim_time_horizon);
-			sim_time_horizon=atof(_sim_time_horizon);
+			sim_time_horizon_factor=atof(_sim_time_horizon_factor);
 			tpx_time_horizon=atoi(_tpx_time_horizon);
 			perf_sampling_period=atoi(_perf_sampling_period);
 			float_tolerance=atof(_float_tolerance);

--- a/Test/settings.xml
+++ b/Test/settings.xml
@@ -15,7 +15,7 @@
     tpx_dsr_thr="0.1"
     min_sim_time_horizon="0"
     max_sim_time_horizon="0"
-    sim_time_horizon="0.3"
+    sim_time_horizon_factor="0.3"
     tpx_time_horizon="500000"
     perf_sampling_period="250000"
     float_tolerance="0.00001"
@@ -64,7 +64,7 @@ System
   tpx_dsr_thr: in [0,1].
   min_sim_time_horizon: in us.
   max_sim_time_horizon: in us.
-  sim_time_horizon: in [0,1]: percentage of (before-now) allocated to simulation.
+  sim_time_horizon_factor: in [0,1]: factor of (before-now) allocated to simulation.
   tpx_time_horizon: in us.
   perf_sampling_prd: in us.
   float_tolerance: in [0,1].

--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1116,7 +1116,7 @@ namespace	r_exec{
 	inline	uint64	PMDLController::get_sim_thz(uint64	now,uint64 deadline)	const{
 
 		uint32	min_sim_thz=_Mem::Get()->get_min_sim_time_horizon();	// time allowance for the simulated predictions to flow upward.
-		uint64	sim_thz=_Mem::Get()->get_sim_time_horizon(deadline-now);
+		uint64	sim_thz=_Mem::Get()->get_sim_time_horizon_factor(deadline-now);
 		if(sim_thz>min_sim_thz){
 
 			sim_thz-=min_sim_thz;

--- a/r_exec/mem.h
+++ b/r_exec/mem.h
@@ -124,7 +124,7 @@ namespace	r_exec{
 		float32	tpx_dsr_thr;
 		uint32	min_sim_time_horizon;
 		uint32	max_sim_time_horizon;
-		float32	sim_time_horizon;
+		float32	sim_time_horizon_factor;
 		uint32	tpx_time_horizon;
 		uint32	perf_sampling_period;
 		float32	float_tolerance;
@@ -208,7 +208,7 @@ namespace	r_exec{
 					float32	tpx_dsr_thr,
 					uint32	min_sim_time_horizon,
 					uint32	max_sim_time_horizon,
-					float32	sim_time_horizon,
+					float32	sim_time_horizon_factor,
 					uint32	tpx_time_horizon,
 					uint32	perf_sampling_period,
 					float32	float_tolerance,
@@ -229,7 +229,7 @@ namespace	r_exec{
 		float32	get_tpx_dsr_thr()						const{	return	tpx_dsr_thr;	}
 		uint32	get_min_sim_time_horizon()				const{	return	min_sim_time_horizon;	}
 		uint32	get_max_sim_time_horizon()				const{	return	max_sim_time_horizon;	}
-		uint64	get_sim_time_horizon(uint64	horizon)	const{	return	horizon*sim_time_horizon;	}
+		uint64	get_sim_time_horizon_factor(uint64	horizon)	const{	return	horizon*sim_time_horizon_factor;	}
 		uint32	get_tpx_time_horizon()					const{	return	tpx_time_horizon;	}
 		uint64	get_primary_thz()						const{	return	primary_thz;	}
 		uint64	get_secondary_thz()						const{	return	secondary_thz;	}


### PR DESCRIPTION
In [settings.xml](https://github.com/IIIM-IS/replicode/blob/cab4eaf2aa107e0d27cc65c0a12e2b54f93bccc4/Test/settings.xml#L16-L18), `min_sim_time_horizon` and `max_sim_time_horizon` are in microseconds. But `sim_time_horizon` is named similarly but is not in microseconds. It is a factor in the range of 0 to 1 of the remaining time to the goal time. To avoid confusion, this pull request renames it to `sim_time_horizon_factor`.