### PR TITLE
Fix bug in store_requirement for checking is_alive()

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1368,7 +1368,7 @@ void PrimaryMDLController::store_requirement(_Fact *f_p_f_imdl, MDLController *c
     g_monitorsCS_.enter();
     for (m = r_monitors_.begin(); m != r_monitors_.end();) { // signal r-monitors.
 
-      if ((*m)->is_alive())
+      if (!(*m)->is_alive())
         m = r_monitors_.erase(m);
       else {
 


### PR DESCRIPTION
While `PrimaryMDLController::store_requirement` is iterating through the `r_monitors_` list, it also does cleanup checks for each monitor. One check is:

    if ((*m)->is_alive())
      m = r_monitors_.erase(m);
 
This has to be a typo because the monitor is erased if it is alive. This pull request changes to erase the monitor if it is _not_ alive:

    if (!(*m)->is_alive())
      m = r_monitors_.erase(m);
 