### PR TITLE
In retrieve_imdl_bwd, etc., choose strong requirement if equal confidence to weak requirement

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -586,7 +586,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(HLPBindingMap *bm, Fac
             timingsUpdater.setTimings(_f_imdl);
             if (_original.match_bwd_strict(_f_imdl, f_imdl)) {
 
-              if ((*e).confidence_ >= negative_cfd) {
+              if ((*e).confidence_ > negative_cfd) {
 
                 r = WEAK_REQUIREMENT_ENABLED;
                 bm->load(&_original);
@@ -728,7 +728,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_bwd(HLPBindingMap *bm, Fac
             // Use match_fwd because the f_imdl time interval matches the binding map's fwd_after and fwd_before from the model LHS.
             if (_original.match_fwd_strict(_f_imdl, f_imdl)) {
 
-              if ((*e).confidence_ >= negative_cfd) {
+              if ((*e).confidence_ > negative_cfd) {
 
                 r = WEAK_REQUIREMENT_ENABLED;
                 bm->load(&_original);
@@ -887,7 +887,7 @@ ChainingStatus MDLController::retrieve_imdl_fwd(HLPBindingMap *bm, Fact *f_imdl,
 
         requirements_.CS.leave();
         float32 confidence = ground->get_pred()->get_target()->get_cfd();
-        if (confidence >= negative_cfd) {
+        if (confidence > negative_cfd) {
 
           r = WEAK_REQUIREMENT_ENABLED;
           r_p.first.controllers.push_back(req_controller);
@@ -910,7 +910,7 @@ ChainingStatus MDLController::retrieve_imdl_fwd(HLPBindingMap *bm, Fact *f_imdl,
 
             if (r != WEAK_REQUIREMENT_ENABLED && (*e).chaining_was_allowed_) { // first siginificant match.
 
-              if ((*e).confidence_ >= negative_cfd) {
+              if ((*e).confidence_ > negative_cfd) {
 
                 r = WEAK_REQUIREMENT_ENABLED;
                 ground = (*e).evidence_;
@@ -1048,7 +1048,7 @@ ChainingStatus MDLController::retrieve_imdl_bwd(HLPBindingMap *bm, Fact *f_imdl,
           // Use match_fwd because the f_imdl time interval matches the binding map's fwd_after and fwd_before from the model LHS.
           if (_original.match_fwd_strict(_f_imdl, f_imdl)) {
 
-            if ((*e).confidence_ >= negative_cfd) {
+            if ((*e).confidence_ > negative_cfd) {
 
               r = WEAK_REQUIREMENT_ENABLED;
               ground = (*e).evidence_;


### PR DESCRIPTION
Background: The methods `retrieve_imdl_bwd`, etc. are used to match a proposed imdl against the stored strong and weak requirements. A weak requirement has the form `(fact (imdl ...))`. A strong requirement uses an anti-fact and has the form `(|fact (imdl ...))`. The method `retrieve_imdl_bwd` has different logic depending on whether there can be no matching requirements, only weak requirements, only strong requirements or both weak and strong. In the case where there are both, the method first matches the strong requirement and sets `negative_cfd` to the confidence of the strong requirement (called "negative" because of the anti-fact). Then it searches for matching weak requirements and will let it override the strong requirement if its [confidence is greater than negative_cfd](https://github.com/IIIM-IS/replicode/blob/master/r_exec/mdl_controller.cpp#L1051).

    if ((*e).confidence_ >= negative_cfd)

Notice that this uses `>=`. So what happens if the weak and strong requirements have the same confidence? (This is usually the case since the confidence is usually 1.) In this case, the weak requirement will override the strong requirement. This does not seem correct. The strong requirement comes from a model that was created from a prediction failure. It should have precedence if it has the same confidence as the observation of a prediction success.

This pull request updates the methods `retrieve_imdl_bwd`, etc. so that the comparison uses '>' instead of '>=' so that if a weak and strong requirement have the same confidence then the weak requirement will not override the strong requirement.
