### PR TITLE
Allow an empty string

### DIFF
--- a/r_comp/compiler.cpp
+++ b/r_comp/compiler.cpp
@@ -1353,7 +1353,7 @@ bool Compiler::str(std::string &s) {
 
     switch (char c = (char)in_stream_->get()) {
     case '"':
-      if (!count) {
+      if (!started) {
 
         started = true;
         break;


### PR DESCRIPTION
As explained in issue #190, an empty string like "" gives a parsing error. After investigation, the internal "bytecode" representation of a string does indeed allow for a zero-length string, and processes a zero-length string properly including comparison with other strings. The issue was only caused by a minor oversight in the compiler, which assumed that a string is "started" if its length is positive.

This pull request updates the `str` method in the compiler to allow a double quote to immediately follow another one. Now code like shown in issue #190 will compile and perform properly.