### PR TITLE
SecondaryMDLController: Fix bug in store_requirement to use param f_p_f_imdl.

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -2611,14 +2611,13 @@ void SecondaryMDLController::predict(HLPBindingMap *bm, _Fact *input, Fact *f_im
   add_monitor(m);
 }
 
-void SecondaryMDLController::store_requirement(_Fact *f_imdl, MDLController *controller, bool chaining_was_allowed) {
+void SecondaryMDLController::store_requirement(_Fact *f_p_f_imdl, MDLController *controller, bool chaining_was_allowed) {
 
-  Code *mdl = f_imdl->get_reference(0);
-  RequirementEntry e(f_imdl, controller, chaining_was_allowed);
-  if (f_imdl->is_fact()) {
+  RequirementEntry e(f_p_f_imdl, controller, chaining_was_allowed);
+  if (((_Fact*)f_p_f_imdl->get_reference(0)->get_reference(0))->is_fact()) {
 
     _store_requirement(&requirements_.positive_evidences, e);
-    reduce_cache<SecondaryMDLController>((Fact *)f_imdl, controller);
+    reduce_cache<SecondaryMDLController>((Fact *)f_p_f_imdl, controller);
   } else
     _store_requirement(&requirements_.negative_evidences, e);
 }


### PR DESCRIPTION
The first param to `SecondaryMDLController::store_requirement` is a (fact (pred (fact (imdl ...)))), as can be seen it [how it is called](https://github.com/IIIM-IS/AERA/blob/2b2a1348db1727e892954f8c25f32af7836ca223/r_exec/mdl_controller.cpp#L2597-L2606) by `SecondaryMDLController::predict`. (And this is consistent with `store_requirement` in related classes.) However, `SecondaryMDLController::store_requirement` treats the first parameter simply as (fact (imdl ...)) , which is incorrect especially when it uses `is_fact()` to check if the first param is an anti-requirement (fact (pred (|fact (imdl ...)))).

This pull request updates `SecondaryMDLController::store_requirement` to rename the first param as `f_p_f_imdl`, and to fix the check for `is_fact()` by getting the inner fact from the (fact (pred (fact (imdl ...)))) . We also remove the unused local variable `mdl` (which was also assigned incorrectly).