### PR TITLE
In retrieve_simulated_imdl_fwd, ignore wr_enabled when matching

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -411,6 +411,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(HLPBindingMap *bm, Fac
     return NO_REQUIREMENT;
   ChainingStatus r;
   HLPBindingMap original(bm);
+  bool save_f_imdl_wr_enabled = f_imdl->get_reference(0)->code(I_HLP_WEAK_REQUIREMENT_ENABLED).asBoolean();
   if (!sr_count) { // no strong req., some weak req.: true if there is one f->imdl complying with timings and bindings.
 
     r = WEAK_REQUIREMENT_DISABLED;
@@ -429,6 +430,9 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(HLPBindingMap *bm, Fac
           //_f_imdl->get_reference(0)->trace();
           //f_imdl->get_reference(0)->trace();
           HLPBindingMap _original = original; // matching updates the bm; always start afresh.
+          // Temporarily make f_imdl wr_enabled match the one from _f_imdl so that any difference is ignored.
+          f_imdl->get_reference(0)->code(I_HLP_WEAK_REQUIREMENT_ENABLED) = Atom::Boolean(
+            _f_imdl->get_reference(0)->code(I_HLP_WEAK_REQUIREMENT_ENABLED).asBoolean());
           if (_original.match_fwd_strict(_f_imdl, f_imdl)) { // tpl args will be valuated in bm, but not in f_imdl yet.
 
             r = WEAK_REQUIREMENT_ENABLED;
@@ -441,6 +445,8 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(HLPBindingMap *bm, Fac
     }
 
     requirements_.CS.leave();
+    // Restore.
+    f_imdl->get_reference(0)->code(I_HLP_WEAK_REQUIREMENT_ENABLED) = Atom::Boolean(save_f_imdl_wr_enabled);
     return r;
   } else {
 


### PR DESCRIPTION
Some code in the simulator [modifies the "weak requirement (wr) enabled" flag](https://github.com/IIIM-IS/replicode/blob/5794c30b1bf7daea0ecc94c7e81e4456e258138c/r_exec/mdl_controller.cpp#L1908) of shared imdl objects. These need to be [matched with simulated imdl requirements](https://github.com/IIIM-IS/replicode/blob/5794c30b1bf7daea0ecc94c7e81e4456e258138c/r_exec/mdl_controller.cpp#L432). The call to `match_fwd_strict` will fail if the `wr_enabled` flag is different in the two imdl objects. I still don't understand the role of the `wr_enabled` flag, but it is clear that the code is modifying a flag of an object which is shared among different simulation paths. Maybe in one simulation path it is meaning for the object to be "weak requirement enabled" but maybe not in the other path.

My testing suggests that modifying shared objects causes unexpected behavior in the simulator, and it is possible that the `wr-enabled` mechanism is not fully implemented for use in the simulator. As a temporary measure, this pull request changes `retrieve_simulated_imdl_fwd` so that it ignores the `wr_enabled` flag when matching two imdl objects. (It does this by setting them to be the same during the matching, and then restoring them.) My testing shows that this gives more consistent and reliable behavior of the simulator (maybe only in the limited conditions in which we are testing it now).

When we better understand the role of the `wr_enabled` flag, we can revert this change and implement in a more detailed way.