### PR TITLE
In (sim) syntax, add f_super_goal and other fields

### DIFF
--- a/AERA/replicode_v1.2/std.replicode
+++ b/AERA/replicode_v1.2/std.replicode
@@ -38,7 +38,7 @@
 !class (mk.new (_obj obj:))
 
 ; simulator
-!class (sim (_obj {mode:nb thz:us}))
+!class (sim (_obj {mode:nb thz:us f_super_goal: opposite:bl root_model:mdl solution_model:mdl solution_cfd:nb solution_before:us}))
 ; values for sim mode
 !def SIM_ROOT 0
 !def SIM_OPTIONAL 1

--- a/r_code/replicode_defs.h
+++ b/r_code/replicode_defs.h
@@ -265,7 +265,13 @@
 
 #define SIM_MODE 1
 #define SIM_THZ 2
-#define SIM_ARITY 3
+#define SIM_F_SUPER_GOAL 3
+#define SIM_OPPOSITE 4
+#define SIM_ROOT_MODEL 5
+#define SIM_SOLUTION_MODEL 6
+#define SIM_SOLUTION_CFD 7
+#define SIM_SOLUTION_BEFORE 8
+#define SIM_ARITY 9
 
 #define UNDEFINED_OID 0xFFFFFFFF
 

--- a/r_exec/factory.h
+++ b/r_exec/factory.h
@@ -226,34 +226,28 @@ public:
   /**
    * Get the (fact of the) super goal of the goal the sim is attached to.
    */
-  Fact* get_f_super_goal() const { return super_goal_; }
+  Fact* get_f_super_goal() const { return (Fact*)get_reference(0); }
 
   /**
    * Get the opposite flag of the goal the sim is attached to, i.e. the result of the
    * match during controller->reduce(); the confidence is in the goal target.
    */
-  bool get_opposite() const { return opposite_; }
+  bool get_opposite() const { return code(SIM_OPPOSITE).asBoolean(); }
 
   /**
    * Get the confidence of the solution goal.
    */
-  float32 get_solution_cfd() const { return solution_cfd_; }
+  float32 get_solution_cfd() const { return code(SIM_SOLUTION_CFD).asFloat(); }
 
   /**
    * Get the  deadline of the solution goal.
    */
-  Timestamp get_solution_before() const { return solution_before_; }
+  Timestamp get_solution_before() const { return r_code::Utils::GetTimestamp<Code>(this, SIM_SOLUTION_BEFORE); }
 
   bool is_requirement_;
 
   P<Controller> root_; // controller that produced the simulation branch root (SIM_ROOT): identifies the branch.
   P<Controller> solution_controller_; // controller that produced a sub-goal of the branch's root: identifies the model that can be a solution for the super-goal.
-
-private:
-  P<Fact> super_goal_;
-  bool opposite_;
-  float32 solution_cfd_;
-  Timestamp solution_before_;
 };
 
 // Caveat: instances of Fact can becone instances of AntiFact (set_opposite() upon MATCH_SUCCESS_NEGATIVE during backward chaining).


### PR DESCRIPTION
Currently, the Replicode `(sim)` syntax has only the mode and time horizon. But for the Visualizer, we need the decompiled output to have all the fields as the C++ `Sim` class. This pull request adds the extra fields to the `(sim)` syntax.

    !class (sim (_obj {mode:nb thz:us f_super_goal: opposite:bl root_model:mdl solution_model:mdl solution_cfd:nb solution_before:us}))

In the C++ class, this pull request removes the fields `super_goal_`, `opposite_`, `solution_cfd_` and `solution_before_`. These are now stored in the code representation (along with the mode and time horizon). For clarity, in the `(sim)` syntax with use `f_super_goal` because the object is not the `(goal ...)` but is the `(fact (goal ...))`.

In the C++ `Sim` object, we retain the pointers to the controllers for `root_` and `solution_controller_` . But we can't represent a controller in the decompiled `(sim)` object. So, as a special case, when the C++ `Sim` constructor stores the values in the code representation, it [stores the target models](https://github.com/IIIM-IS/replicode/blob/a66835666f03636d96fa648f95640b1444913aa1/r_exec/factory.cpp#L656-L670) of the controllers. Therefore, an example decompiled object is the following where we see the root and solution models:

    (sim 1 0s:50ms:0us fact_448 false m_run_position mdl_146 1 0s:0ms:0us 1)

This works because the Replicode seed does not create a `(sim)` object and does not update the controller fields of existing objects. Therefore the decompiled object can be treated as "read only".
    