### PR TITLE
Add is_sim operator

### DIFF
--- a/AERA/Demo1/std.replicode
+++ b/AERA/Demo1/std.replicode
@@ -78,6 +78,8 @@
 !op (ins : :[] :bl :us :bl):
 !op (red :[] :[] :[]):[]
 !op (fvw : :):
+; true if pred or goal is a simulation.
+!op (is_sim :):bl
 
 ; operator aliases.
 !def now (_now)

--- a/AERA/replicode_v1.2/pong.2.goal.replicode
+++ b/AERA/replicode_v1.2/pong.2.goal.replicode
@@ -89,22 +89,12 @@ i_pgm_set_speed:(ipgm pgm_set_speed |[] RUN_ONCE 20000us VOLATILE NOTIFY 1) []
 ; calls the command, which will call the override of _Mem::eject().
 pgm_cmd_set_speed_y:(pgm |[]
 []
-   (ptn (fact (goal (fact c:(cmd set_speed_y [obj: sy:] ::) ::) : nil ::) ::) |[])
+   (ptn (fact g:(goal (fact c:(cmd set_speed_y [obj: sy:] ::) ::) ::) ::) |[])
 |[]
 []
+   (= (is_sim g) false)
    (cmd set_speed_y [obj sy] 1)
    (prb [1 "print" "cmd set_speed_y" [c]])
 1) |[]
 i_pgm_cmd_set_speed_y:(ipgm pgm_cmd_set_speed_y |[] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
-   [SYNC_ONCE now 0 forever primary nil 1]; Use primary since abduced goals go in there.
-
-pgm_cmd_set_speed_y_not_sim:(pgm |[]
-[]
-   (ptn (fact (goal (fact c:(cmd set_speed_y [obj: sy:] ::) ::) : (sim : 0us ::) ::) ::) |[])
-|[]
-[]
-   (cmd set_speed_y [obj sy] 1)
-   (prb [1 "print" "cmd set_speed_y" [c]])
-1) |[]
-i_pgm_cmd_set_speed_y_not_sim:(ipgm pgm_cmd_set_speed_y_not_sim |[] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever primary nil 1]; Use primary since abduced goals go in there.

--- a/AERA/replicode_v1.2/pong.discrete.cmd.external.replicode
+++ b/AERA/replicode_v1.2/pong.discrete.cmd.external.replicode
@@ -63,8 +63,9 @@ pgm_cmd_move_y_plus:(pgm |[]
 []
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val p1 essence paddle :) after: before: ::) |[])
-   (ptn (fact (goal (fact (cmd move_y_plus [obj:] ::) c_after: c_before: ::) : nil ::) ::) |[])
+   (ptn (fact g:(goal (fact (cmd move_y_plus [obj:] ::) c_after: c_before: ::) ::) ::) |[])
 []
+   (= (is_sim g) false)
    (< c_after before)
    (> c_before after)
 []
@@ -74,30 +75,15 @@ pgm_cmd_move_y_plus:(pgm |[]
 i_pgm_cmd_move_y_plus:(ipgm pgm_cmd_move_y_plus |[] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever primary nil 1]
 
-pgm_cmd_move_y_plus_not_sim:(pgm |[]
-[]
-   ; This fact repeats periodically. We use it as a "heartbeat".
-   (ptn (fact (mk.val p1 essence paddle :) after: before: ::) |[])
-   ; A sim with 0us time horizon means not simulating.
-   (ptn (fact (goal (fact (cmd move_y_plus [obj:] ::) c_after: c_before: ::) : (sim : 0us ::) ::) ::) |[])
-[]
-   (< c_after before)
-   (> c_before after)
-[]
-   (prb [1 "print" "cmd move_y_plus..." |[]])
-   (cmd move_y_plus [obj] 1)
-1) |[]
-i_pgm_cmd_move_y_plus_not_sim:(ipgm pgm_cmd_move_y_plus_not_sim |[] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
-   [SYNC_ONCE now 0 forever primary nil 1]
-
 ; This program intercepts an abduced goal to run a command and directly
 ; calls the command, which will call the override of _Mem::eject().
 pgm_cmd_move_y_minus:(pgm |[]
 []
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val p1 essence paddle :) after: before: ::) |[])
-   (ptn (fact (goal (fact (cmd move_y_minus [obj:] ::) c_after: c_before: ::) : nil ::) ::) |[])
+   (ptn (fact g:(goal (fact (cmd move_y_minus [obj:] ::) c_after: c_before: ::) ::) ::) |[])
 []
+   (= (is_sim g) false)
    (< c_after before)
    (> c_before after)
 []
