### PR TITLE
Don't allow redefining a global label

### DIFF
--- a/r_comp/compiler.cpp
+++ b/r_comp/compiler.cpp
@@ -198,8 +198,13 @@ bool Compiler::read_sys_object() {
     if (current_class_.str_opcode == "mdl" || current_class_.str_opcode == "cst")
       in_hlp_ = true;
     current_object_ = new SysObject();
-    if (lbl)
+    if (lbl) {
+      if (global_references_.find(l) != global_references_.end()) {
+        set_error("error: redefinition of label `" + l + "`");
+        return false;
+      }
       global_references_[l] = Reference(image_->code_segment_.objects_.size(), current_class_, Class());
+    }
   }
 
   current_object_->code_[0] = current_class_.atom_;


### PR DESCRIPTION
In Replicode, objects can be given a label such as `b`:

    b:(ent 1) |[]

and this label can be used in further definitions.

    b_is_a_ball:(mk.val b essence ball 1) |[]

The compiler doesn't currently check if redefining a label, e.g.:

    b:(mk.val self position 1) |[]

The label `b` now refers to a different object. But if we define a new model that uses `b_is_a_ball`, what does its `b` refer to? And even if the code has a new statement that defines `b` the same as the first time, internally the compiler creates and references a new object (instead of re-using the first one). Finally, the compiler doesn't currently check if the code redefines important labels like `stdin`.

Replicode doesn't have modules or namespaces. Every label is in the same global namespace, even if one code file loads another file. Therefore, there is an implicit assumption that labels are not redefined. This pull request updates the compiler to make it an error to redefine a global label.