### PR TITLE
Don't take simulated goals and predictions as program input

### DIFF
--- a/r_exec/pgm_controller.cpp
+++ b/r_exec/pgm_controller.cpp
@@ -151,6 +151,20 @@ void PGMController::notify_reduction() {
 
 void PGMController::take_input(r_exec::View *input) {
 
+  if (input->object_->code(0).asOpcode() == Opcodes::Fact) {
+    Goal* goal = ((_Fact *)input->object_)->get_goal();
+    if (goal) {
+      if (!!goal->sim_ && goal->sim_->thz_.count() > 0)
+        // Don't take simulated goals as program input.
+        return;
+    }
+    else {
+      Pred* prediction = ((_Fact *)input->object_)->get_pred();
+      if (prediction && prediction->is_simulation())
+        // Don't take simulated predictions as program input.
+        return;
+    }
+  }
   Controller::__take_input<PGMController>(input);
 }
 


### PR DESCRIPTION
Both simulated and actual goals are injected into the primary group. Internally, they are distinguished by `sim_` in the C++ goal object, and similarly for simulated predictions. But a Replicode program can't examine `sim_`, and so may be triggered by a simulated goal such as to eject a command. In any case, the Replicode design document says that "the system has no knowledge about what is being simulated and about the results." Therefore a Replicode program does not need access to simulated goals and predictions.

This pull request updates `PGMController::take_input` to not take simulated goals and predictions as program input. Therefore, a Replicode program will only receive the actual committed goals and predictions from the simulation.