### PR TITLE
Make eject return the executed command or NULL

### DIFF
--- a/AERA/test_mem.cpp
+++ b/AERA/test_mem.cpp
@@ -154,7 +154,7 @@ TestMem<O, S>::findObject(std::vector<Code*> *objects, const char* name) {
   return NULL;
 }
 
-template<class O, class S> void TestMem<O, S>::eject(Code *command) {
+template<class O, class S> Code* TestMem<O, S>::eject(Code *command) {
   uint16 function = (command->code(CMD_FUNCTION).atom_ >> 8) & 0x000000FF;
 
   if (function == ready_opcode_) {
@@ -167,15 +167,15 @@ template<class O, class S> void TestMem<O, S>::eject(Code *command) {
         if (!(command->code_size() >= 3 && command->code(args_set_index + 2).getDescriptor() == Atom::R_PTR &&
               command->references_size() > command->code(args_set_index + 2).asIndex())) {
           cout << "WARNING: Cannot get the object for ready \"ball\"" << endl;
-          return;
+          return NULL;
         }
         if (!velocity_y_property_) {
           cout << "WARNING: Can't find the velocity_y property" << endl;
-          return;
+          return NULL;
         }
         if (!position_y_property_) {
           cout << "WARNING: Can't find the position_y property" << endl;
-          return;
+          return NULL;
         }
 
         Code* obj = command->get_reference(command->code(args_set_index + 2).asIndex());
@@ -183,27 +183,28 @@ template<class O, class S> void TestMem<O, S>::eject(Code *command) {
           // This is the first call. Remember the object whose position we're reporting.
           position_y_obj_ = obj;
           startTimeTickThread();
+          return command;
         }
         else {
           if (position_y_obj_ != obj)
             // For now, don't allow tracking multiple objects.
-            return;
+            return NULL;
         }
       }
       else {
         cout << "WARNING: Ignoring unrecognized ready command identifier: " << identifier << endl;
-        return;
+        return NULL;
       }
     }
   }
   else if (function == set_velocity_y_opcode_) {
     if (!velocity_y_property_) {
       cout << "WARNING: Can't find the velocity_y property" << endl;
-      return;
+      return NULL;
     }
     if (!position_y_property_) {
       cout << "WARNING: Can't find the position_y property" << endl;
-      return;
+      return NULL;
     }
 
     auto now = r_exec::Now();
@@ -220,22 +221,23 @@ template<class O, class S> void TestMem<O, S>::eject(Code *command) {
     else {
       if (position_y_obj_ != obj)
         // For now, don't allow tracking the velocity of multiple objects.
-        return;
+        return NULL;
     }
 
     velocity_y_ = command->code(args_set_index + 2).asFloat();
     // Let onTimeTick inject the new velocity_y.
+    return command;
   }
   else if (function == move_y_plus_opcode_ ||
     function == move_y_minus_opcode_) {
     if (!position_property_) {
       cout << "WARNING: Can't find the position property" << endl;
-      return;
+      return NULL;
     }
     for (int i = 0; i <= 9; ++i) {
       if (!yEnt_[i]) {
         cout << "WARNING: Can't find the entities y0, y1, etc." << endl;
-        return;
+        return NULL;
       }
     }
 
@@ -249,17 +251,16 @@ template<class O, class S> void TestMem<O, S>::eject(Code *command) {
       discretePositionObj_ = obj;
       discretePosition_ = yEnt_[0];
       startTimeTickThread();
-      return;
     }
     else {
       if (discretePositionObj_ != obj)
         // For now, don't allow tracking multiple objects.
-        return;
+        return NULL;
     }
 
     if (nextDiscretePosition_)
       // A previous move command is still pending execution.
-      return;
+      return NULL;
 
     // nextDiscretePosition_ will become the position at the next sampling period.
     lastCommandTime_ = now;
@@ -277,7 +278,10 @@ template<class O, class S> void TestMem<O, S>::eject(Code *command) {
       }
     }
     // Let onTimeTick inject the new position.
+    return command;
   }
+
+  return NULL;
 }
 
 template<class O, class S> void TestMem<O, S>::onTimeTick() {

--- a/AERA/test_mem.h
+++ b/AERA/test_mem.h
@@ -101,8 +101,13 @@ public:
 
   /**
    * Override eject to check for (cmd set_velocity_y ...) and other implemented commands.
+   * \param command The command from the Replicode (cmd ...).
+   * \return The given command if it is executed as-is, or a new command object of the command
+   * that is actually executed. The program controller will make a fact from the command and
+   * inject it as the efferent copy. However, if the command is not executed, then return NULL
+   * and the program controller will put an anti-fact of the command in the mk.rdx reduction.
    */
-  virtual void eject(r_code::Code *command);
+  virtual r_code::Code* eject(r_code::Code *command);
 
   /**
    * This is called when runInDiagnosticTime() updates the tickTime. Just call

--- a/r_exec/mem.cpp
+++ b/r_exec/mem.cpp
@@ -707,7 +707,7 @@ void _Mem::pushTimeJob(TimeJob *j) {
 void _Mem::eject(View *view, uint16 nodeID) {
 }
 
-void _Mem::eject(Code *command) {
+r_code::Code* _Mem::eject(Code *command) {
   // This is only for debugging
   /*
   uint16 function = (command->code(CMD_FUNCTION).atom_ >> 8) & 0x000000FF;
@@ -716,6 +716,7 @@ void _Mem::eject(Code *command) {
       //command->trace();
   }
   */
+  return NULL;
 }
 
 ////////////////////////////////////////////////////////////////

