### PR TITLE
Check for simulated f_p_f_imdl

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -121,6 +121,13 @@ Overlay *PrimaryMDLOverlay::reduce(_Fact *input, Fact *f_p_f_imdl, MDLController
     is_simulation = false;
   }
 
+  if (!is_simulation) {
+    if (f_p_f_imdl && f_p_f_imdl->get_pred() && f_p_f_imdl->get_pred()->is_simulation())
+      // The input is not a simulation, but the triggering f_p_f_imdl is part of a
+      // simulation, so don't make predictions from the non-simulated input.
+      return false;
+  }
+
   P<HLPBindingMap> bm = new HLPBindingMap(bindings_);
   bm->reset_fwd_timings(input_object);
   switch (bm->match_fwd_lenient(input_object, ((MDLController *)controller_)->get_lhs())) {


### PR DESCRIPTION
The method `PrimaryMDLOverlay::reduce` processes an input prediction in forward chaining. It [sets the variable](https://github.com/IIIM-IS/replicode/blob/17326b1d2bbd2aaf9c5fb9b40a11621cd2e1d7ff/r_exec/mdl_controller.cpp#L117) `is_simulation` true if the input prediction is simulated. If `is_simulation` is false, then the method creates a non-simulated prediction. 

The parameter `f_p_f_imdl` is the predicted imdl which triggered the forward chaining in this model. The problems is that, even if  `f_p_f_imdl` is from a simulation, the variable `is_simulation` can be false, causing the method to create a non-simulated prediction. In this way a non-simulated prediction "leaks out" of the simulation that created `f_p_f_imdl` which can incorrectly cause the model's rating to be updated based on the result of the prediction, which is treated as real, even though it's a side-effect of a simulation.

This pull request updates the method as follows. If `is_simulation` is false but `f_p_f_imdl` is simulated, then the method returns without creating a prediction.