### PR TITLE
PrimaryMDLOverlay: Set forward chaining f_imdl timings from template values

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -138,6 +138,13 @@ bool PrimaryMDLOverlay::reduce(_Fact *input, Fact *f_p_f_imdl, MDLController *re
     bool stop = (req_controller != NULL);
     ChainingStatus c_s = ((MDLController *)controller_)->retrieve_imdl_fwd(bm, f_imdl, r_p, ground, req_controller, wr_enabled);
     f_imdl->get_reference(0)->code(I_HLP_WEAK_REQUIREMENT_ENABLED) = Atom::Boolean(wr_enabled);
+    // Use the timestamps in the template parameters that came from the prerequisite model.
+    Timestamp f_imdl_after, f_imdl_before;
+    if (((PrimaryMDLController *)controller_)->get_template_timings(bm, f_imdl_after, f_imdl_before)) {
+      Utils::SetTimestamp<Code>(f_imdl, FACT_AFTER, f_imdl_after);
+      Utils::SetTimestamp<Code>(f_imdl, FACT_BEFORE, f_imdl_before);
+    }
+
     bool chaining_allowed = (c_s >= WEAK_REQUIREMENT_ENABLED);
     bool did_check_simulated_chaining = false;
     bool check_simulated_chaining_result;


### PR DESCRIPTION
Background: The prediction targeted pattern extractor (PTPX) is activated on the failure of a prediction of a target model. The PTPX makes a "strong requirement" model where the LHS is a composite state with the conditions of the failure and the RHS is an anti-fact which predicts the failure of the target model. Note that other pattern extractors predict a "normal" fact, but the PTPX predicts the instantiation of a model (imdl). Here is an example model built by PTPX:

    (mdl |[] []
      (fact (icst cst_ball_and_wall_same_position |[] [v0: v1: v2: v3:]) v4: v5:)
      (|fact (imdl mdl_ball_position [v0: v1: v3: v4: v5:] [v6: v7: v8:]) v9: v5:)
    []
      v9:(add v4 0s:20ms:0us)
      v5:(add v5 0s:20ms:0us)
    []
      v4:(sub v9 0s:20ms:0us)
      v5:(sub v5 0s:20ms:0us))

(As mentioned, note that the LHS is an instantiated composite state and the RHS is an anti-fact for an imdl.) The concern is the guards such as `v9:(add v4 0s:20ms:0us)` . Normally a requirement model predicts a RHS imdl where the fact has the same timings as the LHS. But here it predicts a delay of 20ms. This comes from [this calculation](https://github.com/IIIM-IS/replicode/blob/99fd266d426af81089144fa911f4bacf3613a47f/r_exec/pattern_extractor.cpp#L558) of the delay:

    period = duration_cast<microseconds>(consequent->get_after() - cause.input_->get_after());

Here, the consequent is the candidate RHS `(fact (imdl ...))` and the cause is the LHS. The RHS imdl is the imdl that was produced when the target model originally made its prediction. (In forward chaining, in addition to making a prediction from the RHS, a model controller also creates a `(fact (imdl ...))` for the fact that the model was instantiated.) The root cause of the problem is that when the `(fact (imdl ...))` is [originally made](https://github.com/IIIM-IS/replicode/blob/f5bc4ac2a9e84f58957fc0eed740b4ba26d9e063/r_exec/mdl_controller.cpp#L134), its timings come from the timings of the command which matches its LHS, and a command is delayed by 20ms. This is similar to the problem solved by pull request #107 where we need the timings of the `(fact (imdl ...))` produced in backward chaining to match the requirement timings in the template values, not the timings of its LHS command.

This pull request updates the production of the `(fact (imdl ...))` in forward chaining to use the timings from the template values that come from the requirement. These template values are filled in when `retrieve_imdl_fwd` [matches the imdl](https://github.com/IIIM-IS/replicode/blob/f5bc4ac2a9e84f58957fc0eed740b4ba26d9e063/r_exec/mdl_controller.cpp#L139) from the requirement. So, after calling `retrieve_imdl_fwd` we update the `(fact (imdl ...))` timings by calling the utility method `get_template_timings` (same as in pull request #107). After this change, the model produced by PTPX does not have guards that offset the LHS and RHS timings, as expected:

    (mdl |[] []
      (fact (icst cst_ball_and_wall_same_position |[] [v0: v1: v2: v3:]) v4: v5:)
      (|fact (imdl mdl_ball_position [v0: v1: v3: v4: v5:] [v6: v7: v8:]) v4: v5:)
    |[]
    |[])