### PR TITLE
Copy sims from the LHS prediction to the new requirement from the RHS

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1468,6 +1468,11 @@ void PrimaryMDLController::predict(HLPBindingMap *bm, _Fact *input, Fact *f_imdl
     if (is_invalidated())
       // Another thread has invalidated this controller which clears the controllers.
       return;
+    if (is_simulation) {
+      // Copy the simulation, the same as below for a non-requirement prediction.
+      for (uint16 i = 0; i < prediction->simulations_.size(); ++i)
+        pred->simulations_.push_back(prediction->simulations_[i]);
+    }
     PrimaryMDLController *c = (PrimaryMDLController *)controllers_[RHSController]; // rhs controller: in the same view.
     c->store_requirement(production, this, chaining_was_allowed, is_simulation); // if not simulation, stores also in the secondary controller.
 #ifdef WITH_DEBUG_OID


### PR DESCRIPTION
In forward chaining, `PrimaryMDLController::predict` takes an input which matches the model LHS and makes a new prediction from the model RHS. If the LHS is a simulated prediction, then [the prediction's simulation objects are copied](https://github.com/IIIM-IS/replicode/blob/ab59f50841bd4eda657904b686fd6acf42c717c0/r_exec/mdl_controller.cpp#L1533-L1534) to the prediction made from the RHS. In this way, the simulation objects are carried forward in each step of the forward simulation:

    for (uint16 i = 0; i < prediction->simulations_.size(); ++i)
      pred->simulations_.push_back(prediction->simulations_[i]);

(In this code, `prediction` is the prediction object from the LHS and `pred` is the new prediction object from the RHS.) This code is for the case where the model RHS is, for example, `(fact (mk.val ...))`. So the RHS is a "normal" prediction of a value. But if the model RHS is `(fact (imdl ...))`, then the `predict` method handles this [as a special case](https://github.com/IIIM-IS/replicode/blob/ab59f50841bd4eda657904b686fd6acf42c717c0/r_exec/mdl_controller.cpp#L1466-L1482) because a prediction of a  `(fact (imdl ...))` is a "requirement". We need to carry the simulation objects forward in this case too.

This pull request adds the same code [to the "requirement" case](https://github.com/IIIM-IS/replicode/blob/f0cdf48811618fcf96a074578bd34145e8ec4c3b/r_exec/mdl_controller.cpp#L1471-L1475) to copy the simulation objects from the LHS prediction to the requirement made from the RHS.