### PR TITLE
Don't make a goal icst from a single member

### DIFF
--- a/r_exec/cst_controller.cpp
+++ b/r_exec/cst_controller.cpp
@@ -397,32 +397,6 @@ void CSTController::reduce(r_exec::View *input) {
           abduce(bm, input->object_);
       }
     }
-    else {
-      // Make an icst by matching a single member, then make it a goal to instantiate it. This will
-      // propagate bindings to other members of the composite state and make subgoals from them..
-      // Imitate CSTOverlay::reduce.
-      CSTOverlay overlay(this, bindings_);
-      overlay.load_patterns();
-      P<HLPBindingMap> bm = new HLPBindingMap();
-      _Fact *bound_pattern = overlay.bindPattern(goal_target, bm);
-      if (bound_pattern) {
-        // The match has filled in the binding map. Make an icst from it and inject it as a goal.
-        // TODO: Call load_code (if needed) and evaluate backward guards.
-        std::vector<P<_Fact> > empty_inputs;
-        Fact *f_icst = get_f_icst(bm, &empty_inputs);
-        Sim* sim = goal->get_sim();
-        Sim* sub_sim;
-        bool opposite = goal->get_target()->is_anti_fact();
-        if (sim->get_mode() == SIM_ROOT)
-          sub_sim = new Sim(opposite ? SIM_MANDATORY : SIM_OPTIONAL, sim->get_thz(), input->object_, opposite, sim->root_, 1,
-            sim->solution_controller_, sim->get_solution_cfd(), Timestamp(seconds(0)));
-        else
-          sub_sim = new Sim(sim->get_mode(), sim->get_thz(), input->object_, opposite, sim->root_, 1,
-            sim->solution_controller_, sim->get_solution_cfd(), sim->get_solution_before());
-
-        inject_goal(bm, input->object_, f_icst, sub_sim, Now(), goal->get_target()->get_cfd(), get_host());
-      }
-    }
   } else {
     // std::cout<<"CTRL: "<<get_host()->get_oid()<<" > "<<input->object->get_oid()<<std::endl;
     bool match = false;


### PR DESCRIPTION
Pull request #131 updated the behavior for backward chaining through a composite state, so that if there is a goal which matches a member of the composite state, then it makes a goal to instantiate the composite state (which will then make a goal from the other members). This was proposed because the hand-grab-sphere example has a drive with the goal `(mk.val s position 15)` . This matches the RHS of a "reuse" model which needs to make a goal from its LHS which is a `(fact (imdl ...))` . As explained in pull request #153, there were bugs working with "reuse" models in simulation. Since this wasn't working, we noticed that the drive goal also matched a member of a composite state, and making a goal to instantiate it caused simulated backward chaining to eventually make a goal to use the same model which was used by the LHS of the "reuse" model.

But now that simulation properly does backward chaining through a "reuse" model, we don't need the fix in pull request #131. Furthermore, injecting so many more goals to instantiate composite states causes a big increase in processing during simulation. The hand-grab-sphere example works without the change in pull request #131. After releasing the cube and grabbing the sphere, it injects the command to move to the goal position as fact 481 at reduction job 7246. (This roughly means it injected 481 objects and did 7256 computational steps.) But when the change from pull request #131 is enabled, the command to move to goal position is fact 1751 at reduction job 34955. This means it injected 3.6 times as many objects and did 4.8 times as many computational steps to process all those extra goals to instantiate composite states, which were not needed to achieve the drive goal.

This pull request reverts the change in pull request #131.