### PR TITLE
Compiler: Fix bug to decrement pattern_lvl for tail wildcard

### DIFF
--- a/r_comp/compiler.cpp
+++ b/r_comp/compiler.cpp
@@ -1600,7 +1600,9 @@ bool Compiler::expression_tail(bool indented, const Class &p, uint16 write_index
       if (state_.no_arity_check) {
 
         state_.no_arity_check = false;
-        // JTNote: If (count < p.atom_.getAtomCount()) then we didn't decrement state_.pattern_lvl below. Do it here?
+        if (entered_pattern && pattern_end_index > 0 && count - 1 < pattern_end_index)
+          // state_.pattern_lvl was incremented below, but the tail wildcard prevented decrementing it. Do it here.
+          --state_.pattern_lvl;
         return true;
       }
       if (count == p.atom_.getAtomCount())


### PR DESCRIPTION
Background: When the compiler is compiling expressions, it uses `state_.pattern_lvl` to keep track of the level as it recurses into expressions. In the case of LHS or RHS fact in a model, it [sets pattern_end_index](https://github.com/IIIM-IS/replicode/blob/9b8c0955811cec6586b32ea5b4366b81e87b4fd2/r_comp/compiler.cpp#L1586) based on the expected number of expression arguments. When beginning to compile the expression, it [increments state_.pattern_lvl ](https://github.com/IIIM-IS/replicode/blob/9b8c0955811cec6586b32ea5b4366b81e87b4fd2/r_comp/compiler.cpp#L1633-L1634 ). Normally, the end of the expression is reached when the argument count reaches `pattern_end_index` when it [decrements state_.pattern_lvl](https://github.com/IIIM-IS/replicode/blob/9b8c0955811cec6586b32ea5b4366b81e87b4fd2/r_comp/compiler.cpp#L1640-L1641) . But the expression may contain a tail wildcard `::`, For example:

    (fact run T0: T1: ::)

In this case, the count doesn't reach the expected number of arguments and it never decrements `state_.pattern_lvl` . When the tail wildcard is parsed, it sets the flag `state_.no_arity_check` . The compiler code successfully checks this flag and does not throw an error for a lower argument count, but does not check for decrementing level. This pull request updates this case to check if the count never reached `pattern_end_index`, and decrements `state_.pattern_lvl`  if needed.
