### PR TITLE
PTPX: Allow the input timing start to equal the consequent start

### DIFF
--- a/r_exec/pattern_extractor.cpp
+++ b/r_exec/pattern_extractor.cpp
@@ -666,7 +666,7 @@ void PTPX::reduce(r_exec::View *input) {
     if (i->input_->code(0).asOpcode() == Opcodes::Cmd) // no cmds as req lhs (because no bwd-operational); prefer: cmd->effect, effect->imdl.
       i = inputs_.erase(i);
     else if (!end_bm->intersect(i->bindings_) || // discard inputs that do not share values with the consequent.
-             i->input_->get_after() >= consequent->get_after()) // discard inputs not younger than the consequent.
+             i->input_->get_after() > consequent->get_after()) // discard inputs that started after the consequent started.
       i = inputs_.erase(i);
     else
       ++i;
@@ -690,7 +690,12 @@ void PTPX::reduce(r_exec::View *input) {
     period = duration_cast<microseconds>(consequent->get_after() - cause.input_->get_after());
     lhs_duration = duration_cast<microseconds>(cause.input_->get_before() - cause.input_->get_after());
     rhs_duration = duration_cast<microseconds>(consequent->get_before() - consequent->get_after());
-    guard_builder = new TimingGuardBuilder(period); // TODO: use the durations.
+    if (period.count() == 0 && lhs_duration == rhs_duration)
+      // The LHS and RHS timings are the same, so we don't need guards. This often happens if the timings of the
+      // RHS imdl came from an icst.
+      guard_builder = new GuardBuilder();
+    else
+      guard_builder = new TimingGuardBuilder(period); // TODO: use the durations.
 
     uint16 cause_index;
     Code *new_cst;


### PR DESCRIPTION
Background: The prediction targeted pattern extractor (PTPX) responds to a model prediction failure and tries to build a new model which explains the failure conditions. With the other model building (CTPX, etc.) the new model relates an input on the LHS to a consequent on the RHS which in a later frame. Therefore, the model builder filters for inputs that are younger than the consequent. This filter is also in the current PTPX. But unlike the other models, the model from a PTPX are more like prerequisite models and can relate an instantiated composite state on the LHS to predict the failure of instantiating an imdl in the same frame. For example, we want to allow the following which can operate at the same time as a prerequisite model:

    (mdl |[] []
      (fact (icst S0 |[] [v0: v1:]) v2: v3:)
      (|fact (imdl M2 [v0: v4: v2: v3:] [v5: v6:]) v2: v3:)
    |[]
    |[])

This pull request updates PTPX to reject an input (LHS) if its start time is later than the consequent's (RHS) start time. This allows the input to start at the same time as the consequent. We also update the selection of the guard builder. If the LHS and RHS timings are the same, then guards are not needed (as shown in the example above) so we use the default guard builder.