### PR TITLE
In abduce_simulated_lhs, also call predict_simulated_evidence for forward chaining in the simulator

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1825,6 +1825,7 @@ void PrimaryMDLController::abduce_simulated_lhs(HLPBindingMap *bm, Fact *super_g
         break;
       case MATCH_FAILURE: {
 
+        predict_simulated_evidence(bound_lhs, sim);
         f_imdl->set_reference(0, bm->bind_pattern(f_imdl->get_reference(0))); // valuate f_imdl from updated bm.
 
         Goal *sub_goal = new Goal(bound_lhs, super_goal->get_goal()->get_actor(), sim, 1);


### PR DESCRIPTION
`PrimaryMDLController::abduce_simulated_lhs` matches a simulated model RHS and [injects a simulated sub-goal](https://github.com/IIIM-IS/replicode/blob/f8fb0437bd50cd9e8633a3be0c45347de005b965/r_exec/mdl_controller.cpp#L1830-L1836) for the LHS. This performs the simulation backward chaining as described in section 6.5 "Simulation" of the [Replicode language specification](https://github.com/IIIM-IS/replicode/blob/master/Replicode_A_constructivist_programming_paradigm_and_language_2013.pdf).
This section also describes how the simulator does forward chaining from a sub-goal to predict the consequences (both to predict if the sub-goal will achieve the primary goal, and to predict if the sub-goal will cause other consequences that conflict with the primary goal). However, this step to do forward chaining seems to be missing from the simulation code.

This pull request updates `PrimaryMDLController::abduce_simulated_lhs` to also call `predict_simulated_evidence(bound_lhs, sim)` which begins forward chaining for the simulation `sim` starting from the LHS `bound_lhs`.