### PR TITLE
PTPX: Fix typo: Need get_reference(0) to check for cmd

### DIFF
--- a/r_exec/pattern_extractor.cpp
+++ b/r_exec/pattern_extractor.cpp
@@ -657,7 +657,7 @@ void PTPX::reduce(r_exec::View *input) {
   r_code::list<Input>::const_iterator i;
   for (i = inputs_.begin(); i != inputs_.end();) { // filter out inputs irrelevant for the prediction.
 
-    if (i->input_->code(0).asOpcode() == Opcodes::Cmd) // no cmds as req lhs (because no bwd-operational); prefer: cmd->effect, effect->imdl.
+    if (i->input_->get_reference(0)->code(0).asOpcode() == Opcodes::Cmd) // no cmds as req lhs (because no bwd-operational); prefer: cmd->effect, effect->imdl.
       i = inputs_.erase(i);
     else if (!end_bm->intersect(i->bindings_) || // discard inputs that do not share values with the consequent.
              i->input_->get_after() >= consequent->get_after()) // discard inputs not younger than the consequent.


### PR DESCRIPTION
In the prediction targeted pattern extractor (PTPX), it has a loop with several checks to filter possible inputs for a new model. One of the filters [checks whether the input is a command](https://github.com/IIIM-IS/replicode/blob/58a2fb5f3ba4509e14f430cfd9adc54e7ed88e6c/r_exec/pattern_extractor.cpp#L660):

    if (i->input_->code(0).asOpcode() == Opcodes::Cmd) // no cmds as req lhs (because no bwd-operational)

It checks whether the opcode is Cmd. But the input would be a fact like (fact (cmd ...)). So, this code is checking the outer fact, not the referenced target. This appears to be a typo. There are [other places](https://github.com/IIIM-IS/replicode/blob/58a2fb5f3ba4509e14f430cfd9adc54e7ed88e6c/r_exec/pattern_extractor.cpp#L256-L257) in the file which check for cmd and these use `get_reference(0)` to get the target of the fact.

This pull request updates the code to use `get_reference(0)` to get the target of the fact for checking if it is a cmd.