### PR TITLE
In check_simulated_imdl, add forwardSimulation for abduce_simulated_lhs

### DIFF
--- a/r_exec/g_monitor.cpp
+++ b/r_exec/g_monitor.cpp
@@ -356,14 +356,14 @@ RMonitor::RMonitor(PrimaryMDLController *controller,
   _Mem::Get()->pushTimeJob(j);
 }
 
-bool RMonitor::signal(bool is_simulation) {
+bool RMonitor::signal(bool is_simulation, Sim* forwardSimulation) {
 
   if (target_->is_invalidated())
     return true;
 
   if (simulating_ && is_simulation) { // report the simulated outcome: this will inject a simulated prediction of the outcome, to allow any g-monitor deciding on this ground.
 
-    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_, target_->get_goal()->get_sim()->root_))
+    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_, target_->get_goal()->get_sim()->root_, NULL))
       ((PMDLController *)controller_)->register_simulated_goal_outcome(target_, true, target_); // report a simulated success.
     else
       ((PMDLController *)controller_)->register_simulated_goal_outcome(target_, false, NULL); // report a simulated failure.
@@ -535,18 +535,18 @@ SRMonitor::SRMonitor(PrimaryMDLController *controller,
   _Mem::Get()->pushTimeJob(j);
 }
 
-bool SRMonitor::signal(bool is_simulation) {
+bool SRMonitor::signal(bool is_simulation, Sim* forwardSimulation) {
 
   if (target_->is_invalidated())
     return true;
 
   if (is_simulation) {
 
-    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_, target_->get_goal()->get_sim()->root_))
+    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_, target_->get_goal()->get_sim()->root_, forwardSimulation))
       ((PMDLController *)controller_)->register_simulated_goal_outcome(target_, true, target_); // report a simulated success.
   } else {
 
-    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_, NULL))
+    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_, NULL, NULL))
       ((PMDLController *)controller_)->register_simulated_goal_outcome(target_, false, NULL); // report a simulated failure.
   }
   return false;

--- a/r_exec/g_monitor.h
+++ b/r_exec/g_monitor.h
@@ -119,7 +119,7 @@ protected:
     Fact *goal,
     Fact *f_imdl); // goal is f0->g->f1->object.
 public:
-  virtual bool signal(bool is_simulation) { return false; }
+  virtual bool signal(bool is_simulation, Sim* forwardSimulation) { return false; }
 };
 
 // Monitors goals (other than requirements).
@@ -187,7 +187,7 @@ public:
 
   bool reduce(_Fact *input);
   void update(Timestamp &next_target);
-  bool signal(bool is_simulation);
+  bool signal(bool is_simulation, Sim* forwardSimulation);
 };
 
 // Monitors simulated goals.
@@ -220,7 +220,10 @@ public:
   bool reduce(_Fact *input);
   void update(Timestamp &next_target);
 
-  bool signal(bool is_simulation);
+  /**
+   * @param forwardSimulation Pass forwardSimulation to PrimaryMDLController::check_simulated_imdl.
+   */
+  bool signal(bool is_simulation, Sim* forwardSimulation);
 };
 
 // Case A: target==actual goal and target!=f_imdl: simulations have been produced for all sub-goals.

