### PR TITLE
In abduce, for new Sim use the current super_goal, not the parent's

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1662,7 +1662,7 @@ void PrimaryMDLController::abduce(HLPBindingMap *bm, Fact *super_goal, bool oppo
       break;
     case SIM_OPTIONAL:
     case SIM_MANDATORY:
-      sub_sim = new Sim(sim->get_mode(), sim_thz, sim->get_f_super_goal(), opposite, sim->root_, 1, sim->solution_controller_, sim->get_solution_cfd(), sim->get_solution_before());
+      sub_sim = new Sim(sim->get_mode(), sim_thz, super_goal, opposite, sim->root_, 1, this, sim->get_solution_cfd(), sim->get_solution_before());
       break;
     }
 


### PR DESCRIPTION
Every abduction in simulated backward chaining produces [a new Sim object](https://github.com/IIIM-IS/replicode/blob/6938bee0558fcefcca98e523a51be7ebb9e3f240/r_exec/mdl_controller.cpp#L1672) from the parent `Sim` object:

    sub_sim = new Sim(sim->get_mode(), sim_thz, sim->get_f_super_goal(), opposite, sim->root_, 1, sim->solution_controller_, ...);

The new `Sim` object is attached to the goal which is abduced from the LHS. Note that it gets most of the parameters for the new `Sim` object from the parent `sim`. It makes sense that it would use the parent's mode, root, solution controller and confidence since these identify the branch of the simulation. The [comment for super_goal](https://github.com/IIIM-IS/replicode/blob/6938bee0558fcefcca98e523a51be7ebb9e3f240/r_exec/factory.h#L227) says it is the super goal "of the goal the sim is attached to". So it seems that it is a typo to use `sim->super_goal_` which means that every `Sim` object will have the super_goal of the root goal, not of the goal that the new `Sim` object is attached to.

This pull request changes `sim->get_f_super_goal()` to `super_goal` so that the `Sim` object of the abduced goal has the super goal of the abduced goal.