### PR TITLE
In retrieve_simulated_imdl_fwd, check if the evidence is from the given sim

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -531,7 +531,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(HLPBindingMap *bm, Fac
         e = simulated_requirements_.positive_evidences.erase(e);
       else {
 
-        if ((*e).evidence_->get_pred()->get_simulation(sim->root_)) {
+        if ((*e).evidence_->get_pred()->has_simulation(sim)) {
 
           _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
           //_f_imdl->get_reference(0)->trace();
@@ -570,7 +570,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(HLPBindingMap *bm, Fac
           e = simulated_requirements_.negative_evidences.erase(e);
         else {
 
-          if ((*e).evidence_->get_pred()->get_simulation(sim->root_)) {
+          if ((*e).evidence_->get_pred()->has_simulation(sim)) {
 
             _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
             HLPBindingMap _original = original; // matching updates the bm; always start afresh.
@@ -601,7 +601,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(HLPBindingMap *bm, Fac
           e = simulated_requirements_.negative_evidences.erase(e);
         else {
 
-          if ((*e).evidence_->get_pred()->get_simulation(sim->root_)) {
+          if ((*e).evidence_->get_pred()->has_simulation(sim)) {
 
             _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
             HLPBindingMap _original = original; // matching updates the bm; always start afresh.
@@ -625,7 +625,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(HLPBindingMap *bm, Fac
         else {
           //(*e).f->get_reference(0)->trace();
           //f->get_reference(0)->trace();
-          if ((*e).evidence_->get_pred()->get_simulation(sim->root_)) {
+          if ((*e).evidence_->get_pred()->has_simulation(sim)) {
 
             _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
             HLPBindingMap _original = original; // matching updates the bm; always start afresh.


### PR DESCRIPTION
Background: During simulated forward chaining, the model controller matches a predicted action to the model's LHS. Then it calls `retrieve_simulated_imdl_fwd` to match a simulated requirement (predicted imdl) which was previously stored by a requirement model. It is passed the `Sim` object from the simulated LHS. Currently, when `retrieve_simulated_imdl_fwd` is checking a stored requirement, it [ensures that](https://github.com/IIIM-IS/AERA/blob/299a10bf8de8f2f41c655109ac3d7a9e06a80a68/r_exec/mdl_controller.cpp#L534) its `Sim` object shares the same root with the LHS:

    if ((*e).evidence_->get_pred()->get_simulation(sim->root_))

(Here, `(*e).evidence_` is the stored requirement.) Recall that each drive starts a simulation with the drive's goal at the "root", so the "root" applies to the entire simulation, and the "root" is different for a simulation from a different drive. Also recall that, in simulated forward chaining, all predictions have the same `Sim` object from the initial simulated command which starts the forward chaining.

So the current code makes sure that a requirement is from the same drive (root), but the requirement could be from a different simulation branch which started from a different initial simulated command. This means that, in different simulation branch, different actions are taken and the composite states are different. Therefore, it may not be correct to match a requirement to a predicted LHS that is from a different branch.

This pull request updates `retrieve_simulated_imdl_fwd` to enforce that a matching requirement is from the same simulation branch as the predicted LHS:

    if ((*e).evidence_->get_pred()->has_simulation(sim))

(Here, `sim` is the `Sim` object of the predicted LHS, and `has_simulation(sim)` checks if it is in the list of `Sim` objects for the requirement.)