### PR TITLE
NoArgCmdGuardBuilder: for cmd_t1, use the same formula as for t1.

### DIFF
--- a/r_exec/guard_builder.cpp
+++ b/r_exec/guard_builder.cpp
@@ -280,7 +280,7 @@ void NoArgCmdGuardBuilder::_build(Code *mdl, uint16 q0, uint16 t0, uint16 t1, ui
   write_guard(mdl, t1, t3, Opcodes::Sub, period_, write_index, extent_index);
 
   write_guard(mdl, cmd_t0, t2, Opcodes::Sub, offset_, write_index, extent_index);
-  write_guard(mdl, cmd_t1, cmd_t0, Opcodes::Add, cmd_duration_, write_index, extent_index);
+  write_guard(mdl, cmd_t1, t3, Opcodes::Sub, period_, write_index, extent_index);
 
   write_index = extent_index;
 }


### PR DESCRIPTION
`NoArgCmdGuardBuilder` builds the guards of a learned model like this:

    (mdl [v0: v1: v2:]
    []
       (fact (cmd move_y_plus [v3:] :) v4: v5: : :)
       (fact (mk.val v3: position y2 :) v6: v7: : :)
    []
       v6:(add v1 0s:100ms:0us)
       v7:(add v2 0s:100ms:0us)
    []
       v1:(sub v6 0s:100ms:0us)
       v2:(sub v7 0s:100ms:0us)
       v4:(sub v6 0s:80ms:0us)
       v5:(add v4 0s:80ms:0us)

For the LHS and RHS, it uses input facts like these:

    (fact (cmd move_y_plus [p1])  0s:320ms:0us 0s:400ms:0us)   ; LHS
    (fact (mk.val p1 position y2) 0s:400ms:0us 0s:500ms:0us)   ; RHS

In this case, the values of `v4` and `v5` of the LHS are 0s:320ms:0us 0s:400ms:0us. The values of `v6` and `v7` of the RHS are 0s:400ms:0us 0s:500ms:0us . For the backward guards, the pattern extractor needs to create expressions to compute `v4` and `v5` from `v6` and `v7`. As shown above, it uses:

    v4:(sub v6 0s:80ms:0us)
    v5:(add v4 0s:80ms:0us)

In this case, `v6` is 0s:400ms:0us, so it subtracts 80ms and correctly computes `v4` as 0s:320ms:0us . It computes `v5` based on this value of `v4`, correctly computed as 0s:400ms:0us to match the input fact. The problem is that, we might use this model with a goal for the RHS which has a larger timing interval like:

    (fact (mk.val p1 position y2) 0s:400ms:0us 0s:900ms:0us)

This means that it is a goal to achieve `(mk.val p1 position y2)` some time between 0s:400ms:0us and 0s:900ms:0us, allowing more time to achieve the goal. To abduce the goal for the LHS, if we use the backward guards shown above then the LHS would be the same as before:

    (fact (cmd move_y_plus [p1]) 0s:320ms:0us 0s:400ms:0us)

But if the timings of the RHS goal have a larger timing interval, we also need the goal for the LHS to have a larger timing interval, represented by the variables `v4` and `v5`. As shown above, the pattern extractor created an expression to compute `v5` based on `v4`. But it could equally have matched the value for `v5` based on `v7`. In fact, it already computes `v2` based on `v7`.

So, this pull request updates `NoArgCmdGuardBuilder::_build` to create an expression for `v5` based on `v7` (using the same code as in the expression for `v2`):

    v5:(sub v7 0s:100ms:0us)

In the case of the RHS fact with a larger timing interval, `v7` is 0s:900ms:0us, so the guard will subtract 100ms and set `v5` to 0s:800ms:0us . Thus, the abduced LHS fact will have a larger timing interval as desired:

    (fact (cmd move_y_plus [p1]) 0s:320ms:0us 0s:800ms:0us)

(Note that there are multiple ways that the pattern extractor could create expressions to match the input facts. Ultimately, the best approach is to create different models for each possible was to match the input facts, then let the AERA runtime track the success rates of the different models and keep the best one. However, we are still developing the mechanism to compare and "weed out" models. When the mechanism is performing as expected, then we can revisit this pull request and allow the pattern extractor build multiple models with the different guard expressions.)