### PR TITLE
GMonitor constructor: pass the sim_thz as an offset from now

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1106,7 +1106,7 @@ void PMDLController::register_predicted_goal_outcome(Fact *goal, HLPBindingMap *
 
         g->sim = new_sim;
 
-        add_g_monitor(new GMonitor(this, bm, deadline, sim_thz, new_goal, f_imdl, NULL));
+        add_g_monitor(new GMonitor(this, bm, deadline, now + sim_thz, new_goal, f_imdl, NULL));
 
         inject_goal(bm, new_goal, f_imdl);
       }
@@ -1752,7 +1752,7 @@ void PrimaryMDLController::abduce_imdl(HLPBindingMap *bm, Fact *super_goal, Fact
 
   auto now = Now();
   Fact *f_sub_goal = new Fact(sub_goal, now, now, 1, 1);
-  add_r_monitor(new RMonitor(this, bm, super_goal->get_goal()->get_target()->get_before(), sim->thz, f_sub_goal, f_imdl)); // the monitor will wait until the deadline of the super-goal.
+  add_r_monitor(new RMonitor(this, bm, super_goal->get_goal()->get_target()->get_before(), now + sim->thz, f_sub_goal, f_imdl)); // the monitor will wait until the deadline of the super-goal.
   inject_goal(bm, f_sub_goal, f_imdl);
   OUTPUT(MDL_OUT) << Utils::RelativeTime(Now()) << " " << getObject()->get_oid() << " -> fact " << f_sub_goal->get_oid() << " goal fact " << f_imdl->get_oid();
 #ifdef WITH_DEBUG_OID
@@ -1797,7 +1797,7 @@ void PrimaryMDLController::abduce_simulated_lhs(HLPBindingMap *bm, Fact *super_g
         auto now = Now();
         Fact *f_sub_goal = new Fact(sub_goal, now, now, 1, 1);
 
-        add_g_monitor(new SGMonitor(this, bm, sim->thz, f_sub_goal, f_imdl));
+        add_g_monitor(new SGMonitor(this, bm, now + sim->thz, f_sub_goal, f_imdl));
         inject_simulation(f_sub_goal);
         break;
       }
@@ -1816,7 +1816,7 @@ void PrimaryMDLController::abduce_simulated_imdl(HLPBindingMap *bm, Fact *super_
 
   auto now = Now();
   Fact *f_sub_goal = new Fact(sub_goal, now, now, 1, 1);
-  add_r_monitor(new SRMonitor(this, bm, sim->thz, f_sub_goal, f_imdl));
+  add_r_monitor(new SRMonitor(this, bm, now + sim->thz, f_sub_goal, f_imdl));
   inject_simulation(f_sub_goal);
 }
 


### PR DESCRIPTION
In the `Sim` class, [the time horizon `thz` variable](https://github.com/IIIM-IS/replicode/blob/7bcb20af9709ac282bd3c5a112a81565d2779d84/r_exec/factory.h#L211) is a duration. But in the `_GMonitor` class, [the `sim_thz` variable](https://github.com/IIIM-IS/replicode/blob/7bcb20af9709ac282bd3c5a112a81565d2779d84/r_exec/g_monitor.h#L93) is a time stamp. This is clear from the `_GMonitor` constructor which sets the `simulating` flag by [comparing `sim_thz` with `Now()`](https://github.com/IIIM-IS/replicode/blob/7bcb20af9709ac282bd3c5a112a81565d2779d84/r_exec/g_monitor.cpp#L99). If `sim_thz` were a duration (like 100000 microseconds) then it would always be less than `Now()` which is a time stamp (the number if microseconds since January 1, 1970), and the `simulating` flag would always be false.

    simulating = (sim_thz > Now());

So, a time stamp must be passed to the constructor of `_GMonitor` and its subclasses, `GMonitor`, `RMonitor`, `SGMonitor` and `SRMonitor`. The current code shows the correct usage in this [call to the `GMonitor` constructor](https://github.com/IIIM-IS/replicode/blob/7bcb20af9709ac282bd3c5a112a81565d2779d84/r_exec/mdl_controller.cpp#L1235), which adds `now` to the local variable `sim_thz` which is a duration.

    new GMonitor(this, bm, deadline, now + sim_thz, f_sub_goal, f_imdl, evidence)

But this was not done correctly in this other places, and the compiler gives an error when trying to pass `microseconds` to the constructor which requires a `Timestamp`. This pull request adds `now +` as needed in the calls to the constructor of `_GMonitor` and its subclasses.