### PR TITLE
Allow parsing timestamps with format 0s:100ms:0us

### DIFF
--- a/r_comp/compiler.cpp
+++ b/r_comp/compiler.cpp
@@ -1207,7 +1207,13 @@ bool Compiler::number(float32 &n) {
     return false;
   }
   if (match_symbol("us", true)) {
-
+    // Assume this is a timestamp, not a number.
+    in_stream_->clear();
+    in_stream_->seekg(i);
+    return false;
+  }
+  if (match_symbol("s", true)) {
+    // Assume this is a timestamp, not a number.
     in_stream_->clear();
     in_stream_->seekg(i);
     return false;
@@ -1274,6 +1280,58 @@ bool Compiler::timestamp(uint64 &ts) {
     in_stream_->seekg(i);
     return false;
   }
+  return true;
+}
+
+bool Compiler::timestamp_s_ms_us(uint64 &ts) {
+
+  std::streampos i = in_stream_->tellg();
+  if (match_symbol("0x", true)) {
+    in_stream_->clear();
+    in_stream_->seekg(i);
+    return false;
+  }
+
+  uint64 s;
+  *in_stream_ >> std::dec >> s;
+  if (in_stream_->fail() || in_stream_->eof()) {
+    in_stream_->clear();
+    in_stream_->seekg(i);
+    return false;
+  }
+  if (!match_symbol("s:", false)) {
+    in_stream_->clear();
+    in_stream_->seekg(i);
+    return false;
+  }
+
+  uint64 ms;
+  *in_stream_ >> std::dec >> ms;
+  if (in_stream_->fail() || in_stream_->eof()) {
+    in_stream_->clear();
+    in_stream_->seekg(i);
+    return false;
+  }
+  if (!match_symbol("ms:", false)) {
+    in_stream_->clear();
+    in_stream_->seekg(i);
+    return false;
+  }
+
+  uint64 us;
+  *in_stream_ >> std::dec >> us;
+  if (in_stream_->fail() || in_stream_->eof()) {
+    in_stream_->clear();
+    in_stream_->seekg(i);
+    return false;
+  }
+  if (!match_symbol("us", false)) {
+    in_stream_->clear();
+    in_stream_->seekg(i);
+    return false;
+  }
+
+  ts = s * 1000000 + ms * 1000 + us;
   return true;
 }
 
@@ -2012,6 +2070,17 @@ bool Compiler::read_timestamp(bool &indented, bool enforce, const Class *p, uint
     }
     return true;
   }
+  if (timestamp_s_ms_us(ts)) {
+    if (write) {
+
+      current_object_->code_[write_index] = Atom::IPointer(extent_index);
+      current_object_->code_[extent_index++] = Atom::Timestamp();
+      current_object_->code_[extent_index++] = ts >> 32;
+      current_object_->code_[extent_index++] = (ts & 0x00000000FFFFFFFF);
+    }
+    return true;
+  }
+
   State s = save_state();
   if (expression(indented, TIMESTAMP, write_index, extent_index, write))
     return true;

--- a/r_comp/compiler.h
+++ b/r_comp/compiler.h
@@ -203,7 +203,20 @@ private:
   bool global_indirection(std::vector<int16> &v, const ReturnType t); // ex: p.res where p is a label/variable declared outside the object.
   bool wildcard();
   bool tail_wildcard();
+  /// <summary>
+  /// Read a timestamp of the form XXXus, where XXX is a decimal.
+  /// </summary>
+  /// <param name="ts">Set ts to the timestamp in microseconds.</param>
+  /// <returns>True for success, false if this is not a timestamp (and in_stream_ is not advanced)</returns>
   bool timestamp(uint64 &ts);
+  /// <summary>
+  /// Read a timestamp of the form XXXs:YYYms:ZZZus, where XXX, YYY and ZZZ are decimal
+  /// seconds, milliseconds and microseconds. This is the reverse of the output of
+  /// Time::ToString_seconds used by the decompiler.
+  /// </summary>
+  /// <param name="ts">Set ts to the timestamp in microseconds.</param>
+  /// <returns>True for success, false if this is not a timestamp (and in_stream_ is not advanced)</returns>
+  bool timestamp_s_ms_us(uint64 &ts);
   bool str(std::string &s);
   bool number(float32 &n);
   bool hex(uint32 &h);


### PR DESCRIPTION
As mentioned in issue #41, the decompiler will output timestamps like 1s:200ms:0us, but the compiler doesn't accept this format. Therefore, we cannot recompile code from the decompiler output which is needed, for example, by the Visualizer to recreate the objects which are in the decompiler output.

The first commit in this pull request changes the parse to not consider a symbol starting with a decimal digit to be a label. This prevents it from interpreting 1s:200ms:0us as a value with a label "1s". (This was already an implicit assumption, and none of the existing Replicode examples use a label starting with a decimal digit.)

The second commit in this pull request adds the parser function `timestamp_s_ms_us` which parses XXXs:YYYms:ZZZus, similar to the existing function `timestamp` which just parses ZZZus. This updates `read_timestamp` to try `timestamp_s_ms_us` if the function `timestamp` fails.