### PR TITLE
If the input goal matches a member, make a goal icst from it

### DIFF
--- a/r_exec/cst_controller.cpp
+++ b/r_exec/cst_controller.cpp
@@ -391,6 +391,32 @@ void CSTController::reduce(r_exec::View *input) {
           abduce(bm, input->object_);
       }
     }
+    else {
+      // Make an icst by matching a single member, then make it a goal to instantiate it. This will
+      // propagate bindings to other members of the composite state and make subgoals from them..
+      // Imitate CSTOverlay::reduce.
+      CSTOverlay overlay(this, bindings_);
+      overlay.load_patterns();
+      P<HLPBindingMap> bm = new HLPBindingMap();
+      _Fact *bound_pattern = overlay.bindPattern(goal_target, bm, NULL);
+      if (bound_pattern) {
+        // The match has filled in the binding map. Make an icst from it and inject it as a goal.
+        // TODO: Call load_code (if needed) and evaluate backward guards.
+        std::vector<P<_Fact> > empty_inputs;
+        Fact *f_icst = get_f_icst(bm, &empty_inputs);
+        Sim* sim = goal->get_sim();
+        Sim* sub_sim;
+        bool opposite = goal->get_target()->is_anti_fact();
+        if (sim->get_mode() == SIM_ROOT)
+          sub_sim = new Sim(opposite ? SIM_MANDATORY : SIM_OPTIONAL, sim->get_thz(), input->object_, opposite, sim->root_, 1,
+            sim->solution_controller_, sim->get_solution_cfd(), Timestamp(seconds(0)));
+        else
+          sub_sim = new Sim(sim->get_mode(), sim->get_thz(), input->object_, opposite, sim->root_, 1,
+            sim->solution_controller_, sim->get_solution_cfd(), sim->get_solution_before());
+
+        inject_goal(bm, input->object_, f_icst, sub_sim, Now(), goal->get_target()->get_cfd(), get_host());
+      }
+    }
   } else {
     // std::cout<<"CTRL: "<<get_host()->get_oid()<<" > "<<input->object->get_oid()<<std::endl;
     bool match = false;


### PR DESCRIPTION
Consider the composite state `C`:

    C:(cst |[] []
       (fact (mk.val H: position P:) : :)
       (fact (mk.val H: attached s) : :)

And suppose the simulator has made the goal `(mk.val h position 10)`. To achieve the goal, it may be necessary to achieve facts with related values in the composite state `C`. In this case, it may be necessary to achieve `(mk.val h attached s)`. In other words, a way to achieve a goal which matches a member of a composite state is to achieve instantiating the composite state. Note that we need values of bound variables to propagate to the goals for other members, in this case the binding of `H:` to 'h' from `(mk.val H: position P:) ` to `(mk.val H: attached s)`.

Currently, the composite state controller will only process a goal to instantiate the composite state (by making subgoals for each member). This pull request update `CSTController::reduce` to also check if a goal matches a member. If it does, then it injects a goal for the icst where the variables have been bound by the match. In the example above, it injects a goal to achieve `(icst C |[] [h 10])`. This will then be processed as usual by the composite state controller to make subgoals for each member. Note that it will not make a subgoal to achieve the original fact because this goal is already registered (see pull request #108) in the simulator and will not be injected again due to pull request #108. (So, this will not cause a loop.)