### PR TITLE
Move "using namespace r_code" from headers into cpp files

### DIFF
--- a/CorrelatorTest/CorrelatorTest.cpp
+++ b/CorrelatorTest/CorrelatorTest.cpp
@@ -86,6 +86,7 @@
 #include "correlator.h"
 
 using namespace std::chrono;
+using namespace r_code;
 
 //#define DECOMPILE_ONE_BY_ONE
 

--- a/Test/Test.cpp
+++ b/Test/Test.cpp
@@ -85,6 +85,7 @@
 //#define DECOMPILE_ONE_BY_ONE
 
 using namespace std::chrono;
+using namespace r_code;
 using namespace r_comp;
 
 r_exec::View *build_view(Timestamp time, Code* rstdin) { // this is application dependent WRT view->sync.

--- a/Test/test_mem.cpp
+++ b/Test/test_mem.cpp
@@ -78,6 +78,7 @@
 #include "test_mem.h"
 
 using namespace std::chrono;
+using namespace r_code;
 using namespace r_exec;
 
 template<class O, class S> TestMem<O, S>::TestMem()

--- a/Test/test_mem.h
+++ b/Test/test_mem.h
@@ -108,7 +108,7 @@ public:
   /// Override eject to check for (cmd set_speed_y ...) and other implemented commands.
   /// </summary>
   /// <param name="command"></param>
-  virtual void eject(Code *command);
+  virtual void eject(r_code::Code *command);
 
   /// <summary>
   /// This is called when runInDiagnosticTime() updates the tickTime. Just call
@@ -127,7 +127,7 @@ protected:
   /// <param name="name"> The name of the symbol.</param>
   /// <returns>The object, or NULL if not found.</returns>
   ///
-  static Code* findObject(
+  static r_code::Code* findObject(
     std::vector<r_code::Code *> *objects, const char* name);
 
   /// <summary>
@@ -144,8 +144,8 @@ protected:
   /// <param name="group"></param>
   /// <returns>The created View.</returns>
   r_exec::View* injectMarkerValue(
-    Code* obj, Code* prop, Atom val, Timestamp after, Timestamp before,
-    r_exec::View::SyncMode syncMode, Code* group);
+    r_code::Code* obj, r_code::Code* prop, Atom val, Timestamp after, Timestamp before,
+    r_exec::View::SyncMode syncMode, r_code::Code* group);
 
   /// <summary>
   /// Inject (fact (mk.val obj prop val 1) after before 1 1)
@@ -160,7 +160,7 @@ protected:
   /// <param name="syncMode"></param>
   /// <returns>The created View.</returns>
   r_exec::View* injectMarkerValue(
-    Code* obj, Code* prop, Atom val, Timestamp after, Timestamp before,
+    r_code::Code* obj, r_code::Code* prop, Atom val, Timestamp after, Timestamp before,
     r_exec::View::SyncMode syncMode)
   {
     return injectMarkerValue(obj, prop, val, after, before, syncMode, get_stdin());
@@ -179,7 +179,7 @@ protected:
   /// <param name="group"></param>
   /// <returns>The created View.</returns>
   r_exec::View* injectMarkerValue(
-    Code* obj, Code* prop, Atom val, Timestamp after, Timestamp before, Code* group)
+    r_code::Code* obj, r_code::Code* prop, Atom val, Timestamp after, Timestamp before, r_code::Code* group)
   {
     return injectMarkerValue(
       obj, prop, val, after, before, r_exec::View::SYNC_PERIODIC, group);
@@ -197,7 +197,7 @@ protected:
   /// <param name="before"></param>
   /// <returns>The created View.</returns>
   r_exec::View* injectMarkerValue(
-    Code* obj, Code* prop, Atom val, Timestamp after, Timestamp before)
+    r_code::Code* obj, r_code::Code* prop, Atom val, Timestamp after, Timestamp before)
   {
     return injectMarkerValue(
       obj, prop, val, after, before, r_exec::View::SYNC_PERIODIC, get_stdin());
@@ -217,8 +217,8 @@ protected:
   /// <param name="group"></param>
   /// <returns>The created View.</returns>
   r_exec::View* injectMarkerValue(
-    Code* obj, Code* prop, Code* val, Timestamp after, Timestamp before,
-    r_exec::View::SyncMode syncMode, Code* group);
+    r_code::Code* obj, r_code::Code* prop, r_code::Code* val, Timestamp after, Timestamp before,
+    r_exec::View::SyncMode syncMode, r_code::Code* group);
 
   /// <summary>
   /// Inject (fact (mk.val obj prop val 1) after before 1 1)
@@ -233,7 +233,7 @@ protected:
   /// <param name="syncMode"></param>
   /// <returns>The created View.</returns>
   r_exec::View* injectMarkerValue(
-    Code* obj, Code* prop, Code* val, Timestamp after, Timestamp before,
+    r_code::Code* obj, r_code::Code* prop, r_code::Code* val, Timestamp after, Timestamp before,
     r_exec::View::SyncMode syncMode)
   {
     return injectMarkerValue(obj, prop, val, after, before, syncMode, get_stdin());
@@ -252,7 +252,7 @@ protected:
   /// <param name="group"></param>
   /// <returns>The created View.</returns>
   r_exec::View* injectMarkerValue(
-    Code* obj, Code* prop, Code* val, Timestamp after, Timestamp before, Code* group)
+    r_code::Code* obj, r_code::Code* prop, r_code::Code* val, Timestamp after, Timestamp before, r_code::Code* group)
   {
     return injectMarkerValue(
       obj, prop, val, after, before, r_exec::View::SYNC_PERIODIC, group);
@@ -270,7 +270,7 @@ protected:
   /// <param name="before"></param>
   /// <returns>The created View.</returns>
   r_exec::View* injectMarkerValue(
-    Code* obj, Code* prop, Code* val, Timestamp after, Timestamp before)
+    r_code::Code* obj, r_code::Code* prop, r_code::Code* val, Timestamp after, Timestamp before)
   {
     return injectMarkerValue(
       obj, prop, val, after, before, r_exec::View::SYNC_PERIODIC, get_stdin());
@@ -287,8 +287,8 @@ protected:
   /// <param name="group"></param>
   /// <returns>The created View.</returns>
   r_exec::View* injectFact(
-    Code* object, Timestamp after, Timestamp before, r_exec::View::SyncMode syncMode,
-    Code* group);
+    r_code::Code* object, Timestamp after, Timestamp before, r_exec::View::SyncMode syncMode,
+    r_code::Code* group);
 
   /// <summary>
   /// Inject (fact object after before 1 1)
@@ -299,7 +299,7 @@ protected:
   /// <param name="before"></param>
   /// <param name="group"></param>
   /// <returns>The created View.</returns>
-  r_exec::View* injectFact(Code* object, Timestamp after, Timestamp before, Code* group) {
+  r_exec::View* injectFact(r_code::Code* object, Timestamp after, Timestamp before, r_code::Code* group) {
     return injectFact(
       object, after, before, r_exec::View::SYNC_PERIODIC, group);
   }
@@ -324,20 +324,20 @@ protected:
   Timestamp lastInjectTime_;
   float speed_y_;
   float position_y_;
-  Code* position_y_obj_;
-  Code* position_property_;
-  Code* position_y_property_;
-  Code* speed_y_property_;
-  Code* primary_group_;
+  r_code::Code* position_y_obj_;
+  r_code::Code* position_property_;
+  r_code::Code* position_y_property_;
+  r_code::Code* speed_y_property_;
+  r_code::Code* primary_group_;
   uint16 set_speed_y_opcode_;
   uint16 move_y_plus_opcode_;
   uint16 move_y_minus_opcode_;
   Timestamp lastCommandTime_;
 
-  Code* yEnt_[10];
-  Code* discretePositionObj_;
-  Code* discretePosition_;
-  Code* nextDiscretePosition_;
+  r_code::Code* yEnt_[10];
+  r_code::Code* discretePositionObj_;
+  r_code::Code* discretePosition_;
+  r_code::Code* nextDiscretePosition_;
   int babbleState_;
 };
 

--- a/r_comp/class.cpp
+++ b/r_comp/class.cpp
@@ -78,6 +78,7 @@
 #include "class.h"
 #include "segments.h"
 
+using namespace r_code;
 
 namespace r_comp {
 

--- a/r_comp/class.h
+++ b/r_comp/class.h
@@ -93,7 +93,7 @@ public:
   static const char *Type;
 
   Class(ReturnType t = ANY);
-  Class(Atom atom,
+  Class(r_code::Atom atom,
     std::string str_opcode,
     std::vector<StructureMember> r,
     ReturnType t = ANY);
@@ -103,7 +103,7 @@ public:
   std::string get_member_name(uint32 index); // for decompilation
   ReturnType get_member_type(const uint16 index);
   Class *get_member_class(Metadata *metadata, const std::string &name);
-  Atom atom_;
+  r_code::Atom atom_;
   std::string str_opcode; // unused for anything but objects, markers and operators.
   std::vector<StructureMember> things_to_read;
   ReturnType type; // ANY for non-operators.

--- a/r_comp/compiler.cpp
+++ b/r_comp/compiler.cpp
@@ -78,6 +78,7 @@
 #include "compiler.h"
 #include <string.h>
 
+using namespace r_code;
 
 namespace r_comp {
 

--- a/r_comp/compiler.h
+++ b/r_comp/compiler.h
@@ -85,9 +85,6 @@
 #include "segments.h"
 #include "../r_code/image.h"
 
-
-using namespace r_code;
-
 namespace r_comp {
 
 class dll_export Compiler {
@@ -99,7 +96,7 @@ private:
   bool trace_;
 
   Class current_class_; // the sys-class currently parsed.
-  ImageObject *current_object_; // the sys-object currently parsed.
+  r_code::ImageObject *current_object_; // the sys-object currently parsed.
   uint32 current_object_index_; // ordinal of the current sys-object in the code segment.
   int32 current_view_index_; // ordinal of a view in the sys-object's view set.
 
@@ -137,7 +134,7 @@ private:
   UNORDERED_MAP<std::string, Reference> local_references_; // labels and variables declared inside objects (cleared before parsing each sys-object): translate to value pointers.
   UNORDERED_MAP<std::string, Reference> global_references_; // labels declared outside sys-objects. translate to reference pointers.
   void addLocalReference(const std::string reference_name, const uint16 index, const Class &p); // detect cast.
-  bool getGlobalReferenceIndex(const std::string reference_name, const ReturnType t, ImageObject *object, uint16 &index, Class *&_class); // index points to the reference set.
+  bool getGlobalReferenceIndex(const std::string reference_name, const ReturnType t, r_code::ImageObject *object, uint16 &index, Class *&_class); // index points to the reference set.
                                                                                                                                                       // return false when not found.
   bool in_hlp_;
   std::vector<std::string> hlp_references_;

--- a/r_comp/decompiler.cpp
+++ b/r_comp/decompiler.cpp
@@ -80,6 +80,7 @@
 #include "../submodules/CoreLibrary/CoreLibrary/utils.h"
 
 using namespace std::chrono;
+using namespace r_code;
 
 namespace r_comp {
 

--- a/r_comp/decompiler.h
+++ b/r_comp/decompiler.h
@@ -96,7 +96,7 @@ private:
   bool hlp_postfix_;
   bool horizontal_set_;
 
-  ImageObject *current_object_;
+  r_code::ImageObject *current_object_;
 
   r_comp::Metadata *metadata_;
   r_comp::Image *image_;
@@ -137,7 +137,7 @@ private:
   bool partial_decompilation_; // used when decompiling on-the-fly.
   bool ignore_named_objects_;
   UNORDERED_SET<uint16> named_objects_;
-  std::vector<SysObject *> imported_objects_; // referenced objects added to the image that were not in the original list of objects to be decompiled.
+  std::vector<r_code::SysObject *> imported_objects_; // referenced objects added to the image that were not in the original list of objects to be decompiled.
 public:
   Decompiler();
   ~Decompiler();
@@ -150,7 +150,7 @@ public:
   uint32 decompile(r_comp::Image *image,
     std::ostringstream *stream,
     Timestamp::duration time_offset,
-    std::vector<SysObject *> &imported_objects); // idem, ignores named objects if in the imported object list.
+    std::vector<r_code::SysObject *> &imported_objects); // idem, ignores named objects if in the imported object list.
   uint32 decompile_references(r_comp::Image *image); // initialize a reference table so that objects can be decompiled individually; returns the number of objects.
   void decompile_object(uint16 object_index, std::ostringstream *stream, Timestamp::duration time_offset); // decompiles a single object; object_index is the position of the object in the vector returned by Image::getObject.
   void decompile_object(const std::string object_name, std::ostringstream *stream, Timestamp::duration time_offset); // decompiles a single object given its name: use this function to follow references.

--- a/r_comp/out_stream.h
+++ b/r_comp/out_stream.h
@@ -82,9 +82,6 @@
 
 #include "../r_code/vector.h"
 
-
-using namespace r_code;
-
 namespace r_comp {
 
 // Allows inserting data at a specified index and right shifting the current content;

--- a/r_comp/preprocessor.cpp
+++ b/r_comp/preprocessor.cpp
@@ -81,6 +81,7 @@
 #include "../submodules/CoreLibrary/CoreLibrary/utils.h"
 namespace fs = std::experimental::filesystem;
 
+using namespace r_code;
 
 namespace r_comp {
 

--- a/r_comp/preprocessor.h
+++ b/r_comp/preprocessor.h
@@ -83,8 +83,6 @@
 #include <sstream>
 #include <fstream>
 
-using namespace r_code;
-
 namespace r_comp {
 
 class RepliMacro;

--- a/r_comp/segments.cpp
+++ b/r_comp/segments.cpp
@@ -80,6 +80,7 @@
 #include <iostream>
 
 using namespace std::chrono;
+using namespace r_code;
 
 namespace r_comp {
 

--- a/r_comp/segments.h
+++ b/r_comp/segments.h
@@ -83,9 +83,6 @@
 
 #include "class.h"
 
-
-using namespace r_code;
-
 namespace r_comp {
 
 class Reference {
@@ -141,7 +138,7 @@ public:
 
 class dll_export CodeSegment {
 public:
-  r_code::vector<SysObject *> objects_;
+  r_code::vector<r_code::SysObject *> objects_;
 
   ~CodeSegment();
 
@@ -174,11 +171,11 @@ private:
   UNORDERED_MAP<r_code::Code *, uint16> ptrs_to_indices_; // used for injection in memory.
 
   void add_object(r_code::Code *object);
-  SysObject *add_object(Code *object, std::vector<SysObject *> &imported_objects);
-  uint32 get_reference_count(const Code *object) const;
+  r_code::SysObject *add_object(r_code::Code *object, std::vector<r_code::SysObject *> &imported_objects);
+  uint32 get_reference_count(const r_code::Code *object) const;
   void build_references();
-  void build_references(SysObject *sys_object, r_code::Code *object);
-  void unpack_objects(r_code::vector<Code *> &ram_objects);
+  void build_references(r_code::SysObject *sys_object, r_code::Code *object);
+  void unpack_objects(r_code::vector<r_code::Code *> &ram_objects);
 public:
   ObjectMap object_map_;
   CodeSegment code_segment_;
@@ -189,11 +186,11 @@ public:
   Image();
   ~Image();
 
-  void add_sys_object(SysObject *object, std::string name); // called by the compiler.
-  void add_sys_object(SysObject *object); // called by add_object().
+  void add_sys_object(r_code::SysObject *object, std::string name); // called by the compiler.
+  void add_sys_object(r_code::SysObject *object); // called by add_object().
 
-  void get_objects(Mem *mem, r_code::vector<r_code::Code *> &ram_objects);
-  template<class O> void get_objects(r_code::vector<Code *> &ram_objects) {
+  void get_objects(r_code::Mem *mem, r_code::vector<r_code::Code *> &ram_objects);
+  template<class O> void get_objects(r_code::vector<r_code::Code *> &ram_objects) {
 
     for (uint32 i = 0; i < code_segment_.objects_.size(); ++i) {
 
@@ -204,7 +201,7 @@ public:
   }
 
   void add_objects(r_code::list<P<r_code::Code> > &objects); // called by the rMem.
-  void add_objects(r_code::list<P<r_code::Code> > &objects, std::vector<SysObject *> &imported_objects); // called by any r_exec code for decompiling on the fly.
+  void add_objects(r_code::list<P<r_code::Code> > &objects, std::vector<r_code::SysObject *> &imported_objects); // called by any r_exec code for decompiling on the fly.
 
   template<class I> I *serialize() {
 

--- a/r_comp/structure_member.h
+++ b/r_comp/structure_member.h
@@ -83,9 +83,6 @@
 #include "../r_code/image.h"
 #include "../r_code/atom.h"
 
-
-using namespace r_code;
-
 namespace r_comp {
 
 class Class;

--- a/r_exec/_context.cpp
+++ b/r_exec/_context.cpp
@@ -77,6 +77,7 @@
 
 #include "_context.h"
 
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/_context.h
+++ b/r_exec/_context.h
@@ -81,9 +81,6 @@
 #include "../r_code/atom.h"
 #include "overlay.h"
 
-
-using namespace r_code;
-
 namespace r_exec {
 
 // Base class for evaluation contexts.

--- a/r_exec/ast_controller.h
+++ b/r_exec/ast_controller.h
@@ -105,7 +105,7 @@ protected:
 public:
   virtual ~ASTController();
 
-  Code *get_core_object() const { return getObject(); }
+  r_code::Code *get_core_object() const { return getObject(); }
 
   void take_input(r_exec::View *input);
   void reduce(View *input);

--- a/r_exec/ast_controller.tpl.cpp
+++ b/r_exec/ast_controller.tpl.cpp
@@ -80,6 +80,7 @@
 #include "factory.h"
 #include "auto_focus.h"
 
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/auto_focus.cpp
+++ b/r_exec/auto_focus.cpp
@@ -78,6 +78,7 @@
 #include "auto_focus.h"
 #include "ast_controller.h"
 
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/auto_focus.h
+++ b/r_exec/auto_focus.h
@@ -125,12 +125,12 @@ private:
     }
   };
 
-  typedef UNORDERED_MAP<P<_Fact>, P<TPX>, PHash<_Fact> > TPXMap;
+  typedef UNORDERED_MAP<P<_Fact>, P<TPX>, r_code::PHash<_Fact> > TPXMap;
 
   TPXMap goals_; // f->g->f->target.
   TPXMap predictions_; // f->p->f->target.
 
-  typedef UNORDERED_MAP<P<_Fact>, Rating, PHash<_Fact> > RatingMap;
+  typedef UNORDERED_MAP<P<_Fact>, Rating, r_code::PHash<_Fact> > RatingMap;
 
   // entries are patterns, i.e. abstract targets.
   RatingMap goal_ratings_;
@@ -139,8 +139,8 @@ private:
   static const uint32 CacheInitialSize = 128;
   static const uint32 CrossBufferInitialSize = 1024;
 
-  time_buffer<CInput, CInput::IsInvalidated> cache_; // contains all inputs we don't no yet if they are relevant or not; thz==sampling period.
-  time_buffer<Input, Input::IsInvalidated> cross_buffer_; // contains all relevant inputs.
+  r_code::time_buffer<CInput, CInput::IsInvalidated> cache_; // contains all inputs we don't no yet if they are relevant or not; thz==sampling period.
+  r_code::time_buffer<Input, Input::IsInvalidated> cross_buffer_; // contains all relevant inputs.
 
   void notify(_Fact *target, View *input, TPXMap &map);
   void dispatch_pred_success(_Fact *predicted_f, TPXMap &map);
@@ -169,7 +169,7 @@ public:
   AutoFocusController(r_code::View *view);
   ~AutoFocusController();
 
-  Code *get_core_object() const;
+  r_code::Code *get_core_object() const;
 
   void take_input(r_exec::View *input);
   void reduce(r_exec::View *input);
@@ -177,7 +177,7 @@ public:
   View *inject_input(View *input); // inject a filtered input into the output groups starting from 0; return the view injected in the primary group.
   void inject_input(View *input, uint32 start); // inject an unfiltered input into the output groups starting from start.
   void inject_input(View *input, _Fact *abstract_input, BindingMap *bm); // inject a filtered input into the output groups.
-  void inject_hlps(const std::vector<P<Code> > &hlps) const; // called by TPX; hlp is a mdl or a cst.
+  void inject_hlps(const std::vector<P<r_code::Code> > &hlps) const; // called by TPX; hlp is a mdl or a cst.
 
   bool decompile_models() const { return decompile_models_; }
   bool gtpx_on() const { return gtpx_on_; }
@@ -185,7 +185,7 @@ public:
   Group *get_primary_group() const { return output_groups_[0]; }
 
   void copy_cross_buffer(r_code::list<Input> &destination);
-  time_buffer<CInput, CInput::IsInvalidated> &get_cache() { return cache_; }
+  r_code::time_buffer<CInput, CInput::IsInvalidated> &get_cache() { return cache_; }
 };
 }
 

--- a/r_exec/binding_map.cpp
+++ b/r_exec/binding_map.cpp
@@ -80,6 +80,7 @@
 #include "factory.h"
 
 using namespace std::chrono;
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/binding_map.h
+++ b/r_exec/binding_map.h
@@ -96,10 +96,10 @@ protected:
   Value(BindingMap *map);
 public:
   virtual Value *copy(BindingMap *map) const = 0;
-  virtual void valuate(Code *destination, uint16 write_index, uint16 &extent_index) const = 0;
-  virtual bool match(const Code *object, uint16 index) = 0;
+  virtual void valuate(r_code::Code *destination, uint16 write_index, uint16 &extent_index) const = 0;
+  virtual bool match(const r_code::Code *object, uint16 index) = 0;
   virtual Atom *get_code() = 0;
-  virtual Code *get_object() = 0;
+  virtual r_code::Code *get_object() = 0;
   virtual uint16 get_code_size() = 0;
 
   virtual bool intersect(const Value *v) const { return false; }
@@ -109,7 +109,7 @@ public:
 
   virtual bool contains(const Atom a) const { return false; }
   virtual bool contains(const Atom *s) const { return false; }
-  virtual bool contains(const Code *o) const { return false; }
+  virtual bool contains(const r_code::Code *o) const { return false; }
 
   /// <summary>
   /// Return the trace of the value as a string by creating a temporary Code
@@ -140,10 +140,10 @@ public:
   ~UnboundValue();
 
   Value *copy(BindingMap *map) const;
-  void valuate(Code *destination, uint16 write_index, uint16 &extent_index) const;
-  bool match(const Code *object, uint16 index);
+  void valuate(r_code::Code *destination, uint16 write_index, uint16 &extent_index) const;
+  bool match(const r_code::Code *object, uint16 index);
   Atom *get_code();
-  Code *get_object();
+  r_code::Code *get_object();
   uint16 get_code_size();
 };
 
@@ -155,10 +155,10 @@ public:
   AtomValue(BindingMap *map, Atom atom);
 
   Value *copy(BindingMap *map) const;
-  void valuate(Code *destination, uint16 write_index, uint16 &extent_index) const;
-  bool match(const Code *object, uint16 index);
+  void valuate(r_code::Code *destination, uint16 write_index, uint16 &extent_index) const;
+  bool match(const r_code::Code *object, uint16 index);
   Atom *get_code();
-  Code *get_object();
+  r_code::Code *get_object();
   uint16 get_code_size();
 
   bool intersect(const Value *v) const;
@@ -170,18 +170,18 @@ public:
 class r_exec_dll StructureValue :
   public BoundValue {
 private:
-  P<Code> structure_;
-  StructureValue(BindingMap *map, const Code *structure);
+  P<r_code::Code> structure_;
+  StructureValue(BindingMap *map, const r_code::Code *structure);
 public:
-  StructureValue(BindingMap *map, const Code *source, uint16 structure_index);
+  StructureValue(BindingMap *map, const r_code::Code *source, uint16 structure_index);
   StructureValue(BindingMap *map, Atom *source, uint16 structure_index);
   StructureValue(BindingMap *map, Timestamp time);
 
   Value *copy(BindingMap *map) const;
-  void valuate(Code *destination, uint16 write_index, uint16 &extent_index) const;
-  bool match(const Code *object, uint16 index);
+  void valuate(r_code::Code *destination, uint16 write_index, uint16 &extent_index) const;
+  bool match(const r_code::Code *object, uint16 index);
   Atom *get_code();
-  Code *get_object();
+  r_code::Code *get_object();
   uint16 get_code_size();
 
   bool intersect(const Value *v) const;
@@ -193,21 +193,21 @@ public:
 class r_exec_dll ObjectValue :
   public BoundValue {
 private:
-  const P<Code> object_;
+  const P<r_code::Code> object_;
 public:
-  ObjectValue(BindingMap *map, Code *object);
+  ObjectValue(BindingMap *map, r_code::Code *object);
 
   Value *copy(BindingMap *map) const;
-  void valuate(Code *destination, uint16 write_index, uint16 &extent_index) const;
-  bool match(const Code *object, uint16 index);
+  void valuate(r_code::Code *destination, uint16 write_index, uint16 &extent_index) const;
+  bool match(const r_code::Code *object, uint16 index);
   Atom *get_code();
-  Code *get_object();
+  r_code::Code *get_object();
   uint16 get_code_size();
 
   bool intersect(const Value *v) const;
   bool _intersect(const ObjectValue *v) const;
 
-  bool contains(const Code *o) const;
+  bool contains(const r_code::Code *o) const;
 };
 
 typedef enum {
@@ -235,12 +235,12 @@ protected:
 
   bool match_timings(Timestamp stored_after, Timestamp stored_before, Timestamp after, Timestamp before, uint32 destination_after_index, uint32 destination_before_index);
   bool match_fwd_timings(const _Fact *f_object, const _Fact *f_pattern);
-  bool match(const Code *object, uint16 o_base_index, uint16 o_index, const Code *pattern, uint16 p_index, uint16 o_arity);
+  bool match(const r_code::Code *object, uint16 o_base_index, uint16 o_index, const r_code::Code *pattern, uint16 p_index, uint16 o_arity);
 
-  void abstract_member(Code *object, uint16 index, Code *abstracted_object, uint16 write_index, uint16 &extent_index);
+  void abstract_member(r_code::Code *object, uint16 index, r_code::Code *abstracted_object, uint16 write_index, uint16 &extent_index);
   Atom get_atom_variable(Atom a);
-  Atom get_structure_variable(Code *object, uint16 index);
-  Atom get_object_variable(Code *object);
+  Atom get_structure_variable(r_code::Code *object, uint16 index);
+  Atom get_object_variable(r_code::Code *object);
 public:
   BindingMap();
   BindingMap(const BindingMap *source);
@@ -252,11 +252,11 @@ public:
 
   virtual void clear();
 
-  void init(Code *object, uint16 index);
+  void init(r_code::Code *object, uint16 index);
 
   _Fact *abstract_f_ihlp(_Fact *fact) const; // for icst and imdl.
   _Fact *abstract_fact(_Fact *fact, _Fact *original, bool force_sync);
-  Code *abstract_object(Code *object, bool force_sync);
+  r_code::Code *abstract_object(r_code::Code *object, bool force_sync);
 
   void reset_fwd_timings(_Fact *reference_fact); // reset after and before from the timings of the reference object.
 
@@ -270,8 +270,8 @@ public:
   Timestamp get_fwd_after() const; // assumes the timings are valuated.
   Timestamp get_fwd_before() const; // idem.
 
-  bool match_object(const Code *object, const Code *pattern);
-  bool match_structure(const Code *object, uint16 o_base_index, uint16 o_index, const Code *pattern, uint16 p_index);
+  bool match_object(const r_code::Code *object, const r_code::Code *pattern);
+  bool match_structure(const r_code::Code *object, uint16 o_base_index, uint16 o_index, const r_code::Code *pattern, uint16 p_index);
   bool match_atom(Atom o_atom, Atom p_atom);
 
   void bind_variable(BoundValue *value, uint8 id);
@@ -284,7 +284,7 @@ public:
   bool is_fully_specified() const;
 
   Atom *get_code(uint16 i) const { return map_[i]->get_code(); }
-  Code *get_object(uint16 i) const { return map_[i]->get_object(); }
+  r_code::Code *get_object(uint16 i) const { return map_[i]->get_object(); }
   int16 get_fwd_after_index() const { return fwd_after_index_; }
   int16 get_fwd_before_index() const { return fwd_before_index_; }
   bool scan_variable(uint16 id) const; // return true if id<first_index or map[id] is not an UnboundValue.
@@ -298,8 +298,8 @@ private:
 
   bool match_bwd_timings(const _Fact *f_object, const _Fact *f_pattern, bool use_f_pattern_timings = false);
 
-  bool need_binding(Code *pattern) const;
-  void init_from_pattern(const Code *source, int16 position); // first source is f->obj.
+  bool need_binding(r_code::Code *pattern) const;
+  void init_from_pattern(const r_code::Code *source, int16 position); // first source is f->obj.
 public:
   HLPBindingMap();
   HLPBindingMap(const HLPBindingMap *source);
@@ -310,10 +310,10 @@ public:
   void load(const HLPBindingMap *source);
   void clear();
 
-  void init_from_hlp(const Code *hlp);
+  void init_from_hlp(const r_code::Code *hlp);
   void init_from_f_ihlp(const _Fact *f_ihlp);
-  Fact *build_f_ihlp(Code *hlp, uint16 opcode, bool wr_enabled) const; // return f->ihlp.
-  Code *bind_pattern(Code *pattern) const;
+  Fact *build_f_ihlp(r_code::Code *hlp, uint16 opcode, bool wr_enabled) const; // return f->ihlp.
+  r_code::Code *bind_pattern(r_code::Code *pattern) const;
 
   void reset_bwd_timings(_Fact *reference_fact); // idem for the last 2 unbound variables (i.e. timings of the second pattern in a mdl).
 

--- a/r_exec/callbacks.h
+++ b/r_exec/callbacks.h
@@ -85,7 +85,7 @@ namespace r_exec {
 
 class r_exec_dll Callbacks {
 public:
-  typedef bool (*Callback)(std::chrono::microseconds relative_time, bool suspended, const char *msg, uint8 object_count, Code **objects);
+  typedef bool (*Callback)(std::chrono::microseconds relative_time, bool suspended, const char *msg, uint8 object_count, r_code::Code **objects);
 private:
   static UNORDERED_MAP<std::string, Callback> Callbacks_;
 public:

--- a/r_exec/context.h
+++ b/r_exec/context.h
@@ -93,12 +93,12 @@ class InputLessPGMOverlay;
 class dll_export IPGMContext :
   public _Context {
 private:
-  Code *object_; // the object the code belongs to; unchanged when the context is dereferenced to the overlay's value array.
+  r_code::Code *object_; // the object the code belongs to; unchanged when the context is dereferenced to the overlay's value array.
   View *view_; // the object's view, can be NULL when the context is dereferenced to a reference_set or a marker_set.
 
   bool is_cmd_with_cptr() const;
 
-  void addReference(Code *destination, uint16 write_index, Code *referenced_object) const {
+  void addReference(r_code::Code *destination, uint16 write_index, r_code::Code *referenced_object) const {
 
     for (uint16 i = 0; i < destination->references_size(); ++i)
       if (referenced_object == destination->get_reference(i)) {
@@ -111,7 +111,7 @@ private:
     destination->code(write_index) = Atom::RPointer(destination->references_size() - 1);
   }
 
-  void addReference(View *destination, uint16 write_index, Code *referenced_object) const { // view references are set in order (index 0 then 1).
+  void addReference(View *destination, uint16 write_index, r_code::Code *referenced_object) const { // view references are set in order (index 0 then 1).
 
     uint16 r_ptr_index;
     if (destination->references_[0]) // first ref already in place.
@@ -315,9 +315,9 @@ public:
   static IPGMContext GetContextFromInput(View *input, InputLessPGMOverlay *overlay) { return IPGMContext(input->object_, input, &input->object_->code(0), 0, overlay, REFERENCE); }
 
   IPGMContext() : _Context(NULL, 0, NULL, UNDEFINED), object_(NULL), view_(NULL) {} // undefined context (happens when accessing the view of an object when it has not been provided).
-  IPGMContext(Code *object, View *view, Atom *code, uint16 index, InputLessPGMOverlay *const overlay, Data data = STEM) : _Context(code, index, overlay, data), object_(object), view_(view) {}
-  IPGMContext(Code *object, uint16 index) : _Context(&object->code(0), index, NULL, REFERENCE), object_(object), view_(NULL) {}
-  IPGMContext(Code *object, Data data) : _Context(&object->code(0), index_, NULL, data), object_(object), view_(NULL) {}
+  IPGMContext(r_code::Code *object, View *view, Atom *code, uint16 index, InputLessPGMOverlay *const overlay, Data data = STEM) : _Context(code, index, overlay, data), object_(object), view_(view) {}
+  IPGMContext(r_code::Code *object, uint16 index) : _Context(&object->code(0), index, NULL, REFERENCE), object_(object), view_(NULL) {}
+  IPGMContext(r_code::Code *object, Data data) : _Context(&object->code(0), index_, NULL, data), object_(object), view_(NULL) {}
 
   // _Context implementation.
   _Context *assign(const _Context *c) {
@@ -391,7 +391,7 @@ public:
     case MKS: {
 
       uint16 i = 0;
-      r_code::list<Code *>::const_iterator m;
+      r_code::list<r_code::Code *>::const_iterator m;
       object_->acq_markers();
       for (m = object_->markers_.begin(); i < index - 1; ++i, ++m) {
 
@@ -425,7 +425,7 @@ public:
     }
   }
   Atom &operator [](uint16 i) const { return code_[index_ + i]; }
-  Code *getObject() const { return object_; }
+  r_code::Code *getObject() const { return object_; }
   uint16 getIndex() const { return index_; }
 
   IPGMContext operator *() const;
@@ -436,7 +436,7 @@ public:
 
   void patch_input_code(uint16 pgm_code_index, uint16 input_index) const { ((InputLessPGMOverlay *)overlay_)->patch_input_code(pgm_code_index, input_index, 0); }
 
-  uint16 addProduction(Code *object, bool check_for_existence) const; // if check_for_existence==false, the object is assumed not to be new.
+  uint16 addProduction(r_code::Code *object, bool check_for_existence) const; // if check_for_existence==false, the object is assumed not to be new.
 
   template<class C> void copy(C *destination, uint16 write_index) const {
 

--- a/r_exec/cst_controller.cpp
+++ b/r_exec/cst_controller.cpp
@@ -80,6 +80,7 @@
 #include "hlp_context.h"
 
 using namespace std::chrono;
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/cst_controller.h
+++ b/r_exec/cst_controller.h
@@ -104,8 +104,8 @@ protected:
 
   std::vector<P<_Fact> > inputs_;
 
-  UNORDERED_SET<P<_Fact>, PHash<_Fact> > predictions_; // f0->pred->f1->obj.
-  UNORDERED_SET<P<Sim>, PHash<Sim> > simulations_;
+  UNORDERED_SET<P<_Fact>, r_code::PHash<_Fact> > predictions_; // f0->pred->f1->obj.
+  UNORDERED_SET<P<Sim>, r_code::PHash<Sim> > simulations_;
 
   void inject_production();
   void update(HLPBindingMap *map, _Fact *input, _Fact *bound_pattern);
@@ -139,7 +139,7 @@ private:
     Sim *sim,
     Timestamp now,
     float32 confidence,
-    Code *group) const;
+    r_code::Code *group) const;
 
   void kill_views();
   void check_last_match_time(bool match); // kill if no match after primary_thz;

--- a/r_exec/factory.cpp
+++ b/r_exec/factory.cpp
@@ -80,6 +80,7 @@
 #include "mem.h"
 
 using namespace std::chrono;
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/factory.h
+++ b/r_exec/factory.h
@@ -94,49 +94,49 @@ namespace r_exec {
 class r_exec_dll MkNew :
   public LObject {
 public:
-  MkNew(r_code::Mem *m, Code *object);
+  MkNew(r_code::Mem *m, r_code::Code *object);
 };
 
 class r_exec_dll MkLowRes :
   public LObject {
 public:
-  MkLowRes(r_code::Mem *m, Code *object);
+  MkLowRes(r_code::Mem *m, r_code::Code *object);
 };
 
 class r_exec_dll MkLowSln :
   public LObject {
 public:
-  MkLowSln(r_code::Mem *m, Code *object);
+  MkLowSln(r_code::Mem *m, r_code::Code *object);
 };
 
 class r_exec_dll MkHighSln :
   public LObject {
 public:
-  MkHighSln(r_code::Mem *m, Code *object);
+  MkHighSln(r_code::Mem *m, r_code::Code *object);
 };
 
 class r_exec_dll MkLowAct :
   public LObject {
 public:
-  MkLowAct(r_code::Mem *m, Code *object);
+  MkLowAct(r_code::Mem *m, r_code::Code *object);
 };
 
 class r_exec_dll MkHighAct :
   public LObject {
 public:
-  MkHighAct(r_code::Mem *m, Code *object);
+  MkHighAct(r_code::Mem *m, r_code::Code *object);
 };
 
 class r_exec_dll MkSlnChg :
   public LObject {
 public:
-  MkSlnChg(r_code::Mem *m, Code *object, float32 value);
+  MkSlnChg(r_code::Mem *m, r_code::Code *object, float32 value);
 };
 
 class r_exec_dll MkActChg :
   public LObject {
 public:
-  MkActChg(r_code::Mem *m, Code *object, float32 value);
+  MkActChg(r_code::Mem *m, r_code::Code *object, float32 value);
 };
 
 class Pred;
@@ -146,16 +146,16 @@ class r_exec_dll _Fact :
   public LObject {
 private:
   static bool MatchAtom(Atom lhs, Atom rhs);
-  static bool MatchStructure(const Code *lhs, uint16 lhs_base_index, uint16 lhs_index, const Code *rhs, uint16 rhs_index);
-  static bool Match(const Code *lhs, uint16 lhs_base_index, uint16 lhs_index, const Code *rhs, uint16 rhs_index, uint16 lhs_arity);
-  static bool CounterEvidence(const Code *lhs, const Code *rhs);
+  static bool MatchStructure(const r_code::Code *lhs, uint16 lhs_base_index, uint16 lhs_index, const r_code::Code *rhs, uint16 rhs_index);
+  static bool Match(const r_code::Code *lhs, uint16 lhs_base_index, uint16 lhs_index, const r_code::Code *rhs, uint16 rhs_index, uint16 lhs_arity);
+  static bool CounterEvidence(const r_code::Code *lhs, const r_code::Code *rhs);
 protected:
   _Fact();
-  _Fact(SysObject *source);
+  _Fact(r_code::SysObject *source);
   _Fact(_Fact *f);
-  _Fact(uint16 opcode, Code *object, Timestamp after, Timestamp before, float32 confidence, float32 psln_thr);
+  _Fact(uint16 opcode, r_code::Code *object, Timestamp after, Timestamp before, float32 confidence, float32 psln_thr);
 public:
-  static bool MatchObject(const Code *lhs, const Code *rhs);
+  static bool MatchObject(const r_code::Code *lhs, const r_code::Code *rhs);
 
   virtual bool is_invalidated();
 
@@ -171,8 +171,8 @@ public:
   MatchResult is_evidence(const _Fact *target) const;
   MatchResult is_timeless_evidence(const _Fact *target) const;
 
-  bool has_after() const { return Utils::HasTimestamp<Code>(this, FACT_AFTER); }
-  bool has_before() const { return Utils::HasTimestamp<Code>(this, FACT_BEFORE); }
+  bool has_after() const { return r_code::Utils::HasTimestamp<r_code::Code>(this, FACT_AFTER); }
+  bool has_before() const { return r_code::Utils::HasTimestamp<r_code::Code>(this, FACT_BEFORE); }
   Timestamp get_after() const;
   Timestamp get_before() const;
   float32 get_cfd() const;
@@ -224,9 +224,9 @@ class r_exec_dll Fact :
 public:
   void *operator new(size_t s);
   Fact();
-  Fact(SysObject *source);
+  Fact(r_code::SysObject *source);
   Fact(Fact *f);
-  Fact(Code *object, Timestamp after, Timestamp before, float32 confidence, float32 psln_thr);
+  Fact(r_code::Code *object, Timestamp after, Timestamp before, float32 confidence, float32 psln_thr);
 };
 
 // Caveat: as for Fact.
@@ -235,9 +235,9 @@ class r_exec_dll AntiFact :
 public:
   void *operator new(size_t s);
   AntiFact();
-  AntiFact(SysObject *source);
+  AntiFact(r_code::SysObject *source);
   AntiFact(AntiFact *f);
-  AntiFact(Code *object, Timestamp after, Timestamp before, float32 confidence, float32 psln_thr);
+  AntiFact(r_code::Code *object, Timestamp after, Timestamp before, float32 confidence, float32 psln_thr);
 };
 
 // Goals and predictions:
@@ -257,7 +257,7 @@ class r_exec_dll Pred :
   public LObject {
 public:
   Pred();
-  Pred(SysObject *source);
+  Pred(r_code::SysObject *source);
   Pred(_Fact *target, float32 psln_thr);
 
   bool is_invalidated();
@@ -276,8 +276,8 @@ class r_exec_dll Goal :
   public LObject {
 public:
   Goal();
-  Goal(SysObject *source);
-  Goal(_Fact *target, Code *actor, float32 psln_thr);
+  Goal(r_code::SysObject *source);
+  Goal(_Fact *target, r_code::Code *actor, float32 psln_thr);
 
   bool invalidate();
   bool is_invalidated();
@@ -290,7 +290,7 @@ public:
 
   _Fact *get_target() const;
   _Fact *get_super_goal() const;
-  Code *get_actor() const;
+  r_code::Code *get_actor() const;
 
   P<Sim> sim_;
   P<_Fact> ground_; // f->p->f->imdl (weak requirement) that allowed backward chaining, if any.
@@ -302,8 +302,8 @@ class r_exec_dll MkRdx :
   public LObject {
 public:
   MkRdx();
-  MkRdx(SysObject *source);
-  MkRdx(Code *imdl_fact, Code *input, Code *output, float32 psln_thr, BindingMap *binding_map); // for mdl.
+  MkRdx(r_code::SysObject *source);
+  MkRdx(r_code::Code *imdl_fact, r_code::Code *input, r_code::Code *output, float32 psln_thr, BindingMap *binding_map); // for mdl.
 
   P<BindingMap> bindings_; // NULL when produced by programs.
 };
@@ -326,7 +326,7 @@ class r_exec_dll ICST :
   public LObject {
 public:
   ICST();
-  ICST(SysObject *source);
+  ICST(r_code::SysObject *source);
 
   bool is_invalidated();
 

--- a/r_exec/g_monitor.cpp
+++ b/r_exec/g_monitor.cpp
@@ -81,6 +81,7 @@
 #include "factory.h"
 
 using namespace std::chrono;
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/group.cpp
+++ b/r_exec/group.cpp
@@ -84,6 +84,7 @@
 #include <math.h>
 
 using namespace std::chrono;
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/guard_builder.cpp
+++ b/r_exec/guard_builder.cpp
@@ -78,6 +78,7 @@
 #include "guard_builder.h"
 
 using namespace std::chrono;
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/guard_builder.h
+++ b/r_exec/guard_builder.h
@@ -89,7 +89,7 @@ public:
   GuardBuilder();
   virtual ~GuardBuilder();
 
-  virtual void build(Code *mdl, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
+  virtual void build(r_code::Code *mdl, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
 };
 
 // fwd: t2=t0+period, t3=t1+period.
@@ -99,13 +99,13 @@ class TimingGuardBuilder :
 protected:
   std::chrono::microseconds period_;
 
-  void write_guard(Code *mdl, uint16 l, uint16 r, uint16 opcode, std::chrono::microseconds offset, uint16 &write_index, uint16 &extent_index) const;
-  void _build(Code *mdl, uint16 t0, uint16 t1, uint16 &write_index) const;
+  void write_guard(r_code::Code *mdl, uint16 l, uint16 r, uint16 opcode, std::chrono::microseconds offset, uint16 &write_index, uint16 &extent_index) const;
+  void _build(r_code::Code *mdl, uint16 t0, uint16 t1, uint16 &write_index) const;
 public:
   TimingGuardBuilder(std::chrono::microseconds period);
   virtual ~TimingGuardBuilder();
 
-  virtual void build(Code *mdl, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
+  virtual void build(r_code::Code *mdl, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
 };
 
 // fwd: q1=q0+speed*period.
@@ -115,12 +115,12 @@ class SGuardBuilder :
 private:
   std::chrono::microseconds offset_; // period-(speed.after-t0).
 
-  void _build(Code *mdl, uint16 q0, uint16 t0, uint16 t1, uint16 &write_index) const;
+  void _build(r_code::Code *mdl, uint16 q0, uint16 t0, uint16 t1, uint16 &write_index) const;
 public:
   SGuardBuilder(std::chrono::microseconds period, std::chrono::microseconds offset);
   ~SGuardBuilder();
 
-  void build(Code *mdl, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
+  void build(r_code::Code *mdl, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
 };
 
 // bwd: cmd.after=q1.after-offset, cmd.before=cmd.after+cmd_duration.
@@ -130,12 +130,12 @@ protected:
   std::chrono::microseconds offset_;
   std::chrono::microseconds cmd_duration_;
 
-  void _build(Code *mdl, uint16 q0, uint16 t0, uint16 t1, uint16 &write_index) const;
+  void _build(r_code::Code *mdl, uint16 q0, uint16 t0, uint16 t1, uint16 &write_index) const;
 public:
   NoArgCmdGuardBuilder(std::chrono::microseconds period, std::chrono::microseconds offset, std::chrono::microseconds cmd_duration);
   ~NoArgCmdGuardBuilder();
 
-  void build(Code *mdl, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
+  void build(r_code::Code *mdl, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
 };
 
 // bwd: cmd.after=q1.after-period, cmd.before=q1.before-period.
@@ -144,8 +144,8 @@ class CmdGuardBuilder :
 protected:
   uint16 cmd_arg_index_;
 
-  void _build(Code *mdl, uint16 fwd_opcode, uint16 bwd_opcode, uint16 q0, uint16 t0, uint16 t1, uint16 &write_index) const;
-  void _build(Code *mdl, uint16 fwd_opcode, uint16 bwd_opcode, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
+  void _build(r_code::Code *mdl, uint16 fwd_opcode, uint16 bwd_opcode, uint16 q0, uint16 t0, uint16 t1, uint16 &write_index) const;
+  void _build(r_code::Code *mdl, uint16 fwd_opcode, uint16 bwd_opcode, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
 
   CmdGuardBuilder(std::chrono::microseconds period, uint16 cmd_arg_index);
 public:
@@ -160,7 +160,7 @@ public:
   MCGuardBuilder(std::chrono::microseconds period, float32 cmd_arg_index);
   ~MCGuardBuilder();
 
-  void build(Code *mdl, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
+  void build(r_code::Code *mdl, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
 };
 
 // fwd: q1=q0+cmd_arg.
@@ -173,7 +173,7 @@ public:
   ACGuardBuilder(std::chrono::microseconds period, uint16 cmd_arg_index);
   ~ACGuardBuilder();
 
-  void build(Code *mdl, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
+  void build(r_code::Code *mdl, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
 };
 
 // bwd: cause.after=t2-offset, cause.before=t3-offset.
@@ -183,8 +183,8 @@ protected:
   float32 constant_;
   std::chrono::microseconds offset_;
 
-  void _build(Code *mdl, uint16 fwd_opcode, uint16 bwd_opcode, uint16 q0, uint16 t0, uint16 t1, uint16 &write_index) const;
-  void _build(Code *mdl, uint16 fwd_opcode, uint16 bwd_opcode, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
+  void _build(r_code::Code *mdl, uint16 fwd_opcode, uint16 bwd_opcode, uint16 q0, uint16 t0, uint16 t1, uint16 &write_index) const;
+  void _build(r_code::Code *mdl, uint16 fwd_opcode, uint16 bwd_opcode, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
 
   ConstGuardBuilder(std::chrono::microseconds period, float32 constant, std::chrono::microseconds offset);
 public:
@@ -199,7 +199,7 @@ public:
   MGuardBuilder(std::chrono::microseconds period, float32 constant, std::chrono::microseconds offset);
   ~MGuardBuilder();
 
-  void build(Code *mdl, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
+  void build(r_code::Code *mdl, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
 };
 
 // fwd: q1=q0+constant.
@@ -210,7 +210,7 @@ public:
   AGuardBuilder(std::chrono::microseconds period, float32 constant, std::chrono::microseconds offset);
   ~AGuardBuilder();
 
-  void build(Code *mdl, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
+  void build(r_code::Code *mdl, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
 };
 }
 

--- a/r_exec/hlp_controller.cpp
+++ b/r_exec/hlp_controller.cpp
@@ -79,6 +79,7 @@
 #include "hlp_overlay.h"
 #include "mem.h"
 
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/hlp_controller.h
+++ b/r_exec/hlp_controller.h
@@ -173,10 +173,10 @@ public:
 
   void invalidate();
 
-  Code *get_core_object() const { return getObject(); } // cst or mdl.
-  Code *get_unpacked_object() const { // the unpacked version of the core object.
+  r_code::Code *get_core_object() const { return getObject(); } // cst or mdl.
+  r_code::Code *get_unpacked_object() const { // the unpacked version of the core object.
 
-    Code *core_object = get_core_object();
+    r_code::Code *core_object = get_core_object();
     return core_object->get_reference(core_object->references_size() - MDL_HIDDEN_REFS);
   }
 
@@ -192,7 +192,7 @@ public:
   virtual Fact *get_f_ihlp(HLPBindingMap *bindings, bool wr_enabled) const = 0;
 
   uint16 get_out_group_count() const;
-  Code *get_out_group(uint16 i) const; // i starts at 1.
+  r_code::Code *get_out_group(uint16 i) const; // i starts at 1.
   Group *get_host() const;
   bool has_tpl_args() const { return has_tpl_args_; }
 

--- a/r_exec/hlp_overlay.cpp
+++ b/r_exec/hlp_overlay.cpp
@@ -80,6 +80,7 @@
 #include "hlp_context.h"
 #include "mem.h"
 
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/hlp_overlay.h
+++ b/r_exec/hlp_overlay.h
@@ -121,7 +121,7 @@ public:
   Atom *get_value_code(uint16 id) const;
   uint16 get_value_code_size(uint16 id) const;
 
-  Code *get_unpacked_object() const;
+  r_code::Code *get_unpacked_object() const;
 
   bool evaluate_bwd_guards();
 };

--- a/r_exec/init.cpp
+++ b/r_exec/init.cpp
@@ -90,6 +90,7 @@
 #include <process.h>
 
 using namespace std::chrono;
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/init.h
+++ b/r_exec/init.h
@@ -121,7 +121,7 @@ private:
   _Thread *thread_;
   volatile uint32 spawned_;
 
-  r_code::list<P<Code> > objects_;
+  r_code::list<P<r_code::Code> > objects_;
 
   uint32 ostream_id_; // 0 is std::cout.
 
@@ -130,9 +130,9 @@ public:
   TDecompiler(uint32 ostream_id, std::string header);
   ~TDecompiler();
 
-  void add_object(Code *object);
-  void add_objects(const r_code::list<P<Code> > &objects);
-  void add_objects(const std::vector<P<Code> > &objects);
+  void add_object(r_code::Code *object);
+  void add_objects(const r_code::list<P<r_code::Code> > &objects);
+  void add_objects(const std::vector<P<r_code::Code> > &objects);
   void decompile();
 };
 

--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -80,6 +80,7 @@
 #include "model_base.h"
 
 using namespace std::chrono;
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/mdl_controller.h
+++ b/r_exec/mdl_controller.h
@@ -170,8 +170,8 @@ protected:
   CriticalSection p_monitorsCS_;
   r_code::list<P<PMonitor> > p_monitors_;
 
-  P<Code> lhs_;
-  P<Code> rhs_;
+  P<r_code::Code> lhs_;
+  P<r_code::Code> rhs_;
 
   static const uint32 LHSController = 0;
   static const uint32 RHSController = 1;
@@ -189,7 +189,7 @@ protected:
   float32 get_cfd() const;
 
   CriticalSection active_requirementsCS_;
-  UNORDERED_MAP<P<_Fact>, RequirementsPair, PHash<_Fact> > active_requirements_; // P<_Fact>: f1 as in f0->pred->f1->imdl; requirements having allowed the production of prediction; first: wr, second: sr.
+  UNORDERED_MAP<P<_Fact>, RequirementsPair, r_code::PHash<_Fact> > active_requirements_; // P<_Fact>: f1 as in f0->pred->f1->imdl; requirements having allowed the production of prediction; first: wr, second: sr.
 
   template<class C> void reduce_cache(Fact *f_p_f_imdl, MDLController *controller) { // fwd; controller is the controller of the requirement which produced f_p_f_imdl.
 
@@ -346,7 +346,7 @@ private:
   CriticalSection last_match_timeCS_;
 
   CriticalSection assumptionsCS_;
-  r_code::list<P<Code> > assumptions_; // produced by the model; garbage collection at reduce() time..
+  r_code::list<P<r_code::Code> > assumptions_; // produced by the model; garbage collection at reduce() time..
 
   void rate_model(bool success);
   void kill_views(); // force res in both primary/secondary to 0.
@@ -374,7 +374,7 @@ public:
   void store_requirement(_Fact *f_imdl, MDLController *controller, bool chaining_was_allowed, bool simulation);
 
   void predict(HLPBindingMap *bm, _Fact *input, Fact *f_imdl, bool chaining_was_allowed, RequirementsPair &r_p, Fact *ground);
-  bool inject_prediction(Fact *prediction, Fact *f_imdl, float32 confidence, Timestamp::duration time_to_live, Code *mk_rdx) const; // here, resilience=time to live, in us; returns true if the prediction has actually been injected.
+  bool inject_prediction(Fact *prediction, Fact *f_imdl, float32 confidence, Timestamp::duration time_to_live, r_code::Code *mk_rdx) const; // here, resilience=time to live, in us; returns true if the prediction has actually been injected.
 
   void register_pred_outcome(Fact *f_pred, bool success, _Fact *evidence, float32 confidence, bool rate_failures);
   void register_req_outcome(Fact *f_pred, bool success, bool rate_failures);

--- a/r_exec/mem.cpp
+++ b/r_exec/mem.cpp
@@ -82,6 +82,7 @@
 #include "model_base.h"
 
 using namespace std::chrono;
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/mem.h
+++ b/r_exec/mem.h
@@ -166,18 +166,18 @@ protected:
   CriticalSection stateCS_;
   Semaphore *stop_sem_; // blocks the rMem until all cores terminate.
 
-  r_code::list<P<Code> > objects_; // store objects in order of injection: holds the initial objects (and dynamically created ones if MemStatic is used).
+  r_code::list<P<r_code::Code> > objects_; // store objects in order of injection: holds the initial objects (and dynamically created ones if MemStatic is used).
 
   P<Group> root_; // holds everything.
-  Code *stdin_;
-  Code *stdout_;
-  Code *self_;
+  r_code::Code *stdin_;
+  r_code::Code *stdout_;
+  r_code::Code *self_;
 
   void reset(); // clear the content of the mem.
 
   std::vector<Group *> initial_groups_; // convenience; cleared after start();
 
-  void store(Code *object);
+  void store(r_code::Code *object);
   virtual void set_last_oid(int32 oid) = 0;
   virtual void bind(View *view) = 0;
 
@@ -188,7 +188,7 @@ protected:
 
   _Mem();
 
-  static void _unpack_code(Code *hlp, uint16 fact_object_index, Code *fact_object, uint16 read_index);
+  static void _unpack_code(r_code::Code *hlp, uint16 fact_object_index, r_code::Code *fact_object, uint16 read_index);
 public:
   static _Mem *Get() { return (_Mem *)Mem::Get(); }
 
@@ -246,13 +246,13 @@ public:
       return goal_pred_success_res_;
     if (time_to_live.count() == 0)
       return 1;
-    return Utils::GetResilience(now, time_to_live, host->get_upr());
+    return r_code::Utils::GetResilience(now, time_to_live, host->get_upr());
   }
 
-  Code *get_root() const;
-  Code *get_stdin() const;
-  Code *get_stdout() const;
-  Code *get_self() const;
+  r_code::Code *get_root() const;
+  r_code::Code *get_stdin() const;
+  r_code::Code *get_stdout() const;
+  r_code::Code *get_self() const;
 
   State check_state(); // called by delegates after waiting in case stop() is called in the meantime.
   void start_core(); // called upon creation of a delegate.
@@ -292,13 +292,13 @@ public:
   void inject(View *view);
   void inject_async(View *view);
   void inject_new_object(View *view);
-  void inject_existing_object(View *view, Code *object, Group *host);
+  void inject_existing_object(View *view, r_code::Code *object, Group *host);
   void inject_null_program(Controller *c, Group *group, std::chrono::microseconds time_to_live, bool take_past_inputs); // build a view v (ijt=now, act=1, sln=0, res according to time_to_live in the group), attach c to v, inject v in the group.
   void inject_hlps(std::vector<View *> views, Group *destination);
   void inject_notification(View *view, bool lock);
-  virtual Code *check_existence(Code *object) = 0; // returns the existing object if any, or object otherwise: in the latter case, packing may occur.
+  virtual r_code::Code *check_existence(r_code::Code *object) = 0; // returns the existing object if any, or object otherwise: in the latter case, packing may occur.
 
-  void propagate_sln(Code *object, float32 change, float32 source_sln_thr);
+  void propagate_sln(r_code::Code *object, float32 change, float32 source_sln_thr);
 
   // Called by groups.
   void inject_copy(View *view, Group *destination); // for cov; NB: no cov for groups, r-groups, models, pgm or notifications.
@@ -321,22 +321,22 @@ public:
 
   // From rMem to I/O device.
   // To be redefined by object transport aware subcalsses.
-  virtual void eject(Code *command);
+  virtual void eject(r_code::Code *command);
 
   virtual r_code::Code *_build_object(Atom head) const = 0;
   virtual r_code::Code *build_object(Atom head) const = 0;
 
   // unpacking of high-level patterns: upon loading or reception.
-  static void unpack_hlp(Code *hlp);
-  static Code *unpack_fact(Code *hlp, uint16 fact_index);
-  static Code *unpack_fact_object(Code *hlp, uint16 fact_object_index);
+  static void unpack_hlp(r_code::Code *hlp);
+  static r_code::Code *unpack_fact(r_code::Code *hlp, uint16 fact_index);
+  static r_code::Code *unpack_fact_object(r_code::Code *hlp, uint16 fact_object_index);
 
   // packing of high-level patterns: upon dynamic generation or transmission.
-  void pack_hlp(Code *hlp) const;
-  static void pack_fact(Code *fact, Code *hlp, uint16 &write_index, std::vector<P<Code> > *references);
-  static void pack_fact_object(Code *fact_object, Code *hlp, uint16 &write_index, std::vector<P<Code> > *references);
+  void pack_hlp(r_code::Code *hlp) const;
+  static void pack_fact(r_code::Code *fact, r_code::Code *hlp, uint16 &write_index, std::vector<P<r_code::Code> > *references);
+  static void pack_fact_object(r_code::Code *fact_object, r_code::Code *hlp, uint16 &write_index, std::vector<P<r_code::Code> > *references);
 
-  Code *clone(Code *original) const; // shallow copy.
+  r_code::Code *clone(r_code::Code *original) const; // shallow copy.
 
   // External device I/O ////////////////////////////////////////////////////////////////
   virtual r_comp::Image *get_objects() = 0; // create an image; fill with all objects; call only when stopped.
@@ -349,7 +349,7 @@ public:
   /// </summary>
   /// <param name="now">The value to add to the timestamps of all the initial facts.</param>
   /// <param name="objects">The list of objects to search for facts.</param>
-  static void init_timings(Timestamp now, const r_code::list<P<Code>>& objects);
+  static void init_timings(Timestamp now, const r_code::list<P<r_code::Code>>& objects);
 
   //std::vector<uint64> timings_report; // debug facility.
 
@@ -450,7 +450,7 @@ public:
 
   // Executive device functions ////////////////////////////////////////////////////////
 
-  Code *check_existence(Code *object);
+  r_code::Code *check_existence(r_code::Code *object);
 
   // Called by the communication device (I/O).
   void inject(O *object, View *view);

--- a/r_exec/mem.tpl.cpp
+++ b/r_exec/mem.tpl.cpp
@@ -190,7 +190,7 @@ template<class O, class S> r_code::Code *Mem<O, S>::build_object(Atom head) cons
 
 ////////////////////////////////////////////////////////////////
 
-template<class O, class S> Code *Mem<O, S>::check_existence(Code *object) {
+template<class O, class S> r_code::Code *Mem<O, S>::check_existence(r_code::Code *object) {
 
   if (object->code(0).getDescriptor() == Atom::GROUP) // groups are always new.
     return object;

--- a/r_exec/model_base.cpp
+++ b/r_exec/model_base.cpp
@@ -79,6 +79,7 @@
 #include "mem.h"
 
 using namespace std::chrono;
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/model_base.h
+++ b/r_exec/model_base.h
@@ -102,15 +102,15 @@ private:
 
   class MEntry {
   private:
-    static bool Match(Code *lhs, Code *rhs);
+    static bool Match(r_code::Code *lhs, r_code::Code *rhs);
     static uint32 _ComputeHashCode(_Fact *component); // use for lhs/rhs.
   public:
-    static uint32 ComputeHashCode(Code *mdl, bool packed);
+    static uint32 ComputeHashCode(r_code::Code *mdl, bool packed);
 
     MEntry();
-    MEntry(Code *mdl, bool packed);
+    MEntry(r_code::Code *mdl, bool packed);
 
-    P<Code> mdl_;
+    P<r_code::Code> mdl_;
     Timestamp touch_time_; // last time the mdl was successfully compared to.
     uint32 hash_code_;
 
@@ -139,13 +139,13 @@ private:
 public:
   static ModelBase *Get();
 
-  void load(Code *mdl); // called by _Mem::load(); models with no views go to the black_list_.
-  void get_models(r_code::list<P<Code> > &models); // white_list_ first, black_list_ next.
+  void load(r_code::Code *mdl); // called by _Mem::load(); models with no views go to the black_list_.
+  void get_models(r_code::list<P<r_code::Code> > &models); // white_list_ first, black_list_ next.
 
-  Code *check_existence(Code *mdl); // caveat: mdl is unpacked; return (a) NULL if the model is in the black list, (b) a model in the white list if the mdl has been registered there or (c) the mdl itself if not in the model base, in which case the mdl is added to the white list.
-  void check_existence(Code *m0, Code *m1, Code *&_m0, Code *&_m1); // m1 is a requirement on m0; _m0 and _m1 are the return values as defined above; m0 added only if m1 is not black listed.
-  void register_mdl_failure(Code *mdl); // moves the mdl from the white to the black list; happens to bad models.
-  void register_mdl_timeout(Code *mdl); // deletes the mdl from the white list; happen to models that have been unused for primary_thz.
+  r_code::Code *check_existence(r_code::Code *mdl); // caveat: mdl is unpacked; return (a) NULL if the model is in the black list, (b) a model in the white list if the mdl has been registered there or (c) the mdl itself if not in the model base, in which case the mdl is added to the white list.
+  void check_existence(r_code::Code *m0, r_code::Code *m1, r_code::Code *&_m0, r_code::Code *&_m1); // m1 is a requirement on m0; _m0 and _m1 are the return values as defined above; m0 added only if m1 is not black listed.
+  void register_mdl_failure(r_code::Code *mdl); // moves the mdl from the white to the black list; happens to bad models.
+  void register_mdl_timeout(r_code::Code *mdl); // deletes the mdl from the white list; happen to models that have been unused for primary_thz.
 };
 }
 

--- a/r_exec/object.h
+++ b/r_exec/object.h
@@ -88,7 +88,7 @@
 
 namespace r_exec {
 
-static inline bool IsNotification(Code *object) {
+static inline bool IsNotification(r_code::Code *object) {
 
   switch (object->code(0).getDescriptor()) {
   case Atom::MARKER:
@@ -126,7 +126,7 @@ protected:
 public:
   virtual ~Object(); // un-registers from the rMem's object_register.
 
-  r_code::View *build_view(SysView *source) {
+  r_code::View *build_view(r_code::SysView *source) {
 
     return Code::build_view<r_exec::View>(source);
   }
@@ -147,7 +147,7 @@ public:
   void set(uint16 member_index, float32 value);
   void mod(uint16 member_index, float32 value);
 
-  View *get_view(Code *group, bool lock); // returns the found view if any, NULL otherwise.
+  View *get_view(r_code::Code *group, bool lock); // returns the found view if any, NULL otherwise.
 
   void kill();
 
@@ -190,7 +190,7 @@ class r_exec_dll LObject :
   public Object<r_code::LObject, LObject> {
 public:
   static bool RequiresPacking() { return false; }
-  static LObject *Pack(Code *object, r_code::Mem *mem) { return (LObject *)object; } // object is always a LObject (local operation).
+  static LObject *Pack(r_code::Code *object, r_code::Mem *mem) { return (LObject *)object; } // object is always a LObject (local operation).
   LObject(r_code::Mem *mem = NULL) : Object<r_code::LObject, LObject>(mem) {}
   LObject(r_code::SysObject *source) : Object<r_code::LObject, LObject>() {
 

--- a/r_exec/object.tpl.cpp
+++ b/r_exec/object.tpl.cpp
@@ -159,7 +159,7 @@ template<class C, class U> void Object<C, U>::set(uint16 member_index, float32 v
   psln_thrCS_.leave();
 }
 
-template<class C, class U> View *Object<C, U>::get_view(Code *group, bool lock) {
+template<class C, class U> View *Object<C, U>::get_view(r_code::Code *group, bool lock) {
 
   if (lock)
     acq_views();

--- a/r_exec/operator.cpp
+++ b/r_exec/operator.cpp
@@ -86,6 +86,7 @@
 #include <math.h>
 
 using namespace std::chrono;
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/overlay.cpp
+++ b/r_exec/overlay.cpp
@@ -79,6 +79,7 @@
 #include "mem.h"
 
 using namespace std::chrono;
+using namespace r_code;
 
 #define MAX_VALUE_SIZE 128
 

--- a/r_exec/overlay.h
+++ b/r_exec/overlay.h
@@ -83,8 +83,7 @@
 #include "../r_code/object.h"
 #include "dll.h"
 
-
-using namespace r_code;
+using r_code::Atom;
 
 namespace r_exec {
 
@@ -125,7 +124,7 @@ public:
   bool is_activated() const { return activated_ == 1; }
   bool is_alive() const { return invalidated_ == 0 && activated_ == 1; }
 
-  virtual Code *get_core_object() const = 0;
+  virtual r_code::Code *get_core_object() const = 0;
 
   r_code::Code *getObject() const { return view_->object_; } // return the reduction object (e.g. ipgm, icpp_pgm, cst, mdl).
   r_exec::View *getView() const { return (r_exec::View *)view_; } // return the reduction object's view.
@@ -154,26 +153,26 @@ protected:
 
   Controller *controller_;
 
-  r_code::vector<Atom> values_; // value array: stores the results of computations.
+  r_code::vector<r_code::Atom> values_; // value array: stores the results of computations.
   // Copy of the pgm/hlp code. Will be patched during matching and evaluation:
   // any area indexed by a vl_ptr will be overwritten with:
   //   the evaluation result if it fits in a single atom,
   //   a ptr to the value array if the result is larger than a single atom,
   //   a ptr to an input if the result is a pattern input.
-  Atom *code_;
+  r_code::Atom *code_;
   uint16 code_size_;
   std::vector<uint16> patch_indices_; // indices where patches are applied; used for rollbacks.
   uint16 value_commit_index_; // index of the last computed value_+1; used for rollbacks.
 
   void load_code();
-  void patch_code(uint16 index, Atom value);
+  void patch_code(uint16 index, r_code::Atom value);
   uint16 get_last_patch_index();
   void unpatch_code(uint16 patch_index);
 
   void rollback(); // reset the overlay to the last commited state: unpatch code and values.
   void commit(); // empty the patch_indices_ and set value_commit_index_ to values.size().
 
-  Code *get_core_object() const; // pgm, mdl, cst.
+  r_code::Code *get_core_object() const; // pgm, mdl, cst.
 
   Overlay();
   Overlay(Controller *c, bool load_code = true);
@@ -189,7 +188,7 @@ public:
   r_code::Code *getObject() const { return ((Controller *)controller_)->getObject(); }
   r_exec::View *getView() const { return ((Controller *)controller_)->getView(); }
 
-  r_code::Code *build_object(Atom head) const;
+  r_code::Code *build_object(r_code::Atom head) const;
 };
 
 class r_exec_dll OController :

--- a/r_exec/p_monitor.cpp
+++ b/r_exec/p_monitor.cpp
@@ -80,6 +80,7 @@
 #include "mdl_controller.h"
 
 using namespace std::chrono;
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/pattern_extractor.cpp
+++ b/r_exec/pattern_extractor.cpp
@@ -81,6 +81,7 @@
 #include "model_base.h"
 
 using namespace std::chrono;
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/pattern_extractor.h
+++ b/r_exec/pattern_extractor.h
@@ -179,18 +179,18 @@ protected:
   };
 
   r_code::list<Input> inputs_; // time-controlled buffer (inputs older than tpx_time_horizon from now are discarded).
-  std::vector<P<Code> > mdls_; // new mdls.
-  std::vector<P<Code> > csts_; // new csts.
+  std::vector<P<r_code::Code> > mdls_; // new mdls.
+  std::vector<P<r_code::Code> > csts_; // new csts.
   std::vector<P<_Fact> > icsts_; // new icsts.
 
   void filter_icst_components(ICST *icst, uint32 icst_index, std::vector<Component> &components);
   _Fact *_find_f_icst(_Fact *component, uint16 &component_index);
   _Fact *find_f_icst(_Fact *component, uint16 &component_index);
-  _Fact *find_f_icst(_Fact *component, uint16 &component_index, Code *&cst);
-  Code *build_cst(const std::vector<Component> &components, BindingMap *bm, _Fact *main_component);
+  _Fact *find_f_icst(_Fact *component, uint16 &component_index, r_code::Code *&cst);
+  r_code::Code *build_cst(const std::vector<Component> &components, BindingMap *bm, _Fact *main_component);
 
-  Code *build_mdl_head(HLPBindingMap *bm, uint16 tpl_arg_count, _Fact *lhs, _Fact *rhs, uint16 &write_index);
-  void build_mdl_tail(Code *mdl, uint16 write_index);
+  r_code::Code *build_mdl_head(HLPBindingMap *bm, uint16 tpl_arg_count, _Fact *lhs, _Fact *rhs, uint16 &write_index);
+  void build_mdl_tail(r_code::Code *mdl, uint16 write_index);
 
   void inject_hlps() const;
   void inject_hlps(Timestamp analysis_starting_time);
@@ -218,7 +218,7 @@ private:
   std::vector<P<_Fact> > predictions_; // successful predictions that may invalidate the need for model building.
 
   bool build_mdl(_Fact *cause, _Fact *consequent, GuardBuilder *guard_builder, std::chrono::microseconds period);
-  bool build_mdl(_Fact *f_icst, _Fact *cause_pattern, _Fact *consequent, GuardBuilder *guard_builder, std::chrono::microseconds period, Code *new_cst);
+  bool build_mdl(_Fact *f_icst, _Fact *cause_pattern, _Fact *consequent, GuardBuilder *guard_builder, std::chrono::microseconds period, r_code::Code *new_cst);
 
   std::string get_header() const;
 public:
@@ -242,7 +242,7 @@ private:
   P<Fact> f_imdl_; // that produced the prediction (and for which the PTPX will find strong requirements).
 
   bool build_mdl(_Fact *cause, _Fact *consequent, GuardBuilder *guard_builder, std::chrono::microseconds period);
-  bool build_mdl(_Fact *f_icst, _Fact *cause_pattern, _Fact *consequent, GuardBuilder *guard_builder, std::chrono::microseconds period, Code *new_cst);
+  bool build_mdl(_Fact *f_icst, _Fact *cause_pattern, _Fact *consequent, GuardBuilder *guard_builder, std::chrono::microseconds period, r_code::Code *new_cst);
 
   std::string get_header() const;
 public:
@@ -273,7 +273,7 @@ private:
   bool build_mdl(_Fact *cause, _Fact *consequent, GuardBuilder *guard_builder, std::chrono::microseconds period);
   bool build_mdl(_Fact *f_icst, _Fact *cause_pattern, _Fact *consequent, GuardBuilder *guard_builder, std::chrono::microseconds period);
 
-  bool build_requirement(HLPBindingMap *bm, Code *m0, std::chrono::microseconds period);
+  bool build_requirement(HLPBindingMap *bm, r_code::Code *m0, std::chrono::microseconds period);
 
   std::string get_header() const;
 public:

--- a/r_exec/pgm_controller.cpp
+++ b/r_exec/pgm_controller.cpp
@@ -78,6 +78,7 @@
 #include "pgm_controller.h"
 #include "mem.h"
 
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/pgm_controller.h
+++ b/r_exec/pgm_controller.h
@@ -91,7 +91,7 @@ protected:
   _PGMController(r_code::View *ipgm_view);
   virtual ~_PGMController();
 public:
-  Code *get_core_object() const { return getObject()->get_reference(0); }
+  r_code::Code *get_core_object() const { return getObject()->get_reference(0); }
 };
 
 // TimeCores holding InputLessPGMSignalingJob trigger the injection of the productions.

--- a/r_exec/pgm_overlay.cpp
+++ b/r_exec/pgm_overlay.cpp
@@ -83,6 +83,7 @@
 #include "context.h"
 #include "callbacks.h"
 
+using namespace r_code;
 
 // pgm layout:
 //

--- a/r_exec/pgm_overlay.h
+++ b/r_exec/pgm_overlay.h
@@ -95,11 +95,11 @@ class r_exec_dll InputLessPGMOverlay :
   friend class InputLessPGMController;
   friend class IPGMContext;
 protected:
-  std::vector<P<Code> > productions_; // receives the results of ins, inj and eje; views are retrieved (fvw) or built (reduction) in the value array.
+  std::vector<P<r_code::Code> > productions_; // receives the results of ins, inj and eje; views are retrieved (fvw) or built (reduction) in the value array.
 
   bool evaluate(uint16 index); // evaluates the pgm_code at the specified index.
 
-  virtual Code *get_mk_rdx(uint16 &extent_index) const;
+  virtual r_code::Code *get_mk_rdx(uint16 &extent_index) const;
 
   void patch_tpl_args(); // no views in tpl args; patches the ptn skeleton's first atom with IPGM_PTR with an index in the ipgm arg set; patches wildcards with similar IPGM_PTRs.
   void patch_tpl_code(uint16 pgm_code_index, uint16 ipgm_code_index); // to recurse.
@@ -140,10 +140,10 @@ protected:
   MatchResult _match(r_exec::View *input, uint16 pattern_index); // delegates to __match.
   MatchResult __match(r_exec::View *input, uint16 pattern_index); // return SUCCESS upon a successful match, IMPOSSIBLE if the input is not of the right class, FAILURE otherwise.
 
-  Code *dereference_in_ptr(Atom a);
+  r_code::Code *dereference_in_ptr(Atom a);
   void patch_input_code(uint16 pgm_code_index, uint16 input_index, uint16 input_code_index, int16 parent_index = -1);
 
-  virtual Code *get_mk_rdx(uint16 &extent_index) const;
+  virtual r_code::Code *get_mk_rdx(uint16 &extent_index) const;
 
   void init();
 

--- a/r_exec/time_job.cpp
+++ b/r_exec/time_job.cpp
@@ -80,6 +80,7 @@
 #include "mem.h"
 
 using namespace std::chrono;
+using namespace r_code;
 
 namespace r_exec {
 

--- a/r_exec/time_job.h
+++ b/r_exec/time_job.h
@@ -168,10 +168,10 @@ public:
 class r_exec_dll SaliencyPropagationJob :
   public TimeJob {
 public:
-  P<Code> object_;
+  P<r_code::Code> object_;
   float32 sln_change_;
   float32 source_sln_thr_;
-  SaliencyPropagationJob(Code *o, float32 sln_change, float32 source_sln_thr, Timestamp ijt);
+  SaliencyPropagationJob(r_code::Code *o, float32 sln_change, float32 source_sln_thr, Timestamp ijt);
   bool update(Timestamp &next_target);
   void report(int64 lag) const;
 };

--- a/r_exec/view.cpp
+++ b/r_exec/view.cpp
@@ -82,6 +82,8 @@
 
 #include <limits>
 
+using namespace r_code;
+
 const float32 PLUS_INFINITY = std::numeric_limits<float>::infinity();
 
 

--- a/r_exec/view.h
+++ b/r_exec/view.h
@@ -112,13 +112,13 @@ private:
   float32 initial_sln_;
   float32 initial_act_;
 
-  void init(SyncMode sync,
+  void init(r_code::View::SyncMode sync,
     Timestamp ijt,
     float32 sln,
     int32 res,
-    Code *host,
-    Code *origin,
-    Code *object);
+    r_code::Code *host,
+    r_code::Code *origin,
+    r_code::Code *object);
 protected:
   void reset_init_sln();
   void reset_init_act();
@@ -139,20 +139,20 @@ public:
   View(r_code::SysView *source, r_code::Code *object);
   View(View *view, Group *group); // copy the view and assigns it to the group (used for cov); morph ctrl values.
   View(const View *view, bool new_OID = false); // simple copy.
-  View(SyncMode sync,
+  View(r_code::View::SyncMode sync,
     Timestamp ijt,
     float32 sln,
     int32 res,
-    Code *host,
-    Code *origin,
-    Code *object); // regular view; res set to -1 means forever.
-  View(SyncMode sync,
+    r_code::Code *host,
+    r_code::Code *origin,
+    r_code::Code *object); // regular view; res set to -1 means forever.
+  View(r_code::View::SyncMode sync,
     Timestamp ijt,
     float32 sln,
     int32 res,
-    Code *host,
-    Code *origin,
-    Code *object,
+    r_code::Code *host,
+    r_code::Code *origin,
+    r_code::Code *object,
     float32 act); // pgm/mdl view; res set to -1 means forever.
   ~View();
 
@@ -165,7 +165,7 @@ public:
 
   Group *get_host();
 
-  SyncMode get_sync();
+  r_code::View::SyncMode get_sync();
   float32 get_res();
   float32 get_sln();
   float32 get_act();
@@ -204,7 +204,7 @@ public:
 class r_exec_dll NotificationView :
   public View {
 public:
-  NotificationView(Code *origin, Code *destination, Code *marker); // res=1, sln=1.
+  NotificationView(r_code::Code *origin, r_code::Code *destination, r_code::Code *marker); // res=1, sln=1.
 
   bool isNotification() const;
 };

--- a/r_exec/view.inline.cpp
+++ b/r_exec/view.inline.cpp
@@ -96,7 +96,7 @@ inline View::View(r_code::SysView *source, r_code::Code *object) : r_code::View(
 inline View::View(const View *view, bool new_OID) : r_code::View(), controller_(NULL) {
 
   object_ = view->object_;
-  memcpy(code_, view->code_, VIEW_CODE_MAX_SIZE * sizeof(Atom) + 2 * sizeof(Code *)); // reference_set is contiguous to code; memcpy in one go.
+  memcpy(code_, view->code_, VIEW_CODE_MAX_SIZE * sizeof(Atom) + 2 * sizeof(r_code::Code *)); // reference_set is contiguous to code; memcpy in one go.
   if (new_OID)
     code_[VIEW_OID].atom_ = GetOID();
   controller_ = NULL; // deprecated: controller=view->controller;
@@ -107,9 +107,9 @@ inline View::View(SyncMode sync,
   Timestamp ijt,
   float32 sln,
   int32 res,
-  Code *destination,
-  Code *origin,
-  Code *object) : r_code::View(), controller_(NULL) {
+  r_code::Code *destination,
+  r_code::Code *origin,
+  r_code::Code *object) : r_code::View(), controller_(NULL) {
 
   code(VIEW_OPCODE) = Atom::SSet(Opcodes::View, VIEW_ARITY);
   init(sync, ijt, sln, res, destination, origin, object);
@@ -119,9 +119,9 @@ inline View::View(SyncMode sync,
   Timestamp ijt,
   float32 sln,
   int32 res,
-  Code *destination,
-  Code *origin,
-  Code *object,
+  r_code::Code *destination,
+  r_code::Code *origin,
+  r_code::Code *object,
   float32 act) : r_code::View(), controller_(NULL) {
 
   code(VIEW_OPCODE) = Atom::SSet(Opcodes::PgmView, PGM_VIEW_ARITY);
@@ -133,16 +133,16 @@ inline void View::init(SyncMode sync,
   Timestamp ijt,
   float32 sln,
   int32 res,
-  Code *destination,
-  Code *origin,
-  Code *object) {
+  r_code::Code *destination,
+  r_code::Code *origin,
+  r_code::Code *object) {
 
   code_[VIEW_OID].atom_ = GetOID();
   reset_ctrl_values();
 
   code(VIEW_SYNC) = Atom::Float(sync);
   code(VIEW_IJT) = Atom::IPointer(code(VIEW_OPCODE).getAtomCount() + 1);
-  Utils::SetTimestamp<View>(this, VIEW_IJT, ijt);
+  r_code::Utils::SetTimestamp<View>(this, VIEW_IJT, ijt);
   code(VIEW_SLN) = Atom::Float(sln);
   code(VIEW_RES) = res < 0 ? Atom::PlusInfinity() : Atom::Float(res);
   code(VIEW_HOST) = Atom::RPointer(0);

--- a/usr_operators/Callbacks/callbacks.cpp
+++ b/usr_operators/Callbacks/callbacks.cpp
@@ -81,6 +81,7 @@
 #include "../r_exec/mem.h"
 
 using namespace std::chrono;
+using namespace r_code;
 
 bool print(microseconds relative_time, bool suspended, const char *msg, uint8 object_count, Code **objects) { // return true to resume the executive (applies when called from a suspend call, i.e. suspended==true).
 

--- a/usr_operators/Callbacks/callbacks.h
+++ b/usr_operators/Callbacks/callbacks.h
@@ -82,7 +82,7 @@
 
 
 extern "C" {
-bool dll_export print(std::chrono::microseconds relative_time, bool suspended, const char *msg, uint8 object_count, Code **objects);
+bool dll_export print(std::chrono::microseconds relative_time, bool suspended, const char *msg, uint8 object_count, r_code::Code **objects);
 }
 
 

--- a/usr_operators/Correlator/correlator.cpp
+++ b/usr_operators/Correlator/correlator.cpp
@@ -80,6 +80,7 @@
 #include "../r_comp/decompiler.h"
 #include "../r_exec/mem.h"
 
+using namespace r_code;
 
 class CorrelatorController :
   public r_exec::Controller {

--- a/usr_operators/TestProgram/test_program.cpp
+++ b/usr_operators/TestProgram/test_program.cpp
@@ -79,6 +79,7 @@
 
 #include "../r_exec/mem.h"
 
+using namespace r_code;
 
 // Sample c++ user-defined program.
 class TestController :


### PR DESCRIPTION
Replicode uses C++ namespaces like `r_code` and `r_exec`. The `r_code` namespace defines classes like `SysObject`. If your method is in a different namespace, you can use this class with `r_code::SysObject`. Alternatively, in a cpp file, you can add a directive like `using namespace r_code`, so that all classes from that namespace are imported and you can just use `SysObject`. This is convenient, but importing all classes from other namespaces can cause ambiguity. For this reason, C++ standard practice is to not put a `using namespace` directive in a header file, because any other code which includes that header file will have all the classes imported, even if they don't want it. (This has caused problems in the Visualizer code. E.g., the `r_code` namespace redefines `vector` which conflicts with `std::vector`.)

This pull request removes `using namespace r_code` from header files and adds it to the cpp files as needed. Also, header files from from other namespaces that use `r_code` classes now need to be qualified, such as `r_code::SysObject`.