### PR TITLE
std.replicode: Create the primary group before stdin

### DIFF
--- a/AERA/replicode_v1.2/std.replicode
+++ b/AERA/replicode_v1.2/std.replicode
@@ -164,12 +164,12 @@
 ; initial groups.
 
 root:(std_grp 0 0 0 0 [nil]) [[SYNC_ONCE now 0 forever nil nil COV_OFF 0]]
-stdout:(std_grp 0 0 0 0 |[]) [[SYNC_ONCE now 0 forever root nil COV_OFF 0]]
-stdin:(std_grp 2 0 0 0 [stdout]) [[SYNC_ONCE now 0 forever root nil COV_OFF 0]]; ensure stdin.upr=sampling_period.
 
 primary:(std_grp 2 0 0.4 0 |[]) [[SYNC_ONCE now 0 forever root nil COV_OFF 0]]; ensure primary.upr=stdin.upr.
 secondary:(std_grp 2 0 0.3 0 |[]) [[SYNC_ONCE now 0 forever root nil COV_OFF 0]]; ensure secondary.upr=primary.upr.
 grp_pair:(mk.grp_pair primary secondary 1) [[SYNC_ONCE now 0 forever root nil]]
+stdout:(std_grp 0 0 0 0 |[]) [[SYNC_ONCE now 0 forever root nil COV_OFF 0]]
+stdin:(std_grp 2 0 0 0 [stdout]) [[SYNC_ONCE now 0 forever root nil COV_OFF 0]]; ensure stdin.upr=sampling_period.
 drives:(std_grp 40 0 0 0 [stdout]) [[SYNC_ONCE now 0 forever root nil COV_OFF 0]]; holds pgm that inject drives periodically; drive priority=pgm.act; ensure ipgm.tsc>primary.upr.
 
 ; extensions.


### PR DESCRIPTION
Background: std.replicode creates the groups [stdin and primary](https://github.com/IIIM-IS/AERA/blob/8a9dc5a531df6c5b38bb2ec1f9683e6b2d555763/AERA/replicode_v1.2/std.replicode#L168-L170). When AERA starts, it creates a time job for each group, in order. The time job for each group performs various maintenance on the group and then creates another time job to run one frame period later. In this way a time job executes in each frame to do maintenance for the group. At each frame, the time jobs for all groups are give the same target time, such as 200ms, but they actually run in some order (not simultaneously).

The time job for the primary group (among other things) invalidates expired objects which were injected into primary in the previous frame and are no longer relevant in the new frame. The time job for the stdin group (among other things) invokes the autofocus controller which injects new facts, including reduction jobs to process the new facts. These reduction jobs (among other things) make new composite states by combining the newly-injected fact with objects that were injected into the primary group. The problem is that, if the time job for stdin runs before the time job for primary, it creates reduction jobs to process objects (from the previous frame) that are just about to be invalidated by the time job for primary. This uses extra unnecessary memory and processing. We would prefer that the time job for the primary group run first, to clear out expired objects from the previous frame.

This pull request updates std.replicode to define the primary group before the stdin group (and also before stdout). When AERA starts, it creates time jobs in the order that the groups are defined, so that the time job for primary runs before the time job for stdin. This solves the problem, at least for diagnostic time mode where execution order is reliable. (For real time we will need to add a mechanism to explicitly make the time job for the stdin group wait until the time job for primary runs.)