### PR TITLE
Store the requirement before signaling the monitors

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1383,6 +1383,11 @@ void PrimaryMDLController::store_requirement(_Fact *f_p_f_imdl, MDLController *c
   Code *mdl = f_imdl->get_reference(0);
   RequirementEntry e(f_p_f_imdl, controller, chaining_was_allowed);
   if (f_imdl->is_fact()) { // in case of a positive requirement tell monitors they can check for chaining again.
+    // Store the requirement before signaling the monitor so that its target will match the requirement.
+    if (is_simulation)
+      _store_requirement(&simulated_requirements_.positive_evidences, e);
+    else
+      _store_requirement(&requirements_.positive_evidences, e);
 
     r_code::list<P<_GMonitor> >::const_iterator m;
     g_monitorsCS_.enter();
@@ -1403,10 +1408,6 @@ void PrimaryMDLController::store_requirement(_Fact *f_p_f_imdl, MDLController *c
     }
     g_monitorsCS_.leave();
 
-    if (is_simulation)
-      _store_requirement(&simulated_requirements_.positive_evidences, e);
-    else
-      _store_requirement(&requirements_.positive_evidences, e);
     reduce_cache<PrimaryMDLController>((Fact *)f_p_f_imdl, controller);
   } else if (!is_simulation)
     _store_requirement(&requirements_.negative_evidences, e);


### PR DESCRIPTION
Background: In non-simulated operation, a composite state (made from current facts) matches the LHS of a prerequisite model which predicts the RHS which is a (fact (imdl ...)) . This predicted imdl is called a "requirement" and the method `store_requirement` is called to store it in the target model's requirements. In non-simulated operation, this requirement remains there until target model's LHS is triggered (usually a command). The requirement is used in forward chaining to carry forward the bindings from the original composite state.

(More background.) But in simulation, the target model's LHS is not triggered by executing a command. Instead the target model is first reached in simulated backward chaining when a goal matches its RHS. Instead of doing abduction to the LHS (command), AERA creates a goal to instantiate the model with the goal requirements. This goal imdl is [stored in an SRMonitor](https://github.com/IIIM-IS/replicode/blob/10546a0082e475f581b8ad614bc4b7484665f47f/r_exec/mdl_controller.cpp#L1907) (simulated requirement monitor) and simulated backward chaining proceeds. Eventually, forward simulation creates a simulated composite state which matches the LHS of the prerequisite model, which makes a simulated prediction of the RHS (a simulated requirement). As in non-simulation, `store_requirement` is called to store the simulated requirement in the target model's requirements. In addition, `store_requirement` [iterates through all the requirement monitors](https://github.com/IIIM-IS/replicode/blob/10546a0082e475f581b8ad614bc4b7484665f47f/r_exec/mdl_controller.cpp#L1394-L1408) and calls 'signal' for each one. This lets the requirement monitor match the simulated requirement (from forward chaining) to the stored requirement from backward chaining, which triggers the model to fire as if its LHS were executed.

The problem is that the original code of `store_requirement` stores the requirement after iterating through the requirement monitors. Therefore the requirement is not available to be matched by the requirement monitor's `signal` method. This pull request updates `store_requirement` to store the requirement before iterating though the requirement monitors.