### PR TITLE
In retrieve_imdl_bwd, change match_bwd to match_fwd

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -584,7 +584,8 @@ ChainingStatus MDLController::retrieve_simulated_imdl_bwd(HLPBindingMap *bm, Fac
           //_f_imdl->get_reference(0)->trace();
           //f_imdl->get_reference(0)->trace();
           HLPBindingMap _original = original; // matching updates the bm; always start afresh.
-          if (_original.match_bwd_strict(_f_imdl, f_imdl)) { // tpl args will be valuated in bm, but not in f_imdl yet.
+          // Use match_fwd because the f_imdl time interval matches the binding map's fwd_after and fwd_before from the model LHS.
+          if (_original.match_fwd_strict(_f_imdl, f_imdl)) { // tpl args will be valuated in bm, but not in f_imdl yet.
 
             bm->load(&_original);
             r = WEAK_REQUIREMENT_ENABLED;
@@ -614,7 +615,8 @@ ChainingStatus MDLController::retrieve_simulated_imdl_bwd(HLPBindingMap *bm, Fac
 
             _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
             HLPBindingMap _original = original; // matching updates the bm; always start afresh.
-            if (_original.match_bwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE) { // tpl args will be valuated in bm.
+            // Use match_fwd because the f_imdl time interval matches the binding map's fwd_after and fwd_before from the model LHS.
+            if (_original.match_fwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE) { // tpl args will be valuated in bm.
 
               bm->load(&_original);
               requirements_.CS.leave();
@@ -644,7 +646,8 @@ ChainingStatus MDLController::retrieve_simulated_imdl_bwd(HLPBindingMap *bm, Fac
 
             _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
             HLPBindingMap _original = original; // matching updates the bm; always start afresh.
-            if (_original.match_bwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE) {
+            // Use match_fwd because the f_imdl time interval matches the binding map's fwd_after and fwd_before from the model LHS.
+            if (_original.match_fwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE) {
 
               negative_cfd = (*e).confidence_;
               r = STRONG_REQUIREMENT_DISABLED_NO_WEAK_REQUIREMENT;
@@ -667,7 +670,8 @@ ChainingStatus MDLController::retrieve_simulated_imdl_bwd(HLPBindingMap *bm, Fac
 
             _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
             HLPBindingMap _original = original; // matching updates the bm; always start afresh.
-            if (_original.match_bwd_strict(_f_imdl, f_imdl)) {
+            // Use match_fwd because the f_imdl time interval matches the binding map's fwd_after and fwd_before from the model LHS.
+            if (_original.match_fwd_strict(_f_imdl, f_imdl)) {
 
               if ((*e).confidence_ >= negative_cfd) {
 
@@ -901,7 +905,8 @@ ChainingStatus MDLController::retrieve_imdl_bwd(HLPBindingMap *bm, Fact *f_imdl,
         //_f_imdl->get_reference(0)->trace();
         //f_imdl->get_reference(0)->trace();
         HLPBindingMap _original = original; // matching updates the bm; always start afresh.
-        if (_original.match_bwd_strict(_f_imdl, f_imdl, true)) { // tpl args will be valuated in bm, but not in f_imdl yet.
+        // Use match_fwd because the f_imdl time interval matches the binding map's fwd_after and fwd_before from the model LHS.
+        if (_original.match_fwd_strict(_f_imdl, f_imdl)) { // tpl args will be valuated in bm, but not in f_imdl yet.
 
           r = WEAK_REQUIREMENT_ENABLED;
           bm->load(&_original);
@@ -931,7 +936,8 @@ ChainingStatus MDLController::retrieve_imdl_bwd(HLPBindingMap *bm, Fact *f_imdl,
 
           _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
           HLPBindingMap _original = original; // matching updates the bm; always start afresh.
-          if (_original.match_bwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE) { // tpl args will be valuated in bm.
+          // Use match_fwd because the f_imdl time interval matches the binding map's fwd_after and fwd_before from the model LHS.
+          if (_original.match_fwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE) { // tpl args will be valuated in bm.
 
             requirements_.CS.leave();
             return STRONG_REQUIREMENT_DISABLED_NO_WEAK_REQUIREMENT;
@@ -957,7 +963,8 @@ ChainingStatus MDLController::retrieve_imdl_bwd(HLPBindingMap *bm, Fact *f_imdl,
 
           _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
           HLPBindingMap _original = original; // matching updates the bm; always start afresh.
-          if (_original.match_bwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE) {
+          // Use match_fwd because the f_imdl time interval matches the binding map's fwd_after and fwd_before from the model LHS.
+          if (_original.match_fwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE) {
 
             negative_cfd = (*e).confidence_;
             r = STRONG_REQUIREMENT_DISABLED_NO_WEAK_REQUIREMENT;
@@ -976,7 +983,8 @@ ChainingStatus MDLController::retrieve_imdl_bwd(HLPBindingMap *bm, Fact *f_imdl,
           //f->get_reference(0)->trace();
           _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
           HLPBindingMap _original = original; // matching updates the bm; always start afresh.
-          if (_original.match_bwd_strict(_f_imdl, f_imdl)) {
+          // Use match_fwd because the f_imdl time interval matches the binding map's fwd_after and fwd_before from the model LHS.
+          if (_original.match_fwd_strict(_f_imdl, f_imdl)) {
 
             if ((*e).confidence_ >= negative_cfd) {
 


### PR DESCRIPTION
When a fact matches an "input fact" to the LHS of a model (in forward chaining) or the RHS (in backward chaining), the model controller uses it to create a new candidate instantiated model. The "input fact" alone usually does not contain sufficient information to fully instantiate the model including its template arguments. Therefore the new candidate instantiated model must be matched to an existing instantiated model in the set of requirements. (A requirement carries the values from the composite state that represents the current context which is required for using the model.)
In `MDLController`, the methods `retrieve_imdl_fwd` and `retrieve_imdl_bwd` both try to match a new instantiated model to an instantiated model in the set of requirements (to confirm that values in the "input fact" are consistent with the values in the requirement, and to obtain extra needed values which are present in the requirement but not in the "input fact"). There are two methods (`retrieve_imdl_fwd` and `retrieve_imdl_bwd`) because there is different logic depending on forward or backward chaining. These methods call a match method to check for a match between the new instantiated model `f_imdl` and a requirement instantiated model `_f_imdl`. An example from `retrieve_imdl_bwd`:

    match_bwd_strict(_f_imdl, f_imdl)

Not to be confused with `retrieve_imdl_fwd` vs. `retrieve_imdl_bwd`, there are forward and backward versions of the match function such as `match_fwd_strict` and `match_bwd_strict`. If the timings between the two instantiated models match then the match function simply returns true. But if the timings don't match exactly, the match method may need to update the timings from the binding map for the model, for example to restrict to a more narrow time interval (for which it currently has algorithms). And the match function needs to know whether to use the timings from the model's LHS fact (`match_fwd_strict`) or RHS fact (`match_bwd_strict`). The problem is that, even though the match function is called from `retrieve_imdl_bwd`, it is matching the timings of an instantiated model that is instantiated "now" which corresponds to the timings of the model's LHS fact that is "now", not to the RHS fact whose timings are in the future. So, when `retrieve_imdl_bwd` calls `match_bwd_strict`, and if it needs to update the timings from the binding map, it wrongly uses the timings from the model's RHS fact. (In most cases so far, the match function didn't need to update the timings so this bug was not seen.)

This pull request changes `retrieve_imdl_bwd` to use `match_fwd_strict` and `match_fwd_lenient` instead of `match_bwd_strict` and `match_bwd_lenient`. And similarly for `retrieve_simulated_imdl_bwd`.