### PR TITLE
Don't abduce from anti-fact imdl

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1626,7 +1626,7 @@ void PrimaryMDLController::reduce(r_exec::View *input) { // no lock.
       abduce(bm, (Fact *)input->object_, opposite, confidence);
       break;
     default: // no match; however, goal_target may be f->imdl, i.e. case of a reuse of the model, i.e. the goal is for the model to make a prediction: this translates into making a sub-goal from the lhs.
-      if (!goal->is_requirement()) { // models like imdl -> |rhs or |imdl -> rhs are not allowed.
+      if (!goal->is_requirement() && goal_target->is_fact()) { // models like imdl -> |rhs or |imdl -> rhs are not allowed.
 
         Code *imdl = goal_target->get_reference(0);
         if (imdl->code(0).asOpcode() == Opcodes::IMdl && imdl->get_reference(0) == getObject()) { // in that case, get the bm from the imdl, ignore the bwd guards, bind the rhs and inject.


### PR DESCRIPTION
In `PrimaryMDLController::reduce`, [this section](https://github.com/IIIM-IS/replicode/blob/051ed93197a152ae5604e95497d1faceca5c6a44/r_exec/mdl_controller.cpp#L1629-L1640) is used during backward chaining when the input goal is an imdl but does not match the RHS. The comment says "models like imdl -> |rhs or |imdl -> rhs are not allowed" but the if statement was not preventing a goal with an anti-fact. This pull request updates the if statement to make sure the goal is a fact (not an anti-fact) like the comment says.