### PR TITLE
Use registerGoalTarget before abducing a simulated goal.

### DIFF
--- a/r_exec/cst_controller.cpp
+++ b/r_exec/cst_controller.cpp
@@ -475,6 +475,10 @@ void CSTController::inject_goal(HLPBindingMap *bm,
   float32 confidence,
   Code *group) const {
 
+  if (sim && !sim->registerGoalTarget(sub_goal_target))
+    // We are already simulating from this goal, so abort to avoid loops.
+    return;
+
   sub_goal_target->set_cfd(confidence);
 
   Goal *sub_goal = new Goal(sub_goal_target, f_super_goal->get_goal()->get_actor(), sim, 1);

--- a/r_exec/factory.cpp
+++ b/r_exec/factory.cpp
@@ -745,6 +745,27 @@ Sim* Sim::getRootSim()
   return NULL;
 }
 
+bool Sim::registerGoalTarget(_Fact* f_obj) {
+  Sim* rootSim = getRootSim();
+  if (!rootSim)
+    // We don't expect this. Return true so that f_obj is injected as a goal anyway.
+    return true;
+
+  uint16 opcode = f_obj->code(0).asOpcode();
+  Code* obj = f_obj->get_reference(0);
+  // Debug: Do we need a critical section for this?
+  for (int i = 0; i < rootSim->goalTargets_.size(); ++i) {
+    _Fact* goalTarget = rootSim->goalTargets_[i];
+    // TODO: Actually match timings. For now, ignore timings and just check the fact opcode and match the object.
+    if (opcode == goalTarget->code(0).asOpcode() && _Fact::MatchObject(obj, goalTarget->get_reference(0), true))
+      // Already registered.
+      return false;
+  }
+
+  rootSim->goalTargets_.push_back(f_obj);
+  return true;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 MkRdx::MkRdx() : LObject(), bindings_(NULL) {

--- a/r_exec/factory.h
+++ b/r_exec/factory.h
@@ -256,10 +256,23 @@ public:
    */
   Sim* getRootSim();
 
+  /**
+   * If f_obj does not match any of the goal targets stored in the root Sim object, then store it in the root Sim object
+   * for future checks and return true. (In this case, you should inject it as a goal.) Othewise if the goal target was already
+   * registered then return false, meaning that it does not need to be made into a goal again.
+   * \param f_obj The (fact of the) object, such as (fact (mk_val ...)).
+   * \return True if f_obj has been registered and should be injected as a goal, false if it is already registered and should not
+   * be injected as a goal.
+   */
+  bool registerGoalTarget(_Fact* f_obj);
+
   bool is_requirement_;
 
   P<Controller> root_; // controller that produced the simulation branch root (SIM_ROOT): identifies the branch.
   P<Controller> solution_controller_; // controller that produced a sub-goal of the branch's root: identifies the model that can be a solution for the super-goal.
+
+private:
+  std::vector<P<_Fact> > goalTargets_;
 };
 
 // Caveat: instances of Fact can becone instances of AntiFact (set_opposite() upon MATCH_SUCCESS_NEGATIVE during backward chaining).


### PR DESCRIPTION
Simulated backward chaining may do abduction through multiple models. For example we may be the following models:

    y0->y1
    y1->y2
    y2->y1

Suppose the drive which starts the simulation is to achieve y2. We use the model `y1->y2` and abduce the LHS subgoal y1. If the current state of the environment is at y0, then we want to match y1 with the RHS with the model `y0->y1` . But y1 also matches the RHS of the model `y2->y1`. If we are not careful, we can abduce the LHS and make it a subgoal to achieve y2, which is where we started. This is a loop, which we don't want. Also, we might have:

    y1->y2
    x->y2
    y1->x

The drive to achieve y2 will abduce a subgoal to achieve y1 and another to achieve x. The goal to achieve x can abduce a subgoal to achieve y1, but we have already injected this as a subgoal. Although this is not a loop, we don't want to repeat the computation to achieve the same goal.

This pull request adds the method [registerGoalTarget](https://github.com/IIIM-IS/replicode/blob/5850e1a32d30fc2f7752da783a81d8ab5a481672/r_exec/factory.h#L259-L267) to the `Sim` object. This registers the goal target in the root `Sim` object and returns true, otherwise if the goal target is already registered it returns false. We also update CSTController and MDLController to call registerGoalTarget before injecting a subgoal in simulated backward chaining. If the goal target is already registered, then don't abduce the same subgoal again.