### PR TITLE
Preprocessor: Read an entire string without substructures

### DIFF
--- a/r_comp/preprocessor.cpp
+++ b/r_comp/preprocessor.cpp
@@ -157,6 +157,26 @@ int32 RepliStruct::parse(std::istream *stream, const std::string& filePath, uint
     lastc = c;
     c = stream->get();
     // printf("%c", c);
+
+    if (!inComment && c == '\"') {
+      // Special case: Read until the end of the string.
+      while (true) {
+        str += c;
+        lastcc = lastc;
+        lastc = c;
+        c = stream->get();
+
+        if (c == '\"')
+          // End of the string. Continue below to append to str.
+          break;
+        if (c == 10 || c == 13) {
+          line_ = GlobalLine_;
+          error_ += "Newline is not permitted in a string. ";
+          return -1;
+        }
+      }
+    }
+
     switch (c) {
     case '\t':
       if (inComment) continue; // allow tabs in comments, does not matter anyway


### PR DESCRIPTION
This pull request resolves the bug in issue #29 . In Replicode, the preprocessor does more that string substitution (like the C proprocessor). It tokenizes and creates a parse tree with substrucutres. Currently, it also tokenizes and makes substructures within a string, causing the bug. This pull request updates the parser to read an entire string as one token. Therefore, it does not have substructures which match `!def` or other preprocessor directives. Now the print statement

    (prb [1 "print" "hello set 1(set 1)" |[]])

prints the unchanged string as expected

    0s:50ms:0us: hello set 1(set 1)