### PR TITLE
In predict, pass the bound bm to the new MkRdx

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1514,9 +1514,9 @@ void PrimaryMDLController::predict(HLPBindingMap *bm, _Fact *input, Fact *f_imdl
 
         Code *mk_rdx;
         if (ground)
-          mk_rdx = new MkRdx(f_imdl, (Code *)input, ground, production, 1, bindings_);
+          mk_rdx = new MkRdx(f_imdl, (Code *)input, ground, production, 1, bm);
         else
-          mk_rdx = new MkRdx(f_imdl, (Code *)input, production, 1, bindings_);
+          mk_rdx = new MkRdx(f_imdl, (Code *)input, production, 1, bm);
         bool rate_failures = inject_prediction(production, f_imdl, confidence, before - now, mk_rdx);
         PMonitor *m = new PMonitor(this, bm, production, rate_failures); // not-injected predictions are monitored for rating the model that produced them (successes only).
         MDLController::add_monitor(m);


### PR DESCRIPTION
When `PMDLController::inject_goal` injects a new abduced goal, it [creates a reduction marker](https://github.com/IIIM-IS/replicode/blob/17326b1d2bbd2aaf9c5fb9b40a11621cd2e1d7ff/r_exec/mdl_controller.cpp#L1066) with the information about the reduction, including the binding map `bm` where the model variables are bound to the values for this particular abduction. 

    new MkRdx(f_imdl, goal->get_goal()->get_super_goal(), goal, 1, bm);

The values in the binding map are used later when the auto focus controller checks whether a newly-injected fact has values in common with a previously-injected goal. (When the auto focus "pass through" is false, it will only do auto focus for facts that have a value in common with an active goal or prediction.)

Likewise, when `PrimaryMDLController::predict` injects a new prediction, it [creates a reduction marker](https://github.com/IIIM-IS/replicode/blob/17326b1d2bbd2aaf9c5fb9b40a11621cd2e1d7ff/r_exec/mdl_controller.cpp#L1517-L1519). 

    new MkRdx(f_imdl, (Code *)input, ground, production, 1, bindings_);

But instead of passing the binding map `bm` with the bound values, it passes the model's `bindings_` which is a binding map template where the values are always unbound. Therefore, when the auto focus controller checks whether a newly-injected fact matches this prediction, the binding map is unbound and the check returns false, meaning that auto focus rejects the newly-injected fact.

This pull request updates `PrimaryMDLController::predict` so that, when it creates the reduction marker, it uses the bound binding map `bm`, similar to `inject_goal`. (It is assumed that this bug was a copy/paste error or other error in the initial development of the code.)