### PR TITLE
PrimaryMDLOverlay: In reduce, don't abort if chaining is allowed

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -153,7 +153,7 @@ Overlay *PrimaryMDLOverlay::reduce(_Fact *input, Fact *f_p_f_imdl, MDLController
         }
       }
     case NO_REQUIREMENT:
-      if (((MDLController *)controller_)->has_tpl_args()) { // there are tpl args, abort.
+      if (!chaining_allowed && ((MDLController *)controller_)->has_tpl_args()) { // there are tpl args, abort.
 
         o = NULL;
         break;


### PR DESCRIPTION
In forward chaining `PrimaryMDLOverlay::reduce` calls `retrieve_imdl_fwd` to get the chaining status, which is checked in a case statement. If the chaining status is WEAK_REQUIREMENT_DISABLED and the LHS is a simulated prediction, [then it calls](check_simulated_chaining) `check_simulated_chaining`:

    case WEAK_REQUIREMENT_DISABLED :
      if (simulation) { // if there is simulated imdl for the root of one sim in prediction, allow forward chaining.
        if (check_simulated_chaining(bm, f_imdl, prediction))
          chaining_allowed = true;
        else {
          o = NULL;
          break;
        }
      }

As the code comment says, "If there is simulated imdl for the root of one sim in prediction, allow forward chaining." So, if `check_simulated_chaining` succeeds then it sets the `chaining_allowed` flag true. The case statement for the chaining status does a "fall through" [to the next case](to the next case) which is NO_REQUIREMENT:

    case NO_REQUIREMENT:
      if (((MDLController *)controller_)->has_tpl_args()) { // there are tpl args, abort.
        o = NULL;
        break;
      }

As the code comment says, "If there are template arguments, then abort." Note that this case does not check for simulation as in the previous case. And indeed, the model in a forward simulation will have template arguments. The previous case just set the chaining allowed flag true, but if we abort due to template arguments then we can't do chaining. This seems to be an oversight (since the simulation code was added later and not all cases were tested).

This pull request updates the NO_REQUIREMENT case to only allow an abort if the `chaining_allowed` flag was not set to true:

      if (!chaining_allowed && ((MDLController *)controller_)->has_tpl_args()) {
        o = NULL;
        break;
      }
