### PR TITLE
In AutoFocusController for pass_through, save in cross_buffer_ if ptpx_on.

### DIFF
--- a/r_exec/auto_focus.cpp
+++ b/r_exec/auto_focus.cpp
@@ -381,8 +381,23 @@ void AutoFocusController::reduce(r_exec::View *input) {
 
         if (pass_through_) {
 
+          View* primary_view = NULL;
           if (opcode != Opcodes::ICst) // don't inject again (since it comes from inside).
-            inject_input(input);
+            primary_view = inject_input(input);
+
+          if (ptpx_on_) {
+            // The PTPX may need the input. Save it in cross_buffer_ up to tpx_time_horizon.
+            if (opcode == Opcodes::ICst) {
+              P<BindingMap> bm = ((ICST *)payload)->bindings_;
+              _Fact *abstract_f_ihlp = bm->abstract_f_ihlp((_Fact *)input_object);
+              cross_buffer_.push_back(Input(input, abstract_f_ihlp, bm));
+            }
+            else {
+              P<BindingMap> bm = new BindingMap();
+              P<_Fact> abstract_input = (_Fact *)bm->abstract_object(input_object, false);
+              cross_buffer_.push_back(Input(primary_view, abstract_input, bm));
+            }
+          }
         } else {
 
           P<BindingMap> bm = new BindingMap();


### PR DESCRIPTION
Background: The auto-focus controller has parameters [pass_through and ptpx_on](https://github.com/IIIM-IS/replicode/blob/d6b19c310bb3cb31e77c21771291ec8ae9e8d758/AERA/replicode_v1.2/std.replicode#L177). If `pass_through` is true, all inputs are passed to the other controllers (instead of using an auto-focus algorithm to only pass inputs that are relevant to active goals, etc.) If `ptpx_on` is true, the PTPX controller (prediction targeted pattern extraction) is notified on a prediction failure and the controller analyzes recent inputs to find a pattern which explains the failure. The auto-focus controller is supposed to save inputs in `cross_buffer_`, which is a time-limited buffer. Currently, the auto-focus controller only saves inputs in `cross_buffer_` if `pass_through` is false. (This was perhaps a design decision to conserver memory, since if `pass_through` is true then lots of memory could be used to save many inputs.) So, when `pass_through` is true, inputs are not saved in  `cross_buffer_` and the PTPX controller doesn't do anything. But we want to experiment with PTPX independent of testing the auto-focus input selection algorithm which activates when `pass_through` is false.

This pull request updates the auto-focus controller so that if `pass_through` is true and  `ptpx_on` is also true, then each input is also saved in  `cross_buffer_` (and PTPX will function). In the near-term, we don't expect problems with too much memory usage. If memory is a concern, note that  `cross_buffer_` is time-limited and inputs are removed after [tpx_time_horizon](https://github.com/IIIM-IS/replicode/blob/6b7d1a80f2693e72137859152b3993c923b3c6ae/AERA/settings.xml#L26) . It is also possible to set `ptpx_on` false if it is not needed. And finally, it is possible to set `pass_through` false if the auto-focus algorithm saves the correct kinds of inputs in  `cross_buffer_` that the PTPX controller needs.

