### PR TITLE
README: Add math type conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ This is a list of unintuitive issues with using Replicode, to help new users.
   [Maybe not in primary. Need to understand how simulated goals are committed, and to which group.]
 * Prediction failures may come from false assumptions. In `settings.xml`, try `enable_assumptions="no"` .
 * Objects with a short resilience aren't in `decompiled_objects.txt`. In `settings.xml`, try `keep_invalidated_objects=yes` .
-* Some conversion of types in math expressions are not obvious. Below 'nb' is a floating-point number and 'us' is a 64-bit timestamp in microseconds.
+* Math operations on two floating point numbers produce a floating point number, as expected. And addition
+  and subtraction of two time values produces a time value, as expected. But the result of operations with
+  mixed types is not obvious. Below 'nb' is a floating-point number and 'us' is a 64-bit timestamp in microseconds.
   - (+ nb us) -> us
   - (+ us nb) -> us
   - (- nb us) not allowed


### PR DESCRIPTION
The conversion of types in math expressions is not obvious. This pull request updates the "Gotchas" section of the README.