### PR TITLE
settings.xml: Add debug_stream_file_path

### DIFF
--- a/Test/Test.cpp
+++ b/Test/Test.cpp
@@ -284,6 +284,15 @@ int32 main(int argc, char **argv) {
   if (!settings.load(file_name))
     return 1;
 
+  ofstream debugStream;
+  if (settings.debug_stream_file_path_ != "") {
+    debugStream.open(settings.debug_stream_file_path_);
+    if (!debugStream.is_open()) {
+      std::cout << "Cannot open debug_stream_file_path \"" << settings.debug_stream_file_path_ << "\"" << std::endl;
+      return 2;
+    }
+  }
+
   std::cout << "> compiling ...\n";
   if (settings.reduction_core_count_ == 0 && settings.time_core_count_ == 0) {
     // Below, we will use runInDiagnosticTime.
@@ -323,6 +332,10 @@ int32 main(int argc, char **argv) {
       mem = new TestMem<r_exec::LObject, r_exec::MemStatic>();
     else
       mem = new TestMem<r_exec::LObject, r_exec::MemVolatile>();
+
+    if (debugStream.is_open())
+      // Use the debug stream from settings.xml.
+      mem->setDefaultDebugStream(&debugStream);
 
     r_code::vector<r_code::Code *> ram_objects;
     r_exec::Seed.get_objects(mem, ram_objects);

--- a/Test/settings.h
+++ b/Test/settings.h
@@ -112,6 +112,7 @@ public:
   core::uint32 ntf_mk_resilience_;
   core::uint32 goal_pred_success_resilience_;
   core::uint32 debug_windows_;
+  std::string debug_stream_file_path_;
   core::uint32 trace_levels_;
   bool get_objects_;
   bool keep_invalidated_objects_;
@@ -210,10 +211,12 @@ public:
 
       const char *debug_string = debug.getAttribute("debug");
       const char *debug_windows = debug.getAttribute("debug_windows");
+      const char *debug_stream_file_path = debug.getAttribute("debug_stream_file_path");
       const char *trace_levels = debug.getAttribute("trace_levels");
 
       debug_ = (strcmp(debug_string, "yes") == 0);
       debug_windows_ = atoi(debug_windows);
+      debug_stream_file_path_ = debug_stream_file_path;
       sscanf(trace_levels, "%x", &trace_levels_);
 
       core::XMLNode resilience = debug.getChildNode("Resilience");

--- a/Test/settings.xml
+++ b/Test/settings.xml
@@ -23,7 +23,7 @@
     primary_thz="3600000"
     secondary_thz="7200000"
   />
-  <Debug debug="yes" debug_windows="1" trace_levels="FFFF"> <!--FFFF sets all Debug Streams to the std::cout-->
+  <Debug debug="yes" debug_windows="1" debug_stream_file_path="" trace_levels="FFFF">
     <Resilience
       ntf_mk_resilience="1"
       goal_pred_success_resilience="1000"
@@ -73,7 +73,11 @@ System
   primary_thz: time after which states/models that did not match are pushed down to secondary group (models) or sent to oblivion (states); in seconds.
   secondary_thz: time after which states/models that did not match are sent to oblivion; in seconds.
 Debug
-  trace_levels: ORed values (numbers indicate the location from right to left): 0:cst inputs, 1: cst outputs, 2: mdl inputs, 3: mdl outputs, 4 prediction monitoring, 5: goal monitoring, 6: model revision, 7:mdl/cst injections, 8: environment injections/ejections. ex: 3 means cst inputs and cst outputs, ignore others.
+  debug_windows: The number of debug windows to show created models. (Not to be confused with the debug stream below.)
+  debug_stream_file_path: The file path for the debug stream of the trace_levels selected below. If "" then use std::cout.
+  trace_levels: Hexadecimal ORed values of traces for the debug stream (numbers indicate the location from right to left): 
+    0: cst inputs, 1: cst outputs, 2: mdl inputs, 3: mdl outputs, 4 prediction monitoring, 5: goal monitoring, 6: model revision, 7:mdl/cst injections, 8: environment injections/ejections.
+    e.g.: 3 means cst inputs and cst outputs, ignore others. FFFF enables all trace levels.
   Resilience
     ntf_mk_resilience: in upr (i.e. relative to the ntf group).
     goal_pred_success_resilience: in upr (i.e. relative to the ntf group).


### PR DESCRIPTION
settings.xml already defines `trace_levels` which selects the types of debug output such as updates to a model success rate. These currently go to the console output. If you want the output in a file, then it is necessary to change the Replicode command line to redirect it. This output is important, for example for the Visualizer, and there should be a more convenient way to specify a file.

This pull request adds optional parameter `debug_stream_file_path` to settings.xml so that the debug stream can be sent to a file, similar to specifying `decompilation_file_path`. With this change, it is possible to inspect settings.xml and know where all the needed output is.