### PR TITLE
In CSTController, add abduce_simulated

### DIFF
--- a/r_exec/cst_controller.cpp
+++ b/r_exec/cst_controller.cpp
@@ -391,8 +391,12 @@ void CSTController::reduce(r_exec::View *input) {
 
         P<HLPBindingMap> bm = new HLPBindingMap(bindings_);
         bm->init_from_f_ihlp(goal_target);
-        if (evaluate_bwd_guards(bm)) // leaves the controller constant: no need to protect; bm may be updated.
-          abduce(bm, input->object_);
+        if (evaluate_bwd_guards(bm)) { // leaves the controller constant: no need to protect; bm may be updated.
+          if (goal->is_simulation())
+            abduce_simulated(bm, input->object_);
+          else
+            abduce(bm, input->object_);
+        }
       }
     }
     else {
@@ -453,6 +457,24 @@ void CSTController::reduce(r_exec::View *input) {
   }
 }
 
+void CSTController::abduce_simulated(HLPBindingMap *bm, Fact *f_super_goal) {
+  Goal *g = f_super_goal->get_goal();
+  _Fact *super_goal_target = g->get_target();
+  Fact* remade_f_icst = get_f_ihlp(bm, false);
+
+  for (auto o = overlays_.begin(); o != overlays_.end(); ++o) {
+    if (((CSTOverlay*)(*o))->is_simulated())
+      // Skip overlays that were produced during simulated forward chaining.
+      continue;
+
+    HLPBindingMap bm_copy(bm);
+    // TODO: this is inefficient. We want to merge (*o)->binding_ into bm_copy, but use an icst.
+    Fact* overlay_f_icst = get_f_ihlp(((HLPOverlay*)(*o))->bindings_, false);
+    if (bm_copy.match_object(overlay_f_icst->get_reference(0), remade_f_icst->get_reference(0)))
+      abduce(&bm_copy, f_super_goal);
+  }
+}
+
 void CSTController::abduce(HLPBindingMap *bm, Fact *f_super_goal) {
 
   Goal *g = f_super_goal->get_goal();
@@ -462,12 +484,17 @@ void CSTController::abduce(HLPBindingMap *bm, Fact *f_super_goal) {
   float32 confidence = super_goal_target->get_cfd();
 
   Sim *sim = g->get_sim();
+  Sim *sub_sim;
+  auto now = Now();
+  if (sim->get_mode() == SIM_ROOT)
+    sub_sim = new Sim(opposite ? SIM_MANDATORY : SIM_OPTIONAL, sim->get_thz(), f_super_goal, opposite, sim->root_, 1, sim->solution_controller_, sim->get_solution_cfd(), now + sim->get_thz());
+  else
+    sub_sim = new Sim(sim->get_mode(), sim->get_thz(), f_super_goal, opposite, sim->root_, 1, sim->solution_controller_, sim->get_solution_cfd(), sim->get_solution_before());
 
   Code *cst = get_unpacked_object();
   uint16 obj_set_index = cst->code(CST_OBJS).asIndex();
   uint16 obj_count = cst->code(obj_set_index).getAtomCount();
   Group *host = get_host();
-  auto now = Now();
   for (uint16 i = 1; i <= obj_count; ++i) {
 
     _Fact *pattern = (_Fact *)cst->get_reference(cst->code(obj_set_index + i).asIndex());
@@ -490,7 +517,7 @@ void CSTController::abduce(HLPBindingMap *bm, Fact *f_super_goal) {
         break;
       case MATCH_SUCCESS_NEGATIVE:
       case MATCH_FAILURE: // inject a sub-goal for the missing predicted positive evidence.
-        inject_goal(bm, f_super_goal, bound_pattern, sim, now, confidence, host); // all sub-goals share the same sim.
+        inject_goal(bm, f_super_goal, bound_pattern, sub_sim, now, confidence, host); // all sub-goals share the same sim.
         break;
       }
     }

--- a/r_exec/cst_controller.h
+++ b/r_exec/cst_controller.h
@@ -155,6 +155,14 @@ class CSTController :
 private:
   Group *secondary_host_;
 
+  /**
+   * For each of the overlays, make a copy of bm and merge it with the overlay's binding map, then call abduce() with the
+   * merged binding map and f_super_goal. In this way we make a branch of the simulation with each possible way of
+   * instantiating the cst.
+   * \param bm The binding map created by reduce.
+   * \param f_super_goal The super goal to pass to abduce().
+   */
+  void abduce_simulated(HLPBindingMap *bm, Fact *f_super_goal);
   void abduce(HLPBindingMap *bm, Fact *f_super_goal); // f_super_goal is f0->g->f1->icst or f0->g->|f1->icst.
   void inject_goal(HLPBindingMap *bm,
     Fact *f_super_goal, // f0->g->f1->icst or f0->g->|f1->icst.


### PR DESCRIPTION
When we are backward chaining from an icst for a particular composite state, the controller for that composite state treats it as if it is a RHS and abduces a subgoal for each of the composite state members. But the [abduce method](https://github.com/IIIM-IS/replicode/blob/f1dce04bf058704cdd210a4fea5ce56127e9b58b/r_exec/cst_controller.cpp#L422) treats each member individually. Suppose we have the composite state `C` where an object `H` has the same position_x and position_y:

    C:(cst |[] []
       (fact (mk.val H: position_x V:) : :)
       (fact (mk.val H: position_y V:) : :)

And suppose we have a goal for the fact `(icst C |[] [h :])` which is a goal for object `h` to have the same position_x and position_y. Right now, it would only abduce the goals for `(mk.val h position_x V:)` and `(mk.val h position_y V:)`, which doesn't help very much.

But suppose that the system already has the (non-simulated) fact `(mk.val h position_x 1)`. We would want a version of the composite state where this is already matched and `V:` is bound to 1. Fortunately, this binding already exists because the controller keeps a list of overlays with all possible combinations of existing facts, which it uses to instantiate a (non-simulated) composite state when all members are matched. But we can use this list of overlays during abduction.

This pull request updates the composite state controller to add a new method `abduce_simulated` which takes a simulated goal for a fact like `(icst C |[] [h :])` and tries to match it against each of the overlays. If it matches then it calls the existing `abduce` method with the updated binding map from the match. In the example above, V: is bound to 1, because there was an overlay which matched the first member with the fact `(mk.val h position_x 1)`. Using the updated map, `abduce` would create a sub-goal for the fact `(mk.val h position_y 1)` as desired.

Another detail: Each overlay represents a different internally-consistent combination of bindings. But one combination of bindings may be inconsistent with another. Therefore, the `abduce` method is updated to [create a new simulation object](https://github.com/IIIM-IS/replicode/blob/56f1d149b204b1b4a23ac6e7124cdfbc8bbad79d/r_exec/cst_controller.cpp#L454-L457) (a new branch of the simulated backward chaining) and attach this same simulation object to the subgoals for each member. Each time that `abduce_simulated` uses an overlay to call `abduce`, it creates a different simulation branch.