### PR TITLE
In retrieve_simulated_imdl_fwd, don't call is_out_of_range(now)

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -437,8 +437,6 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(HLPBindingMap *bm, Fac
 
       if ((*e).is_too_old(now)) // garbage collection.
         e = simulated_requirements_.positive_evidences.erase(e);
-      else if ((*e).is_out_of_range(now))
-        ++e;
       else {
 
         if ((*e).evidence_->get_pred()->get_simulation(root)) {
@@ -471,8 +469,6 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(HLPBindingMap *bm, Fac
 
         if ((*e).is_too_old(now)) // garbage collection.
           e = simulated_requirements_.negative_evidences.erase(e);
-        else if ((*e).is_out_of_range(now))
-          ++e;
         else {
 
           if ((*e).evidence_->get_pred()->get_simulation(root)) {
@@ -503,8 +499,6 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(HLPBindingMap *bm, Fac
 
         if ((*e).is_too_old(now)) // garbage collection.
           e = simulated_requirements_.negative_evidences.erase(e);
-        else if ((*e).is_out_of_range(now))
-          ++e;
         else {
 
           if ((*e).evidence_->get_pred()->get_simulation(root)) {
@@ -527,8 +521,6 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(HLPBindingMap *bm, Fac
 
         if ((*e).is_too_old(now)) // garbage collection.
           e = simulated_requirements_.positive_evidences.erase(e);
-        else if ((*e).is_out_of_range(now))
-          ++e;
         else {
           //(*e).f->get_reference(0)->trace();
           //f->get_reference(0)->trace();


### PR DESCRIPTION
During simulated forward chaining,`MDLController::retrieve_simulated_imdl_fwd` checks if a predicted imdl matches an imdl which was stored as a requirement during simulated backward chaining. It has a loop to examine the evidence `e` of each stored requirement, In the loop, it makes the [following check](https://github.com/IIIM-IS/replicode/blob/59c55a2e774561d51097a6f6fe146dc084af2609/r_exec/mdl_controller.cpp#L440-L441):

    else if ((*e).is_out_of_range(now))
      ++e;

The utility method [is_out_of_range](https://github.com/IIIM-IS/replicode/blob/ecca8fbfb808ef6b1d9209563857cfdfd63f1bf2/r_exec/mdl_controller.h#L155) checks if "now" is outside of the time interval of the fact. The problem is that we are simulating future facts, so the timings of the imdl are later than "now". It appears that this is a copy/paste error from `retrieve_imdl_fwd` which has [the same check](https://github.com/IIIM-IS/replicode/blob/59c55a2e774561d51097a6f6fe146dc084af2609/r_exec/mdl_controller.cpp#L729-L730). In that case it makes sense because it is checking the requirements of non-simulated facts which should be active now.

This pull request removes the `is_out_of_range` from `retrieve_simulated_imdl_fwd`, assuming that it was a copy/paste error, and which prevents simulated forward chaining from working properly.