### PR TITLE
In CSTOverlay, only copy a Sim from the prediction if it has a new Sim root

### DIFF
--- a/r_exec/cst_controller.cpp
+++ b/r_exec/cst_controller.cpp
@@ -201,8 +201,12 @@ void CSTOverlay::update(HLPBindingMap *map, _Fact *input, _Fact *bound_pattern) 
     last_cfd = prediction->get_target()->get_cfd();
     if (prediction->is_simulation()) {
 
-      for (uint16 i = 0; i < prediction->get_simulations_size(); ++i)
-        simulations_.insert(prediction->get_simulation(i));
+      for (uint16 i = 0; i < prediction->get_simulations_size(); ++i) {
+        auto predictionSimulation = prediction->get_simulation(i);
+        if (!get_simulation(predictionSimulation->getRootSim()->root_))
+          // The simulations_ does not have a Sim with the same root_, so add.
+          simulations_.insert(predictionSimulation);
+      }
     } else
       predictions_.insert(input);
   } else


### PR DESCRIPTION
Background: Each `Sim` (simulation) object in a chain of `Sim` objects has a pointer to the "root", which is the model with the drive which started the simulation. (At any time, there can be multiple drives that produce active goals and predictions with attached `Sim` objects, so the pointer to the "root" is necessary to keep the simulations for the different drives separate.) A prediction can have multiple `Sim` objects attached, but each `Sim` object should have a different "root". This is clear from the prediction [get_simulation method](https://github.com/IIIM-IS/replicode/blob/c366e0e13895a4e07c592fc59698b752bbbd7d6a/r_exec/factory.h#L372-L377) where the argument is the "root" to search for and the return value is the _one_ `Sim` for the "root" in the prediction's list of `Sim` objects.

More background: A `CSTOverlay` (composite state overlay) is used to accumulate facts which match members of the composite state, including facts from simulated predictions. When a fact from a simulated prediction is stored, the prediction's `Sim` object is separately stored in the `CSTOverlay`'s list of `Sim` objects. Finally, when all members of the composite state are matched, the `CSTOverlay` is used to inject a predicted instantiated composite state (`icst`), and the `CSTOverlay`'s list of `Sim` objects is[ copied to the prediction](https://github.com/IIIM-IS/replicode/blob/30eb530f733c8f928cb7f57b450cc630821eccec/r_exec/cst_controller.cpp#L173-L174). As mentioned, a prediction's list of `Sim` objects should only have one `Sim` object for each "root", therefore the `CSTOverlay`'s list of `Sim` objects should also only have one `Sim` object for each "root".

The problem is that the `CSTOverlay`'s [code to store the prediction's Sim object](https://github.com/IIIM-IS/replicode/blob/30eb530f733c8f928cb7f57b450cc630821eccec/r_exec/cst_controller.cpp#L204-L205) in the `CSTOverlay`'s list of `Sim` objects, stores every `Sim` object without checking the "root". Different predictions can have different `Sim` objects, and when their facts match members of the composite state, their different 'Sim' objects are all added to the  `CSTOverlay`'s list of `Sim` objects, even if they have the same "root". This pull request updates the code to only add a 'Sim' object from a prediction if it has a "root" which is not the same as the "root" of a `Sim` object that is already in the `CSTOverlay`'s list of `Sim` objects.