### PR TITLE
In (pred) syntax, add list of sims

### DIFF
--- a/AERA/replicode_v1.2/std.replicode
+++ b/AERA/replicode_v1.2/std.replicode
@@ -53,7 +53,7 @@
 !class (mdl (_obj {tpl_args:[] objs:[] fwd_guards:[] bwd_guards:[] out_grps:[::grp] str:nb cnt:nb sr:nb dsr:nb}))
 !class (icst (_obj {cst:cst tpl_args:[] args:[] wr_e:bl}))
 !class (imdl (_obj {mdl:mdl tpl_args:[] args:[] wr_e:bl}))
-!class (pred (_obj {obj:}))
+!class (pred (_obj {obj: sims:[::sim]}))
 !class (goal (_obj {obj: actr:ent sim:}))
 !class (success (_obj {obj: evd:}))
 !class (mk.grp_pair (_obj {primary:grp secondary:grp}))

--- a/r_code/replicode_defs.h
+++ b/r_code/replicode_defs.h
@@ -236,7 +236,8 @@
 
 
 #define PRED_TARGET 1
-#define PRED_ARITY 2
+#define PRED_SIMS 2
+#define PRED_ARITY 3
 
 #define PRED_TARGET_REF 0
 

--- a/r_exec/factory.h
+++ b/r_exec/factory.h
@@ -310,9 +310,7 @@ public:
    * \param simulations_source The Pred with the list of simulations to copy.
    * \param psln_thr The propagation of saliency threshold.
    */
-  Pred(_Fact *target, const Pred* simulations_source, float32 psln_thr) : LObject() {
-    construct(target, simulations_source->simulations_, psln_thr);
-  }
+  Pred(_Fact *target, const Pred* simulations_source, float32 psln_thr);
 
   bool is_invalidated();
   bool grounds_invalidated(_Fact *evidence);
@@ -321,20 +319,27 @@ public:
 
   std::vector<P<_Fact> > grounds_; // f1->obj; predictions that were used to build this predictions (i.e. antecedents); empty if simulated.
 
-  bool is_simulation() const { return simulations_.size() > 0; }
+  bool is_simulation() const { return get_simulations_size() > 0; }
 
   /**
    * Get the size of the list of simulations.
    * \return The size of the list of simulations.
    */
-  size_t get_simulations_size() const { return simulations_.size(); }
+  uint16 get_simulations_size() const {
+    auto sim_set_index = code(PRED_SIMS).asIndex();
+    return code(sim_set_index).getAtomCount();
+  }
 
   /**
    * Get the simulation in the list of simulations at index i.
    * \param i The index of the simulation, from 0 to   get_simulations_size() - 1.
    * \return The simulation at index i.
    */
-  Sim* get_simulation(uint16 i) const { return simulations_[i]; }
+  Sim* get_simulation(uint16 i) const {
+    auto sim_set_index = code(PRED_SIMS).asIndex();
+    auto atom = code(sim_set_index + i);
+    return (Sim*)get_reference(atom.asIndex());
+  }
 
   /**
    * Get the simulation whose root is the given root Controller.
@@ -345,8 +350,6 @@ public:
 
 private:
   void construct(_Fact *target, const std::vector<P<Sim> >& simulations, float32 psln_thr);
-
-  std::vector<P<Sim> > simulations_;
 };
 
 class r_exec_dll Goal :


### PR DESCRIPTION
Internally, the C++ `Pred` object has the `simulations_` member which is a list of `Sim` objects and distinguishes real from simulated predictions. But this is not visible to Replicode programs. It is important that they be visible for self-reflection and to distinguish real and simulated predictions in the decompiled output.

This pull request updates the Replicode language to add a list of sim objects to the pred syntax, which is now `(pred obj sims psln_thr)`. The meaning of `obj` and `psln_thr` are the same as before. The `sims` parameter can be the empty list `|[]` or a list of sim objects. This pull request also updates the C++ `Pred` object to take an array of `Sim` objects in the constructor and to store it as a list in the code representation. The `simulations_` class member is replaced by `get_simulations_size()` `get_simulation(i)` which get the size of the list and get a single `Sim` object from the code representation by index.