### PR TITLE
In abduce, for the new sim time horizon, don't reduce sim->get_thz()

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1651,7 +1651,7 @@ void PrimaryMDLController::abduce(HLPBindingMap *bm, Fact *super_goal, bool oppo
 
   P<Fact> f_imdl = get_f_ihlp(bm, false);
   Sim *sim = super_goal->get_goal()->get_sim();
-  auto sim_thz = sim->get_thz() / 2; // 0 if super-goal had not time for simulation, else use half the thz (in case there are some requirments to simulate: they'll use the other half).
+  auto sim_thz = sim->get_thz(); // 0 if super-goal had no time for simulation.
   auto min_sim_thz = _Mem::Get()->get_min_sim_time_horizon() / 2; // time allowance for the simulated predictions to flow upward.
 
   Sim *sub_sim;


### PR DESCRIPTION
Every abduction in simulated backward chaining produces a new `Sim` object from the parent `Sim` object. When `PrimaryMDLController::abduce` [computes the time horizon](https://github.com/IIIM-IS/replicode/blob/ecca8fbfb808ef6b1d9209563857cfdfd63f1bf2/r_exec/mdl_controller.cpp#L1654) for the new `Sim` object, it currently divides by 2:

    auto sim_thz = sim->get_thz() / 2;

The comment says "use half the thz (in case there are some requirements to simulate: they'll use the other half)". This makes sense if simulated backward chaining only needs one step. But when simulated backward chaining does multiple abduction steps, the time horizon is repeatedly divided by two. In ten steps, the time horizon is reduced to 1/1024 of the original time horizon, which aborts the simulation.

This pull request changes this line of code to simply use the the time horizon of the parent `Sim` object (without dividing by 2). If we later have trouble with the simulation not having enough time to simulate requirements, then we can revisit this.