### PR TITLE
Sim constructor: Change param to sol_before to initialize properly.

### DIFF
--- a/r_exec/factory.cpp
+++ b/r_exec/factory.cpp
@@ -716,7 +716,7 @@ Sim::Sim(Sim *s) : _Object(), mode(s->mode), thz(s->thz), super_goal(s->super_go
 Sim::Sim(SimMode mode, microseconds thz, Fact *super_goal, bool opposite, Controller *root) : _Object(), mode(mode), thz(thz), super_goal(super_goal), root(root), sol(NULL), is_requirement(false), opposite(opposite), invalidated(0), sol_cfd(0), sol_before(seconds(0)) {
 }
 
-Sim::Sim(SimMode mode, microseconds thz, Fact *super_goal, bool opposite, Controller *root, Controller *sol, float32 sol_cfd, Timestamp sol_deadline) : _Object(), mode(mode), thz(thz), super_goal(super_goal), root(root), sol(sol), is_requirement(false), opposite(opposite), invalidated(0), sol_cfd(sol_cfd), sol_before(sol_before) {
+Sim::Sim(SimMode mode, microseconds thz, Fact *super_goal, bool opposite, Controller *root, Controller *sol, float32 sol_cfd, Timestamp sol_before) : _Object(), mode(mode), thz(thz), super_goal(super_goal), root(root), sol(sol), is_requirement(false), opposite(opposite), invalidated(0), sol_cfd(sol_cfd), sol_before(sol_before) {
 }
 
 void Sim::invalidate() {

--- a/r_exec/factory.h
+++ b/r_exec/factory.h
@@ -198,7 +198,7 @@ private:
 public:
   Sim(Sim *s); // is_requirement=false (not copied).
   Sim(SimMode mode, std::chrono::microseconds thz, Fact *super_goal, bool opposite, Controller *root); // use for SIM_ROOT.
-  Sim(SimMode mode, std::chrono::microseconds thz, Fact *super_goal, bool opposite, Controller *root, Controller *sol, float32 sol_cfd, Timestamp sol_deadline); // USE for SIM_MANDATORY or SIM_OPTIONAL.
+  Sim(SimMode mode, std::chrono::microseconds thz, Fact *super_goal, bool opposite, Controller *root, Controller *sol, float32 sol_cfd, Timestamp sol_before); // USE for SIM_MANDATORY or SIM_OPTIONAL.
 
   void invalidate();
   bool is_invalidated();


### PR DESCRIPTION
Here is the abbreviated code for the [`Sim` constructor](https://github.com/IIIM-IS/replicode/blob/7bcb20af9709ac282bd3c5a112a81565d2779d84/r_exec/factory.cpp#L719) to initialize `mode`, `sol_before` and other member variables.

    Sim::Sim(SimMode mode, ... Timestamp sol_deadline) : mode(mode), ... sol_before(sol_before) {}

`mode(mode)` means initialize the member variable `mode` from the parameter `mode` passed to the constructor. Although it's confusing, this code works. But `sol_before(sol_before)` does not work as expected, because there is no parameter `sol_before`. Instead this initializes the member variable `sol_before` with itself, which is uninitialized. The parameter that is intended to initialize `sol_before` is named `sol_deadline` (perhaps from a previous commit). But because it is the wrong name, it is not used to initialize `sol_before`. Any code that uses the uninitialized member variable `sol_before` will have unexpected behavior.

This pull request renames the parameter `sol_deadline` to `sol_before` so that the member variable is initialized as intended.

(This kind of error can be avoided if we use the common practice to name member variables different from local variables, for example with an extra underscore. The code would be `sol_before_(sol_before)`. And if the code were `sol_before_(sol_before_)` it would clearly be a bug to initialize using an existing member variable.)