### PR TITLE
Put reduction jobs for strong requirements at the front of the job queue

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1531,7 +1531,7 @@ void PrimaryMDLController::take_input(r_exec::View *input) {
 
   if (input->object_->code(0).asOpcode() == Opcodes::Fact ||
     input->object_->code(0).asOpcode() == Opcodes::AntiFact) // discard everything but facts and |facts.
-    Controller::__take_input<PrimaryMDLController>(input);
+    Controller::__take_input<PrimaryMDLController>(input)->is_for_strong_requirement_ = (requirement_type_ == STRONG_REQUIREMENT);
 }
 
 void PrimaryMDLController::predict(HLPBindingMap *bm, _Fact *input, Fact *f_imdl, bool chaining_was_allowed, RequirementsPair &r_p, Fact *ground) {

--- a/r_exec/mem.cpp
+++ b/r_exec/mem.cpp
@@ -535,7 +535,11 @@ void _Mem::run_in_diagnostic_time(milliseconds run_time) {
         if (reduction_job == NULL)
           // No more reduction jobs.
           break;
-        reduction_job_queue.push_back(reduction_job);
+        if (reduction_job->is_for_strong_requirement_)
+          // See https://github.com/IIIM-IS/AERA/pull/174
+          reduction_job_queue.insert(reduction_job_queue.begin(), reduction_job);
+        else
+          reduction_job_queue.push_back(reduction_job);
       }
 
       size_t n_jobs_to_run = min(reduction_job_queue.size(), max_reduction_jobs_per_cycle);

--- a/r_exec/reduction_job.cpp
+++ b/r_exec/reduction_job.cpp
@@ -86,6 +86,7 @@ uint32 _ReductionJob::job_count_ = 0;
 _ReductionJob::_ReductionJob() : _Object() {
   // Increment without thread lock. It's only for tracing.
   job_id_ = ++job_count_;
+  is_for_strong_requirement_ = false;
 }
 
 ////////////////////////////////////////////////////////////

--- a/r_exec/reduction_job.h
+++ b/r_exec/reduction_job.h
@@ -92,6 +92,8 @@ public:
   Timestamp ijt_; // time of injection of the job in the pipe.
   virtual bool update(Timestamp now) = 0; // return false to shutdown the reduction core.
   virtual void debug() {}
+  // Temporary until a strong requirement can retroactively invalidate. See https://github.com/IIIM-IS/AERA/pull/174
+  bool is_for_strong_requirement_;
   uint32 get_job_id() { return job_id_; }
 private:
   static uint32 job_count_;


### PR DESCRIPTION
(Note: This pull request is replaced by #182 .)

Background: During simulated forward chaining, there are reduction jobs where the input is a new simulated composite state. A reduction job for the model controller of a strong requirement can match this input to its LHS and create a predicted imdl (requirement) from the RHS. This is added to the target model controller's list of simulated requirements. If the requirement matches a goal requirement (from backward chaining) then the target model "fires" and produces a simulated command from its LHS.

Background continued: If the are only positive (weak) requirements, then this is OK. Each new simulated composite state can cause the forward chaining deduction of a new simulated command. New input can only add new deduced conclusions. This is "monotonic logic".  But there can be a simulated composite state as an input to a reduction job for a "strong" requirement which produces a predicted anti-fact of an imdl (an "anti-requirement", a prediction that the instantiated model's prediction would fail). If the target model controller's list of requirements has a matching anti-requirement, then this prevents if from producing a simulated command from its LHS. The problem is that the reduction job for the strong requirement controller may be run "too late", after a reduction job for a weak requirement has already caused the target model to fire and produce a predicted command. That is, the inference in the reduction job for the strong requirement does not cause new derived conclusion to be added, rather it can imply the "removal" of a previously-derived conclusion. This is "non-monotonic logic", where the order of processing new inputs can cause derived conclusions to be removed. In this case the target model controller should not have produced a simulated command from its LHS because this became input for new reduction jobs and possible a candidate simulation solution, which are all now invalid due to the new input for the "strong" requirement.

In the case of running AERA in diagnostic mode, we can implement a temporary solution. In diagnostic mode, all entries from the main reduction job queue are added to a local queue, and these are executed one at a time (while coordinating with time jobs). Currently, each reduction job from the main reduction job queue is added to the end of the local queue. This pull request updates the diagnostic mode code to check if the reduction job is for a strong requirement model controller. If it is, then the job is placed at the beginning of the local job queue so that (in most circumstances) any strong requirements will be processed first. This means that when a later reduction job for a weak requirement controller adds a requirement to the target model's list of requirements, any strong requirements are already there which might block the model from "firing".

This is a temporary solution. It doesn't work for running in real time, and there is still a small chance that an input for a strong requirement could be processed after the target model (incorrectly) fires.