### PR TITLE
SecondaryMDLController: In rate_model, use float32 for evidence_count, etc.

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -2617,8 +2617,8 @@ void SecondaryMDLController::rate_model() { // acknowledge successes only; the p
     return;
   }
 
-  uint32 evidence_count = model->code(MDL_CNT).asFloat();
-  uint32 success_count = model->code(MDL_SR).asFloat()*evidence_count;
+  float32 evidence_count = model->code(MDL_CNT).asFloat();
+  float32 success_count = model->code(MDL_SR).asFloat()*evidence_count;
 
   ++evidence_count;
   model->code(MDL_DSR) = model->code(MDL_SR);


### PR DESCRIPTION
In `PrimaryMDLController::rate_model`, the local variables `evidence_count` and `success_count` [are float32](https://github.com/IIIM-IS/AERA/blob/be9ecba09e4fe52d8f5a5321dc52d763da19cf9b/r_exec/mdl_controller.cpp#L2307-L2308). If they were integer then the later computation of `success_rate` would use integer division and result in 0. But in `SecondaryMDLController::rate_model`, `evidence_count` and `success_count` are declared as integers. This pull request changes them to float32, the same as `PrimaryMDLController::rate_model`.