### PR TITLE
PrimaryMDLController: Call abduce_simulated_imdl after abduce_simulated_lhs

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1810,8 +1810,15 @@ void PrimaryMDLController::abduce(HLPBindingMap *bm, Fact *super_goal, bool oppo
     case NO_REQUIREMENT:
       if (sub_sim->get_mode() == SIM_ROOT)
         abduce_lhs(bm, super_goal, f_imdl, opposite, confidence, sub_sim, ground, true);
-      else
+      else {
         abduce_simulated_lhs(bm, super_goal, f_imdl, opposite, confidence, sub_sim, ground);
+        if (is_cmd())
+          // We called abduce_simulated_lhs because there is a non-simulated requirement which can instantiate
+          // the model with a simulated predicted command, but simulated forward chaining may fail. Therefore we also call
+          // abduce_simulated_imdl which adds an SRMonitor for a goal to instantiate the model (the same as below),
+          // so that if another simulation branch makes a predicted requirement it can simulate instantiating the model.
+          abduce_simulated_imdl(bm, super_goal, f_imdl, opposite, confidence, sub_sim);
+      }
       break;
     default: // WEAK_REQUIREMENT_DISABLED, STRONG_REQUIREMENT_DISABLED_NO_WEAK_REQUIREMENT or STRONG_REQUIREMENT_DISABLED_WEAK_REQUIREMENT.
       switch (retrieve_simulated_imdl_bwd(bm, f_imdl, sim->root_, ground)) {


### PR DESCRIPTION
Background: `PrimaryMDLController::abduce` is called during simulated backward chaining. If the simulated goal matches the model's RHS, the controller first [calls retrieve_imdl_bwd](https://github.com/IIIM-IS/AERA/blob/d470266e997f6952b4bdb1bcba0496a9611738fc/r_exec/mdl_controller.cpp#L1807) which checks for a matching non-simulated requirement, which means that the current non-simulated state could instantiate the model's LHS. If one is found, it [calls abduce_simulated_lhs](https://github.com/IIIM-IS/AERA/blob/d470266e997f6952b4bdb1bcba0496a9611738fc/r_exec/mdl_controller.cpp#L1814) to make a simulated predicted fact of the model's LHS (simulating that the command is executed). This is important because it is where simulated backward chaining "turns around" and starts simulated forward chaining starting from the simulated predicted command (which is one of the candidate commands that the simulation will commit to).

Background continued: This works if AERA is only designed to simulate one or two commands into the future. But simulated forward chaining may predict that a later command would fail (in this simulation branch). This happens in the hand-grab-sphere example in the simulation branch where the first command is to move the hand to the position of the sphere (because `abduce_simulated_lhs` was called). The next simulated command is to release the cube (at the same position as the sphere). But now simulated grab fails because there is an "anti-requirement" on the grab model which says if two objects are at the same position then grab will fail. In this example, there is a separate simulation branch where the first command in simulated forward chaining is to release the cube (before moving the hand). We would expect that the next simulated command is to move the hand to the position of the sphere, but there is no simulated goal requirement to trigger the instantiation of the move model. The problem is that the first branch called  `abduce_simulated_lhs` and did not save a simulated goal requirement to be used later because the move model can be instantiated with non-simulated conditions and the design assumes that it would therefore not need to be instantiated later (under the limited assumption that each command is only executed once in simulation).

This pull request solves this problem as follows. After the controller calls `abduce_simulated_lhs`, if the model's LHS is a command then the controller also calls `abduce_simulated_imdl` which saves the simulated goal requirement to be used later. (Note that `abduce_simulated_imdl` is normally done during other steps of simulated backward chaining which are not at the "turn around" point of starting forward chaining.) Since there is now a simulated goal requirement, when the requirements are met in simulated forward chaining of the second simulation branch, it can instantiate the move model. (Therefore this is part of removing the design assumption that each command is only executed once during simulation.)