### PR TITLE
CSTOverlay: In inject_production, don't make a second copy in a different Sim

### DIFF
--- a/r_exec/cst_controller.cpp
+++ b/r_exec/cst_controller.cpp
@@ -176,26 +176,6 @@ _Fact* CSTOverlay::inject_production(View* input) {
     OUTPUT_LINE(CST_OUT, Utils::RelativeTime(Now()) << " cst " << getObject()->get_oid() << ": fact " <<
       input->object_->get_oid() << " -> fact " << f_p_f_icst->get_oid() << " simulated pred fact icst [" <<
       inputs_info << "]");
-
-    Pred* input_prediction = ((_Fact*)input->object_)->get_pred();
-    if (input_prediction && input_prediction->get_simulations_size() == 1) {
-      Sim* input_simulation = ((_Fact*)input->object_)->get_pred()->get_simulation((uint16)0);
-      if (simulations_.size() == 1 && *simulations_.begin() != input_simulation &&
-        (*simulations_.begin())->get_root_sim() == input_simulation->get_root_sim()) {
-        // This CSTOverlay's Sim is different that the input's Sim, but has the same Sim root, so it
-        // is part of the same simulation but a branch with a different potential committed action.
-        // Inject the same predicted icst but with the input's Sim so we have a different solution branch.
-        // TODO: Handle the case when simulations_ or the input predictions simulations have multiple root Sims.
-        simulations_copy.clear();
-        simulations_copy.push_back(input_simulation);
-        prediction = new Pred(f_icst, simulations_copy, 1);
-        f_p_f_icst = new Fact(prediction, now, now, 1, 1);
-        ((HLPController *)controller_)->inject_prediction(f_p_f_icst, lowest_cfd_);
-        OUTPUT_LINE(CST_OUT, Utils::RelativeTime(Now()) << " cst " << getObject()->get_oid() << ": fact " <<
-          input->object_->get_oid() << " -> fact " << f_p_f_icst->get_oid() << " simulated pred fact icst [" <<
-          inputs_info << "]");
-      }
-    }
     return f_p_f_icst;
   }
 }


### PR DESCRIPTION
Pull request #160 adds code to the composite state controller for simulated forward chaining to make a second copy of an icst with a different Sim object. But simulated forward chaining should proceeds from one candidate initial command, and the same Sim object is carried through to predict the success of the goal. If there is a different candidate initial command (and different Sim object), this happens in a different reduction job, and the current code creates a separate prediction object for this.

This pull request reverts pull request #160. It was added as theoretically necessary (at the time). But no examples (hand-grab-sphere, etc.) currently execute this code.