### PR TITLE
In CSTOverlay, update the timings from a simulated prediction

### DIFF
--- a/r_exec/cst_controller.cpp
+++ b/r_exec/cst_controller.cpp
@@ -265,10 +265,14 @@ bool CSTOverlay::reduce(View *input, CSTOverlay *&offspring) {
   _Fact *input_object;
   Pred *prediction = ((_Fact *)input->object_)->get_pred();
   bool is_simulation;
+  Sim* predictionSimulation = NULL;
   if (prediction) {
 
     input_object = prediction->get_target(); // input_object is f1 as in f0->pred->f1->object.
     is_simulation = prediction->is_simulation();
+    // TODO: Handle a prediction with multiple simulations for different roots.
+    if (prediction->get_simulations_size() == 1)
+      predictionSimulation = prediction->get_simulation((uint16)0);
   } else {
 
     input_object = (_Fact *)input->object_;
@@ -276,7 +280,7 @@ bool CSTOverlay::reduce(View *input, CSTOverlay *&offspring) {
   }
 
   P<HLPBindingMap> bm = new HLPBindingMap();
-  _Fact *bound_pattern = bindPattern(input_object, bm);
+  _Fact *bound_pattern = bindPattern(input_object, bm, predictionSimulation);
   if (bound_pattern) {
     //if(match_deadline.time_since_epoch().count() == 0){
     // std::cout<<Time::ToString_seconds(now-Utils::GetTimeReference())<<" "<<std::hex<<this<<std::dec<<" (0) ";
@@ -323,13 +327,39 @@ bool CSTOverlay::reduce(View *input, CSTOverlay *&offspring) {
     return false;
 }
 
-_Fact* CSTOverlay::bindPattern(_Fact *input, HLPBindingMap* map)
+_Fact* CSTOverlay::bindPattern(_Fact *input, HLPBindingMap* map, Sim* predictionSimulation)
 {
+  bool use_input_timings = (inputs_.size() == 0);
+  if (predictionSimulation) {
+    if (simulations_.size() > 1)
+      // TODO: Handle the case where simulations_ has multiple simulation roots.
+      return NULL;
+    if (simulations_.size() == 1) {
+      if (*simulations_.begin() != predictionSimulation)
+        // This overlay is for a simulation, but for a different simulation than the input predictionSimulation.
+        return NULL;
+    }
+
+    if (inputs_.size() > 0) {
+      // This overlay's binding map forward timings have been set.
+      if (input->get_after() < bindings_->get_fwd_before() &&
+        input->get_before() > bindings_->get_fwd_after()) {
+        // The timings overlap, so let match_fwd_strict update the map from the input timings.
+      }
+      else if (input->get_before() <= bindings_->get_fwd_after())
+        // The input is earlier than the facts in this overlay, so don't match.
+        return NULL;
+      else
+        // The input is later than the facts in this overlay, so use the input timings.
+        use_input_timings = true;
+    }
+  }
+
   r_code::list<P<_Fact> >::const_iterator p;
   for (p = patterns_.begin(); p != patterns_.end(); ++p) {
 
     map->load(bindings_);
-    if (inputs_.size() == 0)
+    if (use_input_timings)
       map->reset_fwd_timings(input);
     if (map->match_fwd_strict(input, *p))
       return *p;

--- a/r_exec/cst_controller.h
+++ b/r_exec/cst_controller.h
@@ -152,9 +152,12 @@ public:
    * \param input The input _Fact to match against a pattern.
    * \param map The binding map for calling match_fwd_strict and has the bindings
    * if this returns a pattern.
+   * \param predictionSimulation If not NULL, then ensure that its simulation root matches the root
+   * of the simulation in this object's simulations_. Also use the timings from input to update the
+   * timing variables of this CSTOverlay.
    * \return The matching pattern from patterns_, or NULL if not found.
    */
-  _Fact* CSTOverlay::bindPattern(_Fact *input, HLPBindingMap* map);
+  _Fact* CSTOverlay::bindPattern(_Fact *input, HLPBindingMap* map, Sim* predictionSimulation);
 };
 
 // Backward chaining:


### PR DESCRIPTION
This pull request is replaced by #185 .
This pull request was to replace pull request #112 .

This pull request implements [this proposal](https://github.com/IIIM-IS/replicode/issues/97#issuecomment-760197291) to get predicted facts for all members of a simulated instantiated composite state, by updating `CSTOverlay::bindPattern` to[ add the param predictionSimulation](https://github.com/IIIM-IS/replicode/blob/35a2dc9374dec8ae732719416f132119348bc00c/r_exec/cst_controller.h#L140-L142).