### PR TITLE
In retrieve_simulated_imdl_bwd, check if the evidence is from the given Sim

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -675,7 +675,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_bwd(HLPBindingMap *bm, Fac
         e = simulated_requirements_.positive_evidences.erase(e);
       else {
 
-        if ((*e).evidence_->get_pred()->get_simulation(prediction_sim->root_)) {
+        if ((*e).evidence_->get_pred()->has_simulation(prediction_sim)) {
 
           _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
           //_f_imdl->get_reference(0)->trace();
@@ -710,7 +710,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_bwd(HLPBindingMap *bm, Fac
           e = simulated_requirements_.negative_evidences.erase(e);
         else {
 
-          if ((*e).evidence_->get_pred()->get_simulation(prediction_sim->root_)) {
+          if ((*e).evidence_->get_pred()->has_simulation(prediction_sim)) {
 
             _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
             HLPBindingMap _original = original; // matching updates the bm; always start afresh.
@@ -743,7 +743,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_bwd(HLPBindingMap *bm, Fac
           e = simulated_requirements_.negative_evidences.erase(e);
         else {
 
-          if ((*e).evidence_->get_pred()->get_simulation(prediction_sim->root_)) {
+          if ((*e).evidence_->get_pred()->has_simulation(prediction_sim)) {
 
             _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
             HLPBindingMap _original = original; // matching updates the bm; always start afresh.
@@ -769,7 +769,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_bwd(HLPBindingMap *bm, Fac
         else {
           //(*e).f->get_reference(0)->trace();
           //f->get_reference(0)->trace();
-          if ((*e).evidence_->get_pred()->get_simulation(prediction_sim->root_)) {
+          if ((*e).evidence_->get_pred()->has_simulation(prediction_sim)) {
 
             _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
             HLPBindingMap _original = original; // matching updates the bm; always start afresh.


### PR DESCRIPTION
Background: Similar to pull request #179 for `retrieve_simulated_imdl_fwd`, during simulated forward chaining, the controller of a requirement model stores a simulated predicted imdl (simulated requirement) in the list of simulated requirements for the target model. Then it [calls signal](https://github.com/IIIM-IS/AERA/blob/7ae91ea157d7a68007d21596b05fa63459358c95/r_exec/mdl_controller.cpp#L1532) for each of the simulated goal requirements (which were created during simulated backward chaining). This [then calls](https://github.com/IIIM-IS/AERA/blob/7ae91ea157d7a68007d21596b05fa63459358c95/r_exec/mdl_controller.cpp#L2161):

    check_simulated_imdl(Fact *goal, HLPBindingMap *bm, Sim* prediction_sim)

Here, `goal` is the simulated goal requirement from backward chaining and `prediction_sim` is the `Sim` object from the predicted imdl of the requirement model. `check_simulated_imdl` calls `retrieve_simulated_imdl_bwd` which matches the simulated goal requirement to a stored simulated imdl and "fires" the model by injecting a simulated prediction of the LHS command.  Currently, when `retrieve_simulated_imdl_bwd` is checking a stored requirement, it ensures that its `Sim` object shares the same root with the `prediction_sim`:

    if ((*e).evidence_->get_pred()->get_simulation(prediction_sim->root_))

(Here, `(*e).evidence_` is the stored requirement.) Recall that each drive starts a simulation with the drive's goal at the "root", so the "root" applies to the entire simulation, and the "root" is different for a simulation from a different drive. Also recall that, in simulated forward chaining, all predictions have the same `Sim` object from the initial simulated command which starts the forward chaining.

So the current code makes sure that a requirement is from the same drive (root), but the requirement could be from a different simulation branch which started from a different initial simulated command. This means that, the model may "fire" with a simulated prediction of the LHS for a different simulation branch. Furthermore, `retrieve_simulated_imdl_bwd` checks the lists of both "weak" requirements and "strong" requirements (anti-requirements). Therefore a "strong" requirement from one simulation branch may prevent the use of a "weak" requirement from another simulation branch, even though there is no "strong" requirement in its simulation branch.

This pull request updates `retrieve_simulated_imdl_bwd` to enforce that a matching requirement is from the same simulation branch as the predicted imdl:

    if ((*e).evidence_->get_pred()->has_simulation(prediction_sim))

(Here, `prediction_sim` is the predicted imdl's `Sim` object which is passed in from the initial call to `signal`, and `has_simulation(sim)` checks if it is in the list of `Sim` objects for the stored requirement.)