### PR TITLE
Increment the resilience of the new PASTController's view

### DIFF
--- a/r_exec/auto_focus.cpp
+++ b/r_exec/auto_focus.cpp
@@ -176,7 +176,8 @@ inline View *AutoFocusController::inject_input(View *input) {
 
         primary_view = view;
         if (ctpx_on_)
-          _Mem::Get()->inject_null_program(new PASTController(this, view), output_group, output_group->get_upr()*Utils::GetBasePeriod(), true);
+          // Set time_to_live to 2 frame periods so that PASTController stays valid during the whole frame when CTPX may build models.
+          _Mem::Get()->inject_null_program(new PASTController(this, view), output_group, 2 * output_group->get_upr()*Utils::GetBasePeriod(), true);
       }
     }
     break;


### PR DESCRIPTION
Background: When the auto focus controller gets a new input, it creates a `PASTController` (Atomic STate controller for a sync Periodic input). This contains the CTPX controller which will collect inputs and maybe make a new learned model. The auto focus controller calls `inject_null_program` which creates a view for the new `PASTController` and injects it so that future inputs will be passed to it. The default view created by `inject_null_program` has a resiliency of 1, which means that after one frame the group management job will decrement the resiliency to zero and remove it. To create a new model, the CTPX controller needs inputs from two frames: The first input that created the `PASTController` and the input of the "changed" value in the next frame.

This is OK for the examples we have been using where new inputs are injected by the I/O device at the very beginning of the frame before the group management job runs (and removes the `PASTController`). The problem is that now we are using examples like hand-grab-sphere where the inputs are created by programs which may not run right at the beginning of the frame. The program injects the input for the "changed" value after the group management job runs at the beginning of the frame and removes the `PASTController` (and its CTPX controller), so there is no controller to collect the input and create a model.

This pull request updates the auto focus controller to increment the resiliency of the view created by `inject_null_program`. This makes the `PASTController` stay valid during the entire frame to collect inputs needed by the CTPX controller. (Incrementing the resilience doesn't have other side effects, it only makes it live one more frame before the group management job removes it.) With this change, examples like hand-grab-sphere can now learn models from inputs injected by a program.

(As with other recent changes, we may implement a more explicit mechanism to keep objects valid as long as they are needed. If so, then we can revert this commit and use that mechanism.)