### PR TITLE
In SRMonitor::signal, if check_simulated_imdl succeeds, then return true

### DIFF
--- a/r_exec/g_monitor.cpp
+++ b/r_exec/g_monitor.cpp
@@ -542,8 +542,13 @@ bool SRMonitor::signal(bool is_simulation, Sim* forwardSimulation) {
 
   if (is_simulation) {
 
-    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_, target_->get_goal()->get_sim()->root_, forwardSimulation))
+    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_, target_->get_goal()->get_sim()->root_, forwardSimulation)) {
       ((PMDLController *)controller_)->register_simulated_goal_outcome(target_, true, target_); // report a simulated success.
+      // check_simulated_imdl did an abduction, so return true to remove this monitor. Otherwise it will do the same
+      // abduction again and cause a loop.
+      // JTNote: Maybe it is needed for a different simulation branch?
+      return true;
+    }
   } else {
 
     if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_, NULL, NULL))


### PR DESCRIPTION
The return value from `PrimaryMDLController::check_simulated_imdl` is true if the simulated goal imdl matches a requirement and it calls `abduce_simulated_lhs` . (For more details, see pull request #98.) Furthermore, the return value from `SRMonitor::signal` is true if the simulated requirement monitor has processed its target and has injected a new predicted LHS (such as a command). This means that the monitor is finished and [should be removed](https://github.com/IIIM-IS/replicode/blob/59c55a2e774561d51097a6f6fe146dc084af2609/r_exec/mdl_controller.cpp#L1384-L1385):

    if ((*m)->signal(is_simulation))
      m = r_monitors_.erase(m);

If the monitor is not removed, then it will be signaled again to process its target and will inject the same predicted command again, causing a loop. The same is true for the non-simulation requirement monitor. Notice that its `signal` method [returns true](https://github.com/IIIM-IS/replicode/blob/master/r_exec/g_monitor.cpp#L371-L372) when `check_imdl` succeeds:

    if (((PrimaryMDLController *)controller_)->check_imdl(target_, bindings_))
      return true;

This pull request updates `SRMonitor::signal` to do the same thing and to return true when `check_simulated_imdl` succeeds. Thus, the monitor will be removed after injecting the predicted command once, and we prevent loops.