### PR TITLE
In retrieve_simulated_imdl_fwd, use match_fwd.

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -556,7 +556,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(HLPBindingMap *bm, Fac
             _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
             HLPBindingMap _original = original; // matching updates the bm; always start afresh.
             TemplateTimingsUpdater timingsUpdater(_f_imdl, f_imdl, &_original);
-            if (_original.match_bwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE) { // tpl args will be valuated in bm.
+            if (_original.match_fwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE) { // tpl args will be valuated in bm.
 
               bm->load(&_original);
               requirements_.CS.leave();
@@ -587,7 +587,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(HLPBindingMap *bm, Fac
             _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
             HLPBindingMap _original = original; // matching updates the bm; always start afresh.
             TemplateTimingsUpdater timingsUpdater(_f_imdl, f_imdl, &_original);
-            if (_original.match_bwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE) {
+            if (_original.match_fwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE) {
 
               negative_cfd = (*e).confidence_;
               r = STRONG_REQUIREMENT_DISABLED_NO_WEAK_REQUIREMENT;
@@ -611,7 +611,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(HLPBindingMap *bm, Fac
             _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
             HLPBindingMap _original = original; // matching updates the bm; always start afresh.
             TemplateTimingsUpdater timingsUpdater(_f_imdl, f_imdl, &_original);
-            if (_original.match_bwd_strict(_f_imdl, f_imdl)) {
+            if (_original.match_fwd_strict(_f_imdl, f_imdl)) {
 
               if ((*e).confidence_ >= negative_cfd) {
 


### PR DESCRIPTION
For background on matching in the "retrieve imdl" methods, see pull request #96.
The method `retrieve_imdl_fwd` already uses [match_fwd](https://github.com/IIIM-IS/replicode/blob/fb31c3b63e42b07b187930885fd82cb2c3c60b2e/r_exec/mdl_controller.cpp#L764). The method `retrieve_simulated_imdl_fwd` has the same logic, but used for a simulated input. However, it currently uses [match_bwd](https://github.com/IIIM-IS/replicode/blob/fb31c3b63e42b07b187930885fd82cb2c3c60b2e/r_exec/mdl_controller.cpp#L470). 

This pull request changes `retrieve_simulated_imdl_fwd`  to use `match_fwd`, like `retrieve_imdl_fwd` . I assume this was a copy/paste error in the original. This has come up now that we are testing simulated inputs. (I had noticed this earlier, but wanted to wait until we had use cases which used this code.)