--- a/r_exec/mem.h
+++ b/r_exec/mem.h
@@ -547,9 +547,16 @@ public:
   // To be redefined by object transport aware subcalsses.
   virtual void eject(View *view, uint16 nodeID);
 
-  // From rMem to I/O device.
-  // To be redefined by object transport aware subcalsses.
-  virtual void eject(r_code::Code *command);
+  /**
+   * This is called by the program controller to eject a command from rMem to the 
+   * I/O device. This method should be redefined by object transport-aware subclasses.
+   * \param command The command from the Replicode (cmd ...).
+   * \return The given command if it is executed as-is, or a new command object of the command
+   * that is actually executed. The program controller will make a fact from the command and
+   * inject it as the efferent copy. However, if the command is not executed, then return NULL
+   * and the program controller will put an anti-fact of the command in the mk.rdx reduction.
+   */
+  virtual r_code::Code* eject(r_code::Code *command);
 
   virtual r_code::Code *_build_object(Atom head) const = 0;
   virtual r_code::Code *build_object(Atom head) const = 0;


### PR DESCRIPTION
This pull request addresses issue #123. We [update the eject method](https://github.com/IIIM-IS/replicode/blob/26874ba06668a8889657e5ea3fce6fa6a4bb5c51/r_exec/mem.h#L349-L357) to return either the given command object, a new command object with a different command that was actually executed, or NULL if no command was executed. Likewise, we update the override of the `eject` method in `TestMem` to [return the requested command](https://github.com/IIIM-IS/replicode/blob/26874ba06668a8889657e5ea3fce6fa6a4bb5c51/AERA/test_mem.cpp#L284) on success, or to [return NULL](https://github.com/IIIM-IS/replicode/blob/26874ba06668a8889657e5ea3fce6fa6a4bb5c51/AERA/test_mem.cpp#L279) if it cannot execute the command. (The use case in `TestMem` does not require a different command, so this is not shown at the moment.)

Finally, we update the program controller to [check the executedCommand](https://github.com/IIIM-IS/replicode/blob/26874ba06668a8889657e5ea3fce6fa6a4bb5c51/r_exec/pgm_overlay.cpp#L475-L490) returned from eject. If not NULL, it injects the efferent copy. If it is NULL, it places an AntiFact of the requested command in the program reduction which can be examined by other programs.