### PR TITLE
For a program mk.rdx, in the list of productions, also include the ejection fact

### DIFF
--- a/r_exec/pgm_overlay.cpp
+++ b/r_exec/pgm_overlay.cpp
@@ -274,8 +274,12 @@ bool InputLessPGMOverlay::inject_productions() {
         function[0].asOpcode() != Opcodes::Set &&
         function[0].asOpcode() != Opcodes::Prb)
         ++cmd_count;
-    } else
+    } else {
       ++cmd_count;
+      if (cmd[0].asOpcode() == Opcodes::Cmd)
+        // We will also add the fact of the ejection to the set of productions.
+        ++cmd_count;
+    }
   }
 
   Code *mk_rdx = NULL;
@@ -471,8 +475,12 @@ bool InputLessPGMOverlay::inject_productions() {
 
       if (mk_rdx) {
 
+        // Add the original command.
         mk_rdx->code(write_index++) = Atom::IPointer(extent_index);
         (*prods.getChild(i)).copy(mk_rdx, extent_index, extent_index);
+        // Add the fact of the injected command that we just made.
+        mk_rdx->code(write_index++) = Atom::RPointer(mk_rdx->references_size());
+        mk_rdx->add_reference(fact);
       }
     }
   }


### PR DESCRIPTION
When a program executes a command like `(cmd ready ["ball" b] 1)`, the reduction marker looks like this:

    (mk.rdx istart |[] []
       (cmd ready ["ball" b] 1))

But the program reduction also injects a fact of the ejection like:

    fact_39:(fact (cmd ready ["ball" b] 1) 0s:120ms:0us 0s:150ms:0us)

This "ejection fact" is what other programs process in reflection, and what is shown in the Visualizer. We want to be able to trace this fact back to the program which made it. So, this pull request updates the creation of the reduction marker to include the "ejection fact" after the command, In this example, the ejection fact is fact_39:

    (mk.rdx istart |[] []
       (cmd ready ["ball" b] 1)
       fact_39)
