### PR TITLE
RMonitor: In signal, pass a copy of bindings_ to check_simulated_imdl

### DIFF
--- a/r_exec/g_monitor.cpp
+++ b/r_exec/g_monitor.cpp
@@ -383,14 +383,16 @@ bool RMonitor::signal(bool is_simulation) {
   if (target_->is_invalidated())
     return true;
 
+  // check_simulated_imdl can change the binding map, so pass a copy.
+  P<BindingMap> bindings_copy(new BindingMap(bindings_));
   if (simulating_ && is_simulation) { // report the simulated outcome: this will inject a simulated prediction of the outcome, to allow any g-monitor deciding on this ground.
 
-    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_, target_->get_goal()->get_sim()->root_))
+    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_copy, target_->get_goal()->get_sim()->root_))
       ((PMDLController *)controller_)->register_simulated_goal_outcome(target_, true, target_); // report a simulated success.
     else
       ((PMDLController *)controller_)->register_simulated_goal_outcome(target_, false, NULL); // report a simulated failure.
     return false;
-  } else if (((PrimaryMDLController *)controller_)->check_imdl(target_, bindings_))
+  } else if (((PrimaryMDLController *)controller_)->check_imdl(target_, bindings_copy))
     return true;
   return false;
 }
@@ -570,13 +572,15 @@ bool SRMonitor::signal(bool is_simulation) {
   if (target_->is_invalidated())
     return true;
 
+  // check_simulated_imdl can change the binding map, so pass a copy.
+  P<BindingMap> bindings_copy(new BindingMap(bindings_));
   if (is_simulation) {
 
-    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_, target_->get_goal()->get_sim()->root_))
+    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_copy, target_->get_goal()->get_sim()->root_))
       ((PMDLController *)controller_)->register_simulated_goal_outcome(target_, true, target_); // report a simulated success.
   } else {
 
-    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_, NULL))
+    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_copy, NULL))
       ((PMDLController *)controller_)->register_simulated_goal_outcome(target_, false, NULL); // report a simulated failure.
   }
   return false;


### PR DESCRIPTION
Background: In backward chaining, when abduction creates a new goal for an imdl, the controller creates an `RMonitor` (requirement monitor) or `SRMonitor` (simulated requirement monitor) for the imdl and adds to the controller's `r_monitors_` list. When the imdl is made, it can contain some unbound variables, so the `RMonitor` or `SRMonitor` also holds a pointer to the binding map which has the values for the bound variables. Later in forward chaining, the controller may make a new predicted imdl and call the `signal` method of each `RMonitor` or `SRMonitor` in the `r_monitors_` list. The the `signal` method passes the stored imdl and binding map to `retrieve_simulated_imdl_bwd` which checks if it matches a predicted imdl. During matching, `retrieve_simulated_imdl_bwd` can update the binding map. Normally, `retrieve_simulated_imdl_bwd` is passed a "fresh" binding map which has bindings for a new input and is only updated once. But `signal` may be called multiple times and `retrieve_simulated_imdl_bwd` may be called in different conditions. We don't want the updates to the binding map from one call to be used during another call.

This pull request updates the `signal` method to pass a copy of the stored binding map to `check_simulated_imdl` (which calls `retrieve_simulated_imdl_bwd`). This way, the updates to each call do not affect the other calls.