### PR TITLE
In GMonitor, etc. use code(SUCCESS_OBJ).asIndex()

### DIFF
--- a/r_exec/g_monitor.cpp
+++ b/r_exec/g_monitor.cpp
@@ -251,7 +251,7 @@ bool GMonitor::reduce(_Fact *input) { // executed by a reduction core; invalidat
         Code *outcome = _input->get_reference(0);
         if (outcome->code(0).asOpcode() == Opcodes::Success) { // _input is f1->success or |f1->success.
 
-          _Fact *f_success = (_Fact *)outcome->get_reference(SUCCESS_OBJ);
+          _Fact *f_success = (_Fact *)outcome->get_reference(outcome->code(SUCCESS_OBJ).asIndex());
           Goal *affected_goal = f_success->get_goal();
           if (affected_goal) {
 
@@ -386,7 +386,7 @@ bool RMonitor::reduce(_Fact *input) { // catch simulated predictions only; requi
         Code *outcome = _input->get_reference(0);
         if (outcome->code(0).asOpcode() == Opcodes::Success) { // _input is f1->success or |f1->success.
 
-          _Fact *f_success = (_Fact *)outcome->get_reference(SUCCESS_OBJ);
+          _Fact *f_success = (_Fact *)outcome->get_reference(outcome->code(SUCCESS_OBJ).asIndex());
           Goal *affected_goal = f_success->get_goal();
           if (affected_goal) {
 
@@ -482,7 +482,7 @@ bool SGMonitor::reduce(_Fact *input) {
       Code *outcome = _input->get_reference(0);
       if (outcome->code(0).asOpcode() == Opcodes::Success) { // _input is f1->success or |f1->success.
 
-        _Fact *f_success = (_Fact *)outcome->get_reference(SUCCESS_OBJ);
+        _Fact *f_success = (_Fact *)outcome->get_reference(outcome->code(SUCCESS_OBJ).asIndex());
         Goal *affected_goal = f_success->get_goal();
         if (affected_goal) {
 
@@ -564,7 +564,7 @@ bool SRMonitor::reduce(_Fact *input) {
       Code *outcome = _input->get_reference(0);
       if (outcome->code(0).asOpcode() == Opcodes::Success) { // _input is f1->success or |f1->success.
 
-        _Fact *f_success = (_Fact *)outcome->get_reference(SUCCESS_OBJ);
+        _Fact *f_success = (_Fact *)outcome->get_reference(outcome->code(SUCCESS_OBJ).asIndex());
         Goal *affected_goal = f_success->get_goal();
         if (affected_goal) {
 


### PR DESCRIPTION
`GMonitor::reduce` needs to get the object from `(success object evidence)`. The [current code](https://github.com/IIIM-IS/replicode/blob/a0a8ce01b0d94acd60538ab0f95a8244ef474924/r_exec/g_monitor.cpp#L254) is:

    outcome->get_reference(SUCCESS_OBJ)

where `SUCCESS_OBJ` is the index in the code of the output object. But this is not necessarily the index in the references array. This is done correctly in other places such as [this code](https://github.com/IIIM-IS/replicode/blob/a0a8ce01b0d94acd60538ab0f95a8244ef474924/r_exec/group.cpp#L1263) which gets `GRP_PAIR_SECOND` from the marker `*m`:

    (*m)->get_reference((*m)->code(GRP_PAIR_SECOND).asIndex())

It is necessary to use the code as an index into the references array. Otherwise, it is a bug which selects the wrong reference. This pull request fixes the above code to:

    outcome->get_reference(outcome->code(SUCCESS_OBJ).asIndex())

This pull request also makes the same fix in the `reduce` method of `RMonitor`, `SGMonitor` and `SRMonitor`.