### PR TITLE
In store_requirement, also store in simulated_requirements_.negative_evidence

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1536,6 +1536,8 @@ void PrimaryMDLController::store_requirement(_Fact *f_p_f_imdl, MDLController *c
     // Negative requirement.
     if (!is_simulation)
       _store_requirement(&requirements_.negative_evidences, e);
+    else
+      _store_requirement(&simulated_requirements_.negative_evidences, e);
   }
 
   if (!is_simulation)


### PR DESCRIPTION
Background: For a non-simulated anti-requirement, `store_requirement` [stores the anti-requirement](https://github.com/IIIM-IS/AERA/blob/e41fa3f367d02476b9c583911b5e3ac18c65c080/r_exec/mdl_controller.cpp#L1537-L1538) in the target model controller's list of anti-requirements (called `requirements_.negative_evidences`). This is [used by retrieve_imdl_fwd](https://github.com/IIIM-IS/AERA/blob/e41fa3f367d02476b9c583911b5e3ac18c65c080/r_exec/mdl_controller.cpp#L905) and other methods to search for matching anti-requirements.

More background: Similarly, for simulation, methods like `retrieve_simulated_imdl_fwd` also [search for matching simulated anti-requirements](https://github.com/IIIM-IS/AERA/blob/e41fa3f367d02476b9c583911b5e3ac18c65c080/r_exec/mdl_controller.cpp#L598) which are in the list `simulated_requirements_.negative_evidences`. Curiously though, there is currently no code which adds to this list.

This pull request updates `store_requirement` to add a simulated anti-requirement to `simulated_requirements_.negative_evidences` (similarly to the non-simulated case). Why wasn't this done before? I suspect it is because the implementation of simulated anti-requirements was still under development, and needed a use case for testing before activating the code. We now have a use case with hand-grab-sphere and have verified the code for handling simulated anti-requirements.