### PR TITLE
_Mem: In init, fix conversion of primary_thz and secondary_thz to microseconds

### DIFF
--- a/r_exec/mem.cpp
+++ b/r_exec/mem.cpp
@@ -135,8 +135,8 @@ void _Mem::init(microseconds base_period,
   this->perf_sampling_period = perf_sampling_period;
   this->float_tolerance = float_tolerance;
   this->time_tolerance = time_tolerance;
-  this->primary_thz = primary_thz * 1000000;
-  this->secondary_thz = secondary_thz * 1000000;
+  this->primary_thz = primary_thz;
+  this->secondary_thz = secondary_thz;
 
   this->debug = debug;
   if (debug)


### PR DESCRIPTION
In settings.xml, most durations are in microseconds. But [`primary_thz` and `secondary_thz`](https://github.com/IIIM-IS/replicode/blob/84fbe040fcc712199b2ddca4585922880b196368/Test/settings.xml#L72-L73) are in seconds. The default values are 3,600,000 and 7,200,000 which are 1,000 hours and 2,000 hours, respectively. In the `_Mem` class, these are stored as microseconds, not seconds. So to convert, `_Mem::init` [multiplies the passed-in parameters by 1,000,000](https://github.com/IIIM-IS/replicode/blob/01807e351a1bf7264093ce2e362c2499e4b32a80/r_exec/mem.cpp#L137-L138). 

    this->primary_thz = primary_thz * 1000000;
    this->secondary_thz = secondary_thz * 1000000;

The problem is that, in the code before converting to `std::chrono`, the passed-in [parameters are `uint32`](https://github.com/IIIM-IS/replicode/blob/01807e351a1bf7264093ce2e362c2499e4b32a80/r_exec/mem.cpp#L113-L114). The multiplication by 1,000,000 is done as a 32-bit integer, which overflows. So the results stored in `this->primary_thz` and `this->secondary_thz` are nonsense. For example, if `primary_thz` in settings.xml is 3,600,000 seconds, then `this->primary_thz` should be 3,600,000,000,000 microseconds. But it is 817,405,952.

In the code after converting to `std::chrono`, the parameters to `_Mem::init` are already [passed-in as `microseconds`](https://github.com/IIIM-IS/replicode/blob/7bcb20af9709ac282bd3c5a112a81565d2779d84/r_exec/mem.cpp#L114-L115). The conversion from seconds happens automatically when the the settings values are [interpreted as seconds](https://github.com/IIIM-IS/replicode/blob/7bcb20af9709ac282bd3c5a112a81565d2779d84/Test/Test.cpp#L340-L341) when calling `_Mem::init`.

    mem->init(...
      seconds(settings.primary_thz),
      seconds(settings.secondary_thz),
      ...);

Since the conversion is automatic, `_Mem::init` does not need to explicitly convert. This pull request removes the explicit multiplication by 1,000,000.