### PR TITLE
CSTOverlay: Also make an offspring before processing the last match

### DIFF
--- a/r_exec/cst_controller.cpp
+++ b/r_exec/cst_controller.cpp
@@ -285,10 +285,10 @@ bool CSTOverlay::reduce(View *input, CSTOverlay *&offspring) {
         bindings_ = bm;
         if (evaluate_fwd_guards()) { // may update bindings; full match.
 //std::cout<<Time::ToString_seconds(now-Utils::GetTimeReference())<<" full match\n";
+          offspring = new CSTOverlay(this);
           update(bm, (_Fact *)input->object_, bound_pattern);
           inject_production();
           invalidate();
-          offspring = NULL;
           store_evidence(input->object_, prediction, is_simulation);
           return true;
         } else {
@@ -300,10 +300,10 @@ bool CSTOverlay::reduce(View *input, CSTOverlay *&offspring) {
         }
       } else { // guards already evaluated, full match.
 //std::cout<<Time::ToString_seconds(now-Utils::GetTimeReference())<<" full match\n";
+        offspring = new CSTOverlay(this);
         update(bm, (_Fact *)input->object_, bound_pattern);
         if (inputs_.size() == original_patterns_size_) inject_production();
         invalidate();
-        offspring = NULL;
         store_evidence(input->object_, prediction, is_simulation);
         return true;
       }


### PR DESCRIPTION
For a new input fact, a reduction job is created for each CST controller to check if the input is part of the controller's composite state. The controller keeps a list of CSTOverlay objects, where each accumulates a different set of matching inputs. When the input matches the composite state, the controller makes an "offspring" copy of the current state of the CSTOverlay, then adds the input to the CSTOverlay. In this way, the list CSTOverlay objects represents all combinations of inputs which could match a composite state. Or at least it should. This mechanism seems to stop after one full set of facts is collected to instantiate the composite state once for the current frame, without allowing further combinations.

This pull request has two commits. The first commit fixes a bug in the [CSTOverlay copy constructor](https://github.com/IIIM-IS/replicode/blob/f77d3a53e11b8afd77f2a6477cd06170dbc89921/r_exec/cst_controller.cpp#L91-L99) which is used to create an offspring of the current overlay before adding the matched input. The copy constructor copies most members but not the list of `inputs_` . This means that only the original CSTOverlay will properly collect the inputs. In the testing we've done so far, this is usually the case, but we need the offspring CSTOverlay objects to properly collect the inputs. So, this commit updates the copy constructor to also copy  `inputs_` .

The second commit addresses the problem where a composite state is only instantiated once for each frame. When the last fact is added to the list of inputs, it creates an instantiated composite state, but [returns a NULL offspring](https://github.com/IIIM-IS/replicode/blob/f77d3a53e11b8afd77f2a6477cd06170dbc89921/r_exec/cst_controller.cpp#L305) (meaning that it didn't create an offspring). There may be another input which could be the last match of a different instantiation of the composite state, but there is no offspring ready for it. So, this commit updates the last match code to also return a new offspring (by calling the CSTOverlay copy constructor).