### PR TITLE
Add already_signalled to avoid repeating the same simulated command

### DIFF
--- a/r_exec/g_monitor.cpp
+++ b/r_exec/g_monitor.cpp
@@ -388,7 +388,7 @@ bool RMonitor::signal(Pred* prediction) {
   Sim* prediction_sim = prediction->get_simulation(target_->get_goal()->get_sim()->root_);
   if (simulating_ && prediction_sim) { // report the simulated outcome: this will inject a simulated prediction of the outcome, to allow any g-monitor deciding on this ground.
 
-    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_copy, prediction_sim))
+    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_copy, prediction_sim, &already_signalled_))
       ((PMDLController *)controller_)->register_simulated_goal_outcome(target_, true, target_); // report a simulated success.
     else
       ((PMDLController *)controller_)->register_simulated_goal_outcome(target_, false, NULL); // report a simulated failure.
@@ -578,11 +578,11 @@ bool SRMonitor::signal(Pred* prediction) {
   Sim* prediction_sim = prediction->get_simulation(target_->get_goal()->get_sim()->root_);
   if (prediction_sim) {
 
-    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_copy, prediction_sim))
+    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_copy, prediction_sim, &already_signalled_))
       ((PMDLController *)controller_)->register_simulated_goal_outcome(target_, true, target_); // report a simulated success.
   } else {
 
-    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_copy, NULL))
+    if (((PrimaryMDLController *)controller_)->check_simulated_imdl(target_, bindings_copy, NULL, &already_signalled_))
       ((PMDLController *)controller_)->register_simulated_goal_outcome(target_, false, NULL); // report a simulated failure.
   }
   return false;

--- a/r_exec/g_monitor.h
+++ b/r_exec/g_monitor.h
@@ -94,6 +94,7 @@ protected:
   _Fact *goal_target_; // convenience; f1->object.
   P<Fact> f_imdl_;
   SimMode sim_mode_;
+  std::unordered_map<Sim*, std::vector<P<r_code::Code> > > already_signalled_;
 
   uint32 volatile simulating_; // 32 bits alignment.
 

--- a/r_exec/mdl_controller.h
+++ b/r_exec/mdl_controller.h
@@ -410,10 +410,12 @@ private:
 
   /**
    * If sim is null, assume this is called from check_simulated_imdl in forward chaining and get the Sim from ground.
+   * If already_signalled is not null, use it as described in check_simulated_imdl.
    * If goal_requirement is not NULL, use it only for the runtime output.
    */
   void abduce_simulated_lhs(HLPBindingMap *bm, Fact *super_goal, Fact *f_imdl, bool opposite, float32 confidence,
-    Sim *sim, Fact *ground, Fact* goal_requirement = NULL);
+    Sim *sim, Fact *ground, std::unordered_map<Sim*, std::vector<P<r_code::Code> > >* already_signalled = NULL,
+    Fact* goal_requirement = NULL);
   void abduce_simulated_imdl(HLPBindingMap *bm, Fact *super_goal, Fact *f_imdl, bool opposite, float32 confidence, Sim *sim);
   void predict_simulated_lhs(HLPBindingMap *bm, bool opposite, float32 confidence, Sim *sim);
   Fact* predict_simulated_evidence(_Fact *evidence, Sim *sim);
@@ -451,8 +453,14 @@ public:
    * \param bm A copy of the requirement monitor's saved binding map which has values for variables in the goal. This binding
    * map may be updated during matching.
    * \param prediction_sim The Sim of the input prediction, or NULL to just call retrieve_imdl_bwd.
+   * \param already_signalled The list of imdl that abduce_simulated_lhs has already used with this requirement monitor to
+   * abduce a LHS, for the same Sim (as determined by the requirement that is passed to abduce_simulated_lhs as "ground").
+   * If abduce_simulated_lhs has an imdl which is not in the list for the same Sim, then the LHS is injected as usual
+   * (and the imdl is added to this list of imdl for the same Sim, to use in future checks). Otherwise, the same requirement
+   * monitor has already signalled and produced the same LHS, so abduce_simulated_lhs aborts and does not inject it. This
+   * prevents loops during simulation.
    */
-  bool check_simulated_imdl(Fact *goal, HLPBindingMap *bm, Sim* prediction_sim);
+  bool check_simulated_imdl(Fact *goal, HLPBindingMap *bm, Sim* prediction_sim, std::unordered_map<Sim*, std::vector<P<r_code::Code> > >* already_signalled);
 
   void abduce(HLPBindingMap *bm, Fact *super_goal, bool opposite, float32 confidence);
 


### PR DESCRIPTION
Background: During simulated backward chaining, a simulated requirement monitor (`SRMonitor`) is created for each goal requirement. Later, during simulated forward chaining the controller for a requirement model stores a predicted imdl (requirement) in the target model's list of simulated requirements. For each `SRMonitor`, it calls `check_simulated_imdl` which checks if the goal requirement matches a stored simulated requirement. If there is a match, then `check_simulated_imdl`[ calls abduce_simulated_lhs](https://github.com/IIIM-IS/AERA/blob/3c4dbdd6a2d920441402b3e58b4f7bbe45ab3b0f/r_exec/mdl_controller.cpp#L2207) which "fires" the model and makes a simulated prediction for the model's LHS (a command).

Later, the controller for a requirement model could store another simulated requirement which can match the goal requirement in an `SRMonitor` once again where the "fired" LHS would be the same command. If it is in the same simulation branch, there is no need to predict from the same command. Therefore this causes redundancy and in some cases could cause a loop.

To avoid these problems, this pull request updates `SRMonitor` so that it keeps a [list of commands](https://github.com/IIIM-IS/AERA/blob/3c4dbdd6a2d920441402b3e58b4f7bbe45ab3b0f/r_exec/g_monitor.h#L97) that are already_signalled for a particular simulation. When `SRMonitor` calls `check_simulated_imdl`, it passes this list. When `abduce_simulated_lhs` has a candidate LHS, it checks if it is already in the list of "fired" LHS for the same simulation branch. If it is then do nothing. Otherwise, store the LHS in the list for future checks.