--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1381,7 +1381,10 @@ void PrimaryMDLController::store_requirement(_Fact *f_p_f_imdl, MDLController *c
         m = r_monitors_.erase(m);
       else {
 
-        if ((*m)->signal(is_simulation))
+        // If the requirement is simulated, then pass its Sim as the forwardSimulation for check_simulated_imdl.
+        if (f_p_f_imdl->get_pred()->get_simulations_size() > 1)
+          std::cerr << "WARNING: store_requirement: Prediction has multiple simulations. Passing NULL forwardSimulation to r-monitor" << std::endl;
+        if ((*m)->signal(is_simulation, f_p_f_imdl->get_pred()->get_simulations_size() == 1 ? f_p_f_imdl->get_pred()->get_simulation((uint16)0) : NULL))
           m = r_monitors_.erase(m);
         else
           ++m;
@@ -1681,7 +1684,7 @@ void PrimaryMDLController::abduce(HLPBindingMap *bm, Fact *super_goal, bool oppo
       if (sub_sim->get_mode() == SIM_ROOT)
         abduce_lhs(bm, super_goal, f_imdl, opposite, confidence, sub_sim, ground, true);
       else
-        abduce_simulated_lhs(bm, super_goal, f_imdl, opposite, confidence, sub_sim);
+        abduce_simulated_lhs(bm, super_goal, f_imdl, opposite, confidence, sub_sim, NULL);
       break;
     default: // WEAK_REQUIREMENT_DISABLED, STRONG_REQUIREMENT_DISABLED_NO_WEAK_REQUIREMENT or STRONG_REQUIREMENT_DISABLED_WEAK_REQUIREMENT.
       switch (retrieve_simulated_imdl_bwd(bm, f_imdl, sim->root_)) {
@@ -1691,7 +1694,7 @@ void PrimaryMDLController::abduce(HLPBindingMap *bm, Fact *super_goal, bool oppo
         if (sub_sim->get_mode() == SIM_ROOT)
           abduce_lhs(bm, super_goal, f_imdl, opposite, confidence, sub_sim, NULL, true);
         else
-          abduce_simulated_lhs(bm, super_goal, f_imdl, opposite, confidence, sub_sim);
+          abduce_simulated_lhs(bm, super_goal, f_imdl, opposite, confidence, sub_sim, NULL);
         break;
       default: // WEAK_REQUIREMENT_DISABLED, STRONG_REQUIREMENT_DISABLED_NO_WEAK_REQUIREMENT or STRONG_REQUIREMENT_DISABLED_WEAK_REQUIREMENT.
         sub_sim->is_requirement_ = true;
@@ -1799,7 +1802,7 @@ void PrimaryMDLController::abduce_imdl(HLPBindingMap *bm, Fact *super_goal, Fact
     Utils::RelativeTime(sub_goal->get_target()->get_after()) << "," << Utils::RelativeTime(sub_goal->get_target()->get_before()) << "]");
 }
 
-void PrimaryMDLController::abduce_simulated_lhs(HLPBindingMap *bm, Fact *super_goal, Fact *f_imdl, bool opposite, float32 confidence, Sim *sim) { // goal is f->g->f->object or f->g->|f->object; called concurrently by redcue() and _GMonitor::update().
+void PrimaryMDLController::abduce_simulated_lhs(HLPBindingMap *bm, Fact *super_goal, Fact *f_imdl, bool opposite, float32 confidence, Sim *sim, Sim* forwardSimulation) { // goal is f->g->f->object or f->g->|f->object; called concurrently by redcue() and _GMonitor::update().
 
   if (evaluate_bwd_guards(bm)) { // bm may be updated.
 
@@ -1878,7 +1881,7 @@ bool PrimaryMDLController::check_imdl(Fact *goal, HLPBindingMap *bm) { // goal i
   }
 }
 
-bool PrimaryMDLController::check_simulated_imdl(Fact *goal, HLPBindingMap *bm, Controller *root) { // goal is f->g->f->imdl; called by sr-monitors.
+bool PrimaryMDLController::check_simulated_imdl(Fact *goal, HLPBindingMap *bm, Controller *root, Sim* forwardSimulation) { // goal is f->g->f->imdl; called by sr-monitors.
 
   Goal *g = goal->get_goal();
   Fact *f_imdl = (Fact *)g->get_target();
@@ -1899,7 +1902,7 @@ bool PrimaryMDLController::check_simulated_imdl(Fact *goal, HLPBindingMap *bm, C
     if (evaluate_bwd_guards(bm)) { // bm may be updated.
 
       f_imdl->set_reference(0, bm->bind_pattern(f_imdl->get_reference(0))); // valuate f_imdl from updated bm.
-      abduce_simulated_lhs(bm, sim->get_f_super_goal(), f_imdl, sim->get_opposite(), f_imdl->get_cfd(), new Sim(sim));
+      abduce_simulated_lhs(bm, sim->get_f_super_goal(), f_imdl, sim->get_opposite(), f_imdl->get_cfd(), new Sim(sim), forwardSimulation);
       return true;
     }
     return false;

--- a/r_exec/mdl_controller.h
+++ b/r_exec/mdl_controller.h
@@ -356,7 +356,11 @@ private:
 
   void abduce_lhs(HLPBindingMap *bm, Fact *super_goal, Fact *f_imdl, bool opposite, float32 confidence, Sim *sim, Fact *ground, bool set_before);
   void abduce_imdl(HLPBindingMap *bm, Fact *super_goal, Fact *f_imdl, bool opposite, float32 confidence, Sim *sim);
-  void abduce_simulated_lhs(HLPBindingMap *bm, Fact *super_goal, Fact *f_imdl, bool opposite, float32 confidence, Sim *sim);
+
+  /**
+   * @param forwardSimulation If forwardSimulation is NULL, then pass sim to predict_simulated_evidence, otherwise pass forwardSimulation.
+   */
+  void abduce_simulated_lhs(HLPBindingMap *bm, Fact *super_goal, Fact *f_imdl, bool opposite, float32 confidence, Sim *sim, Sim* forwardSimulation);
   void abduce_simulated_imdl(HLPBindingMap *bm, Fact *super_goal, Fact *f_imdl, bool opposite, float32 confidence, Sim *sim);
   void predict_simulated_lhs(HLPBindingMap *bm, bool opposite, float32 confidence, Sim *sim);
   void predict_simulated_evidence(_Fact *evidence, Sim *sim);
@@ -385,7 +389,12 @@ public:
   void register_simulated_goal_outcome(Fact *goal, bool success, _Fact *evidence) const;
 
   bool check_imdl(Fact *goal, HLPBindingMap *bm);
-  bool check_simulated_imdl(Fact *goal, HLPBindingMap *bm, Controller *root);
+
+  /**
+   * @param forwardSimulation If forwardSimulation is NULL, then use the goal->get_goal()->get_sim() when calling abduce_simulated_lhs. 
+   * Otherwise, use the given forwardSimulation, which is carried throughout forward simulation.
+   */
+  bool check_simulated_imdl(Fact *goal, HLPBindingMap *bm, Controller *root, Sim* forwardSimulation);
   void abduce(HLPBindingMap *bm, Fact *super_goal, bool opposite, float32 confidence);
 
   void debug(View *input);


### PR DESCRIPTION
In `PrimaryMDLController::check_simulated_imdl`, if the simulated goal imdl matches a requirement, it calls `abduce_simulated_lhs`, which needs to be passed the simulation object. Currently, the code [passes a copy of the simulation object](https://github.com/IIIM-IS/replicode/blob/6938bee0558fcefcca98e523a51be7ebb9e3f240/r_exec/mdl_controller.cpp#L1863-L1872) of the simulated goal `g`:

    Sim *sim = g->get_sim();
    abduce_simulated_lhs(bm, sim->get_f_super_goal(), f_imdl, sim->get_opposite(), f_imdl->get_cfd(), new Sim(sim));

This makes sense for backward chaining. But `check_simulated_imdl` may be called during forward chaining, such as when `PrimaryMDLController::store_requirement` stores a simulated requirement and invokes the `signal` method of the simulated requirement monitor. In this case, `check_simulated_imdl` should call `abduce_simulated_lhs` with the simulation object of the forward prediction, not the simulated goal.

This pull request adds a parameter `forwardSimulation` to `check_simulated_imdl` and to the requirement monitor `signal` method which calls it. `forwardSimulation` is passed to `abduce_simulated_lhs` which will use it if it is not NULL.