### PR TITLE
In abduce imdl use the timings from the template parameters, not the LHS

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1817,6 +1817,13 @@ void PrimaryMDLController::abduce_lhs(HLPBindingMap *bm, Fact *super_goal, Fact 
 
 void PrimaryMDLController::abduce_imdl(HLPBindingMap *bm, Fact *super_goal, Fact *f_imdl, bool opposite, float32 confidence, Sim *sim) { // goal is f->g->f->object or f->g->|f->object; called concurrently by redcue() and _GMonitor::update().
 
+  // Use the timestamps in the template parameters from the prerequisite model.
+  // This is to make it symmetric with the timestamp in the forward chaining requirement.
+  Timestamp f_imdl_after, f_imdl_before;
+  if (get_template_timings(bm, f_imdl_after, f_imdl_before)) {
+    Utils::SetTimestamp<Code>(f_imdl, FACT_AFTER, f_imdl_after);
+    Utils::SetTimestamp<Code>(f_imdl, FACT_BEFORE, f_imdl_before);
+  }
   f_imdl->set_cfd(confidence);
 
   Goal *sub_goal = new Goal(f_imdl, super_goal->get_goal()->get_actor(), sim, 1);
@@ -1891,6 +1898,13 @@ void PrimaryMDLController::abduce_simulated_imdl(HLPBindingMap *bm, Fact *super_
     // We are already simulating from this goal, so abort to avoid loops.
     return;
 
+  // Use the timestamps in the template parameters from the prerequisite model.
+  // This is to make it symmetric with the timestamp in the forward chaining requirement.
+  Timestamp f_imdl_after, f_imdl_before;
+  if (get_template_timings(bm, f_imdl_after, f_imdl_before)) {
+    Utils::SetTimestamp<Code>(f_imdl, FACT_AFTER, f_imdl_after);
+    Utils::SetTimestamp<Code>(f_imdl, FACT_BEFORE, f_imdl_before);
+  }
   f_imdl->set_cfd(confidence);
 
   Goal *sub_goal = new Goal(f_imdl, super_goal->get_goal()->get_actor(), sim, 1);
@@ -2294,6 +2308,47 @@ bool PrimaryMDLController::abduction_allowed(HLPBindingMap *bm) { // true if fwd
     return false;
   if (!HLPOverlay::ScanBWDGuards(this, bm))
     return false;
+  return true;
+}
+
+bool PrimaryMDLController::get_template_timings(HLPBindingMap *bm, Timestamp& after, Timestamp& before) {
+  // Find the variable indexes of the last two template parameters.
+  Code* model = get_core_object();
+  auto template_set_index = model->code(MDL_TPL_ARGS).asIndex();
+  auto template_set_count = model->code(template_set_index).getAtomCount();
+  if (template_set_count < 2)
+    // Not enough template parameters.
+    return false;
+  auto after_code_index = template_set_index + (template_set_count - 1);
+  auto before_code_index = template_set_index + template_set_count;
+  if (model->code(after_code_index).getDescriptor() != Atom::VL_PTR ||
+      model->code(before_code_index).getDescriptor() != Atom::VL_PTR)
+    // Parameters are not variables.
+    return false;
+  auto after_map_index = model->code(after_code_index).asIndex();
+  auto before_map_index = model->code(before_code_index).asIndex();
+
+  if (bm->get_code(after_map_index) != NULL && bm->get_code(before_map_index) != NULL) {
+    // The map entries are already evaluated, so check now.
+
+    if (!bm->is_timestamp(after_map_index) || !bm->is_timestamp(before_map_index))
+      // They are not timestamps.
+      return false;
+    after = Utils::GetTimestamp(bm->get_code(after_map_index));
+    before = Utils::GetTimestamp(bm->get_code(before_map_index));
+    return true;
+  }
+
+  // Make a copy of the binding map and evaluate to backward guards.
+  P<HLPBindingMap> bm_copy = new HLPBindingMap(bm);
+  if (!evaluate_bwd_guards(bm_copy))
+    return false;
+
+  if (!bm_copy->is_timestamp(after_map_index) || !bm_copy->is_timestamp(before_map_index))
+    // They are still not timestamps.
+    return false;
+  after = Utils::GetTimestamp(bm_copy->get_code(after_map_index));
+  before = Utils::GetTimestamp(bm_copy->get_code(before_map_index));
   return true;
 }
 

--- a/r_exec/mdl_controller.h
+++ b/r_exec/mdl_controller.h
@@ -386,6 +386,16 @@ private:
   void assume_lhs(HLPBindingMap *bm, bool opposite, _Fact *input, float32 confidence);
 
   bool abduction_allowed(HLPBindingMap *bm);
+  /**
+   * Get the last two values from the template parameters, assuming that they are the timings
+   * from the prerequisite model. This evaluates the backward guards if needed.
+   * @param bm The binding map, which is not changed.
+   * @param after Set this to the after timestamp (if this returns true).
+   * @param before Set this to the before timestamp (if this returns true).
+   * @return True for success, otherwise false if there are not enough template parameters,
+   * or cannot evaluate the backward guards, or if the values are not timestamps.
+   */
+  bool get_template_timings(HLPBindingMap *bm, Timestamp& after, Timestamp& before);
 public:
   PrimaryMDLController(r_code::View *view);
 


### PR DESCRIPTION
Consider these learned models:

    mdl_80:(mdl |[] []
       (fact (icst cst_79 |[] [v0:] : :) v1: v2: : :)
       (fact (imdl mdl_81 [y1 v1: v2:] [v0: v3: v4:] : :) v1: v2: : :)
    ...

    mdl_81:(mdl [v0: v1: v2:] []
       (fact (cmd move_y_plus [v3:] :) v4: v5: : :)
       (fact (mk.val v3: position y2 :) v6: v7: : :)
    []
       v6:(add v1 0s:100ms:0us)
       v7:(add v2 0s:100ms:0us)
    []
       v1:(sub v6 0s:100ms:0us)
       v2:(sub v7 0s:100ms:0us)
       v4:(sub v6 0s:80ms:0us)
       v5:(add v4 0s:80ms:0us)
    ...

In forward chaining, facts from the environment instantiate composite state `cst_79`, which matches the LHS of model `mdl_80`. These facts have the timings of the current frame, such as the time interval 500ms to 600ms . These are bound to variables `v1` and `v2` in `mdl_80`. Forward chaining makes a prediction of the RHS such as:

    (fact (imdl mdl_81 [y1 500ms 600ms] [p1 v3: v4:] : :) 500ms 600ms : :)

Note that the values for `v1` and `v2` of the RHS are bound to the timings, both in the timings of the fact, as well as the template values of the imdl. Forward chaining continues when there is a match to the LHS of `mdl_81`,for example:

    (fact (cmd move_y_plus [p1] :) 520ms 600ms : :)

Notice that the timings of the command are 520ms to 600ms which are different than the timings of the facts from the environment. Finally, forward chaining makes a prediction of the RHS of `mdl_81`, with timings for the next frame, such as 600ms to 700ms.

Now consider backward chaining where we start with a goal to achieve the RHS of `mdl_81`, again with timings 600ms to 700ms bound to variables `v6` and `v7`. If the conditions are met to execute the command on the LHS, then it will correctly use the backward guards and compute the timing variables `v4` and `v5` as 520ms and 600ms . This is good because it is symmetric with what we had in forward chaining.

But if the conditions are not met to execute the command, then we need to continue with backward chaining. In this case, we don't make a goal to achieve the LHS of `mdl_81` (which is done in [method abduce_lhs](https://github.com/IIIM-IS/replicode/blob/3d7ab34318836c1e69baaead5b67663c3d564109/r_exec/mdl_controller.cpp#L1733)). Instead we make a goal to make an imdl that instantiates `mdl_81` (which is done in [method abduce_imdl](https://github.com/IIIM-IS/replicode/blob/3d7ab34318836c1e69baaead5b67663c3d564109/r_exec/mdl_controller.cpp#L1782)). Currently, `abduce_imdl` uses the same timings for the imdl as it uses for the LHS, such as 520ms to 600ms:

    (fact (imdl mdl_81 [y1 v1: v2:] [p1 v3: v4:] : :) 520ms 600ms : :)

The problem is that this is not symmetric with what we had in forward chaining where the imdl timings were 500ms 600ms . This problem propagates during backward chaining with `mdl_80`. The variables `v1` and `v2` are bound to 520ms and 600ms, which are used as the timings to instantiate the LHS composite state `cst_79` .  If backward chaining in simulation continues like this through multiple models, then the timing errors accumulate and the simulation can fail.

We need the timings in backward chaining to be symmetric with forward chaining. Fortunately, the information is available. The backward guards in `mdl_81` compute variables `v4` and `v5` which are the timings of the LHS. But note that they also compute variables `v1` and `v2` which are the template values associated with the timings in `mdl_80`. In this case, they are the desired values of 500ms and 600ms.

This pull request updates `abduce_imdl` so that the timings of the imdl come from the last two template values of the model, in this case variables `v1` and `v2`. This means we have to accept that it is a convention that the model builder will always put the timings of the imdl in the last two template values. (This is already the case with all the [model building code](https://github.com/IIIM-IS/replicode/blob/a0a8ce01b0d94acd60538ab0f95a8244ef474924/r_exec/guard_builder.cpp#L232-L242) in the pattern extractor.) We add a utility method [get_template_timings](https://github.com/IIIM-IS/replicode/blob/81004791d3fc2d542f189b4c9d01f206e1eb5259/r_exec/mdl_controller.h#L368-L376) which uses the backward guards to evaluate the last two template values and check that they are timestamps. Then we [use these values](https://github.com/IIIM-IS/replicode/blob/81004791d3fc2d542f189b4c9d01f206e1eb5259/r_exec/mdl_controller.cpp#L1784-L1790) in `abduce_imdl` to set the imdl timings. We do the same in `abduce_simulated_imdl` which has the same issue.