### PR TITLE
In CSTOverlay::reduce, if simulating then make the icst after matching one member

### DIFF
--- a/r_exec/cst_controller.cpp
+++ b/r_exec/cst_controller.cpp
@@ -96,6 +96,7 @@ CSTOverlay::CSTOverlay(const CSTOverlay *original) : HLPOverlay(original->contro
   match_deadline_ = original->match_deadline_;
   lowest_cfd_ = original->lowest_cfd_;
   original_patterns_size_ = original->original_patterns_size_;
+  inputs_ = original->inputs_;
 }
 
 CSTOverlay::~CSTOverlay() {
@@ -275,7 +276,8 @@ bool CSTOverlay::reduce(View *input, CSTOverlay *&offspring) {
     //} else{
     // std::cout<<Time::ToString_seconds(now-Utils::GetTimeReference())<<" "<<std::hex<<this<<std::dec<<" ("<<Time::ToString_seconds(match_deadline-Utils::GetTimeReference())<<") ";
     //}
-    if (patterns_.size() == 1) { // last match.
+    // Debug: If simulating then make the icst after matching one member, as a temporary solution to https://github.com/IIIM-IS/replicode/issues/97
+    if (is_simulation || patterns_.size() == 1) { // last match.
 
       if (!code_) {
 
@@ -284,10 +286,10 @@ bool CSTOverlay::reduce(View *input, CSTOverlay *&offspring) {
         bindings_ = bm;
         if (evaluate_fwd_guards()) { // may update bindings; full match.
 //std::cout<<Time::ToString_seconds(now-Utils::GetTimeReference())<<" full match\n";
+          offspring = new CSTOverlay(this);
           update(bm, (_Fact *)input->object_, bound_pattern);
           inject_production();
           invalidate();
-          offspring = NULL;
           store_evidence(input->object_, prediction, is_simulation);
           return true;
         } else {
@@ -299,10 +301,12 @@ bool CSTOverlay::reduce(View *input, CSTOverlay *&offspring) {
         }
       } else { // guards already evaluated, full match.
 //std::cout<<Time::ToString_seconds(now-Utils::GetTimeReference())<<" full match\n";
+        // Debug: If simulating then make the icst after matching one member, as a temporary solution to https://github.com/IIIM-IS/replicode/issues/97
+        offspring = new CSTOverlay(this);
         update(bm, (_Fact *)input->object_, bound_pattern);
-        if (inputs_.size() == original_patterns_size_) inject_production();
+        // Debug: If simulating then make the icst after matching one member, as a temporary solution to https://github.com/IIIM-IS/replicode/issues/97
+        if (is_simulation || inputs_.size() == original_patterns_size_) inject_production();
         invalidate();
-        offspring = NULL;
         store_evidence(input->object_, prediction, is_simulation);
         return true;
       }


### PR DESCRIPTION
The method `CSTOverlay::reduce` collects inputs relevant to a composite state and creates an icst when complete. As a temporary solution to issue #97 , if simulating then make the icst after matching one member. This will allow simulated forward chaining to continue with one predicted input to a composite state, without having predicted facts for the other members (such as an "essence" fact). When we find a better solution to issue #97, then we won't need this pull request.