### PR TITLE
_Mem::get_goal_pred_success_res: Use == to check time_to_live

### DIFF
--- a/r_exec/mem.h
+++ b/r_exec/mem.h
@@ -245,7 +245,7 @@ public:
 
     if (debug)
       return goal_pred_success_res;
-    if (time_to_live = 0)
+    if (time_to_live.count() == 0)
       return 1;
     return Utils::GetResilience(now, time_to_live, host->get_upr());
   }


### PR DESCRIPTION
`_Mem::get_goal_pred_success_res` has [the following code](https://github.com/IIIM-IS/replicode/blob/7bcb20af9709ac282bd3c5a112a81565d2779d84/r_exec/mem.h#L248) which is supposed to return if `time_to_live` is zero:

    if (time_to_live = 0)
      return 1;

Instead of checking if `time_to_live` is `0`, this actually assigns `time_to_live = 0` and then checks the result which is `0` and always false. So it never returns, and proceeds to process `time_to_live` which has now been set to `0` which is exactly the case where the code was not supposed to proceed. (This ability to assign a value within an `if` condition is a well-known dangerous ""feature" of C++.)

Previously, `time_to_live` was a `uint64` duration in microseconds. But now it is `std::chrono::microseconds`, and the assignment to `0` gives a compiler error. This pull request, fixes the check using `==` as intended.