### PR TITLE
In auto focus, for SYNC_HOLD, don't add offset to the before timing.

### DIFF
--- a/r_exec/auto_focus.cpp
+++ b/r_exec/auto_focus.cpp
@@ -183,9 +183,9 @@ inline View *AutoFocusController::inject_input(View *input) {
   case View::SYNC_HOLD: { // inject a copy, add a controller, sync_once, morph res, after=now+time_tolerance (de-sync as it can have the same effect as a cmd), before=now+output_grp.upr+time_tolerance.
     auto offset = 2 * Utils::GetTimeTolerance();
     if (input_fact->is_anti_fact())
-      copy = new AntiFact(input_fact->get_reference(0), now + offset, now + offset + ref_group->get_upr()*Utils::GetBasePeriod(), 1, 1);
+      copy = new AntiFact(input_fact->get_reference(0), now + offset, now + ref_group->get_upr()*Utils::GetBasePeriod(), 1, 1);
     else
-      copy = new Fact(input_fact->get_reference(0), now + offset, now + offset + ref_group->get_upr()*Utils::GetBasePeriod(), 1, 1);
+      copy = new Fact(input_fact->get_reference(0), now + offset, now + ref_group->get_upr()*Utils::GetBasePeriod(), 1, 1);
     for (uint16 i = 0; i < output_groups_.size(); ++i) {
 
       Group *output_group = output_groups_[i];


### PR DESCRIPTION
When a fact is injected with a SYNC_HOLD view, the [auto focus controller offsets its timings](https://github.com/IIIM-IS/replicode/blob/b7658112d6a767766456a88d3b87769e4cedfca0/r_exec/auto_focus.cpp#L183-L188) by 20ms so that it can be considered as the LHS "cause" of a model. (The LHS "cause" must occur after the prerequisite facts.) In the following, `offset` is 20ms and ` ref_group->get_upr()*Utils::GetBasePeriod()` is 100ms .

    new Fact(input_fact->get_reference(0), now + offset, now + offset + ref_group->get_upr()*Utils::GetBasePeriod(), ...)

The result is a fact with timings such as:

    (fact (mk.val b speed_y 0.0001) 0s:220ms:0us 0s:320ms:0us)

The problem is that the second timing value like 320ms overlaps the start of the next frame, which can create an unexpected prediction in the next frame. Note that when a command is ejected, the fact of the ejected command (also a LHS "cause") does not overlap the next frame.

This pull request removes `+ offset` from the second timing of a SYNC_HOLD fact so that it doesn't overlap the next frame. Now it looks like:

    (fact (mk.val b speed_y 0.0001) 0s:220ms:0us 0s:300ms:0us)