### PR TITLE
In abduce, use this controller for the new Sim

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1668,7 +1668,7 @@ void PrimaryMDLController::abduce(HLPBindingMap *bm, Fact *super_goal, bool oppo
       break;
     case SIM_OPTIONAL:
     case SIM_MANDATORY:
-      sub_sim = new Sim(sim->get_mode(), sim_thz, sim->super_goal_, opposite, sim->root_, 1, sim->sol_controller_, sim->sol_cfd_, sim->sol_before_);
+      sub_sim = new Sim(sim->get_mode(), sim_thz, super_goal, opposite, sim->root_, 1, this, sim->sol_cfd_, sim->sol_before_);
       break;
     }
 


### PR DESCRIPTION
In backward chaining, `PrimaryMDLController::abduce` takes a goal for the model RHS and makes a goal for the model LHS, and attaches a new `Sim` object to the goal for the LHS. The `Sim` object constructor has a parameter for the `super_goal` (the goal for the RHS of a model) and for `sol_controller` (the controller for the model which is considered as the solution for the simulation). When creating the new `Sim` for the LHS goal, the [current code](https://github.com/IIIM-IS/replicode/blob/d83d0d3227c70e9c94ed5f6ec17f089d271bbf8b/r_exec/mdl_controller.cpp#L1671) re-uses `sim->super_goal_` and `sim->sol_controller_` from `sim`, which is the `Sim` object for the RHS goal:

    new Sim(sim->get_mode(), sim_thz, sim->super_goal_, opposite, sim->root_, 1, sim->sol_controller_, ...)

This could be considered as implementing the design described in section 6.5 "Simulation" of the [Replicode language specification](https://github.com/IIIM-IS/replicode/blob/master/Replicode_A_constructivist_programming_paradigm_and_language_2013.pdf). "**Abduction Step 3** For each solution goal, models induce furthermore and the resulting subgoals are tagged with the _same_ solution objects produced in the previous step." [italics added] When the simulation finishes, it commits [by calling abduce](https://github.com/IIIM-IS/replicode/blob/22752834af1decf4c58b5840a81f3ced577ea569/r_exec/g_monitor.cpp#L219) on the `sol_controller` in the `Sim` object of the best solution the make it a goal to achieve its LHS:

    best_sol->sol_controller_->abduce(bindings_, best_sol->super_goal_, best_sol->opposite_, goal_target_->get_cfd())

The problem is that the same `sol_controller` is used for each new `Sim` object during backward chaining. But we need the controller of the "deepest" model found in backward chaining, which is the earliest in time, and the first one whose LHS we need to achieve.

This pull request changes `PrimaryMDLController::abduce` so that the new `Sim` object has the super goal (RHS goal) and controller of the current model being use for abduction:

    new Sim(sim->get_mode(), sim_thz, super_goal, opposite, sim->root_, 1, this, ...)

Therefore, when the simulation commits to the best solution, it has the controller of the model whose LHS we need to achieve. Each `Sim` object has a super goal which itself has a `Sim` object with its own super goal. So if the original "least deep" super goal is needed, it can be found by following the chain of super goals back up to the top. Therefore, this commit does not remove access to any information.