### PR TITLE
Make the efferent copy timings relative to the frame

### DIFF
--- a/r_exec/pgm_overlay.cpp
+++ b/r_exec/pgm_overlay.cpp
@@ -464,11 +464,16 @@ bool InputLessPGMOverlay::inject_productions() {
 
       // Build a fact of the command and inject it in stdin. Give the fact an uncertainty range since we don't know when
       // it will be executed. Otherwise a fact with zero duration may not overlap a fact, making predictions fail.
-      // We offset the beginning of the uncertainty range by 2*GetTimeTolerance() (the same as SYNC_HOLD)
+      // We offset the beginning of the uncertainty range at a minimum by 2*GetTimeTolerance() from the frame start (the same as SYNC_HOLD)
       // so that CTPX::reduce will not fail due to "cause in sync with the premise".
+      auto relativeTime = duration_cast<microseconds>(now - Utils::GetTimeReference());
+      auto frameStart = now - (relativeTime % _Mem::Get()->get_sampling_period());
+      auto after = max(now, frameStart + 2 * Utils::GetTimeTolerance());
+      auto before = frameStart + _Mem::Get()->get_sampling_period();
       P<Code> fact;
       if (executedCommand) {
-        fact = new Fact(command, now + 2 * Utils::GetTimeTolerance(), now + _Mem::Get()->get_sampling_period(), 1, 1);
+        // Set fact to the efferent copy of the command and inject it.
+        fact = new Fact(executedCommand, after, before, 1, 1);
         View *view = new View(View::SYNC_ONCE, now, 1, 1, _Mem::Get()->get_stdin(), getView()->get_host(), fact); // SYNC_ONCE, sln=1, res=1,
         _Mem::Get()->inject(view);
         string mk_rdx_info = "";


### PR DESCRIPTION
In pull request #59, we updated injection of the efferent copy of a command so that the time interval is offset from the beginning of the frame, like SYNC_HOLD. But this change assumed that the command is ejected by a program running at the beginning of the frame, so that "now" is the beginning of the frame. But a command can also be ejected near the end of the frame after running a simulation. In this case, the existing code makes the time interval of the efferent copy extend into the next frame, which makes predictions fail of models that model the effect of the command.

This pull request updates the time interval of the efferent copy to be explicitly based on the time of the beginning of the frame. The time interval starts at an offset from the beginning of the frame, or later if "now" is later in the frame. Also, the end of the time interval is set to the end of the frame. This is an interim solution intended for diagnostic mode which will be revisited when we are updating AERA's treatment in general of time intervals when running in real time.