### PR TITLE
In predict, inject a simulated predicted imdl

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1550,6 +1550,12 @@ void PrimaryMDLController::predict(HLPBindingMap *bm, _Fact *input, Fact *f_imdl
     HLPController::inject_prediction(production, confidence); // inject a simulated prediction in the primary group.
     OUTPUT_LINE(MDL_OUT, Utils::RelativeTime(Now()) << " mdl " << getObject()->get_oid() << ": fact " <<
       input->get_oid() << " pred -> fact " << production->get_oid() << " simulated pred");
+
+    if (is_cmd()) {
+      // Inject the predicted imdl, in case other models are reusing this model.
+      Fact *f_pred_f_imdl = new Fact(new Pred(f_imdl, prediction, 1), now, now, 1, 1);
+      HLPController::inject_prediction(f_pred_f_imdl, confidence);
+    }
   }
 }
 


### PR DESCRIPTION
Background: A "reuse" (or "post-condition") model has an imdl on the LHS which refers to another model. When the other model makes a prediction for its RHS, it also [injects](https://github.com/IIIM-IS/replicode/blob/dc3ba3e28d9ffa62485cc9260314c5b13b48b93f/r_exec/mdl_controller.cpp#L1515-L1516) a `(fact (imdl ...))` to indicated that it fired. This is matched with the LHS of the "reuse" model so that it can also predict its own RHS. But injecting the `(fact (imdl ...))` is [only done for non-simulation](https://github.com/IIIM-IS/replicode/blob/dc3ba3e28d9ffa62485cc9260314c5b13b48b93f/r_exec/mdl_controller.cpp#L1500).

We also want this in simulation, but when I changed the code, the predicted `(fact (imdl ...))` improperly matched some of the imdl requirements which were stored during backward chaining. Pull request #151 fixes the bug for storing a simulated forward requirement (predicted imdl) and signaling it to match a stored requirement from backward chaining. Now model controller properly removes only the needed requirement, and there is no interference from injecting a simulated predicted `(fact (imdl ...))`.

This pull request updates `PrimaryMDLController::predict` so that when a model injects a predicted RHS during simulation, it also injects the predicted `(fact (imdl ...))`. We limit this to the case where the model has a cmd on the LHS. (We don't want to inject predicted `(fact (imdl ...))` when every type of model fires since this is unnecessary and could cause a combinatorial increase in computation during simulation.) With this fix, now a "reuse" model will be caused to fire properly during simulation.