@@ -105,22 +91,6 @@ pgm_cmd_move_y_minus:(pgm |[]
    (cmd move_y_minus [obj] 1)
 1) |[]
 i_pgm_cmd_move_y_minus:(ipgm pgm_cmd_move_y_minus |[] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
-   [SYNC_ONCE now 0 forever primary nil 1]
-
-pgm_cmd_move_y_minus_not_sim:(pgm |[]
-[]
-   ; This fact repeats periodically. We use it as a "heartbeat".
-   (ptn (fact (mk.val p1 essence paddle :) after: before: ::) |[])
-   ; A sim with 0us time horizon means not simulating.
-   (ptn (fact (goal (fact (cmd move_y_minus [obj:] ::) c_after: c_before: ::) : (sim : 0us ::) ::) ::) |[])
-[]
-   (< c_after before)
-   (> c_before after)
-[]
-   (prb [1 "print" "cmd move_y_minus..." |[]])
-   (cmd move_y_minus [obj] 1)
-1) |[]
-i_pgm_cmd_move_y_minus_not_sim:(ipgm pgm_cmd_move_y_minus_not_sim |[] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever primary nil 1]
 
 ; Run repeatedly (when babbling is finished) to inject the drive that will abduce a goal in m_run_position.

--- a/AERA/replicode_v1.2/std.replicode
+++ b/AERA/replicode_v1.2/std.replicode
@@ -83,6 +83,8 @@
 !op (ins : :[] :bl :us :bl :bl):
 !op (red :[] :[] :[]):[]
 !op (fvw : :):
+; true if pred or goal is a simulation.
+!op (is_sim :):bl
 
 ; operator aliases.
 !def now (_now)

--- a/r_exec/init.cpp
+++ b/r_exec/init.cpp
@@ -442,6 +442,7 @@ void InitOpcodes(const r_comp::Metadata& metadata) {
   Operator::Register(operator_opcode++, ins);
   Operator::Register(operator_opcode++, red);
   Operator::Register(operator_opcode++, fvw);
+  Operator::Register(operator_opcode++, is_sim);
 }
 
 bool Init(const char *user_operator_library_path,

--- a/r_exec/operator.cpp
+++ b/r_exec/operator.cpp
@@ -648,4 +648,23 @@ bool fvw(const Context &context, uint16 &index) {
 
   return IPGMContext::Fvw(*(IPGMContext *)context.get_implementation(), index);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool is_sim(const Context &context, uint16 &index) {
+
+  const IPGMContext &ipgm_context = *(IPGMContext *)context.get_implementation();
+  IPGMContext arg = *ipgm_context.getChild(1);
+  Code* obj = arg.getObject();
+
+  bool result = false;
+  if (obj->code(0).asOpcode() == Opcodes::Goal)
+    result = ((Goal*)obj)->is_simulation();
+  else if (obj->code(0).asOpcode() == Opcodes::Pred)
+    result = ((Pred*)obj)->is_simulation();
+
+  index = context.setAtomicResult(Atom::Boolean(result));
+  return true;
+}
+
 }

--- a/r_exec/operator.h
+++ b/r_exec/operator.h
@@ -179,6 +179,8 @@ bool e10(const Context &context, uint16 &index);
 bool ins(const Context &context, uint16 &index); // executive-dependent.
 
 bool fvw(const Context &context, uint16 &index); // executive-dependent.
+
+bool is_sim(const Context &context, uint16 &index);
 }
 
 


### PR DESCRIPTION
In pull request #94, we added the `sim` object to the Replicode language and updated the `goal` object to use it. Then we updated the Replicode program which handles commands to make sure a command goal is not simulated before ejecting it to the external environment. This required two version of the program: One for the case where the goal has a nil `sim` object, and another for the case where the `sim` object in the goal has a time horizon of zero (which also means "not simulated").

Even though adding the `sim` object to the Replicode language is sill a useful addition, there is an easier way to check if a goal is simulated. This pull request adds the `is_sim` operator to the Replicode language. `(is_sim obj)` returns true if `obj` is a simulated goal or prediction. Otherwise it returns false. (Therefore, we are also ready if a program needs to check if a prediction is simulated.) This pull request also updates the Replicode code to use `is_sim`. For example, in `pong.2.goal.replicode`, the [previous two programs](https://github.com/IIIM-IS/replicode/blob/c346c4eeb93219e9e816aa93e1ec471f99b5f685/AERA/replicode_v1.2/pong.2.goal.replicode#L88-L110) to handle the ejection of a command are now simplified to the following one program which adds `(= (is_sim g) false)` to the program guards:

    pgm_cmd_set_speed_y:(pgm |[]
    []
       (ptn (fact g:(goal (fact c:(cmd set_speed_y [obj: sy:] ::) ::) ::) ::) |[])
    |[]
    []
       (= (is_sim g) false)
       (cmd set_speed_y [obj sy] 1)
       (prb [1 "print" "cmd set_speed_y" [c]])
    1) |[]
