### PR TITLE
hand-grab-sphere: Make M0 require change

### DIFF
--- a/AERA/replicode_v1.2/hand-grab-sphere-learn.replicode
+++ b/AERA/replicode_v1.2/hand-grab-sphere-learn.replicode
@@ -41,6 +41,7 @@ M0:(mdl [H: P0: T0: T1:]
    T1_RHS:(+ T0 0s:100ms:0us)
    T3:(+ T1 0s:100ms:0us)
 []
+   (<> P1 P0); Don't make a subgoal that doesn't change anything.
    DeltaP:(- P1 P0)
    T2:(- T1_RHS 0s:80ms:0us); Change 50ms delay to 20ms.
    T1_cmd:(- T3 0s:100ms:0us)

--- a/AERA/replicode_v1.2/hand-grab-sphere.replicode
+++ b/AERA/replicode_v1.2/hand-grab-sphere.replicode
@@ -41,6 +41,7 @@ M0:(mdl [H: P0: T0: T1:]
    T1_RHS:(+ T0 0s:100ms:0us)
    T3:(+ T1 0s:100ms:0us)
 []
+   (<> P1 P0); Don't make a subgoal that doesn't change anything.
    DeltaP:(- P1 P0)
    T2:(- T1_RHS 0s:80ms:0us); Change 50ms delay to 20ms.
    T1_cmd:(- T3 0s:100ms:0us)

--- a/License.txt
+++ b/License.txt
@@ -1,69 +1,77 @@
- Center for Analysis and Design of Intelligent Agents
-   Reykjavik University, Menntavegur 1, 101 Reykjavik, Iceland
-   http://cadia.ru.is
- Copyright(c)2012
+AERA
+Autocatalytic Endogenous Reflective Architecture
 
- This software was developed by the above copyright holder as part of 
- the HUMANOBS EU research project, in collaboration with the 
- following parties:
- 
- Autonomous Systems Laboratory
-   Technical University of Madrid, Spain
-   http://www.aslab.org/
+Copyright (c) 2018-2021 Icelandic Institute for Intelligent Machines
+http://www.iiim.is
 
- Communicative Machines
-   Edinburgh, United Kingdom
-   http://www.cmlabs.com/
+Copyright (c) 2010-2012
+Center for Analysis and Design of Intelligent Agents
+Reykjavik University, Menntavegur 1, 102 Reykjavik, Iceland
+http://cadia.ru.is
 
- Istituto Dalle Molle di Studi sull'Intelligenza Artificiale
-   University of Lugano and SUPSI, Switzerland
-   http://www.idsia.ch/
+Part of this software was developed by Eric Nivel
+in the HUMANOBS EU research project, which included
+the following parties:
 
- Institute of Cognitive Sciences and Technologies
-   Consiglio Nazionale delle Ricerche, Italy
-   http://www.istc.cnr.it/
+Autonomous Systems Laboratory
+Technical University of Madrid, Spain
+http://www.aslab.org/
 
- Dipartimento di Ingegneria Informatica
-   University of Palermo, Italy
-   http://roboticslab.dinfo.unipa.it/index.php/Main/HomePage
+Communicative Machines
+Edinburgh, United Kingdom
+http://www.cmlabs.com/
+
+Istituto Dalle Molle di Studi sull'Intelligenza Artificiale
+University of Lugano and SUPSI, Switzerland
+http://www.idsia.ch/
+
+Institute of Cognitive Sciences and Technologies
+Consiglio Nazionale delle Ricerche, Italy
+http://www.istc.cnr.it/
+
+Dipartimento di Ingegneria Informatica
+University of Palermo, Italy
+http://diid.unipa.it/roboticslab/
 
 
- --- HUMANOBS Open-Source BSD License, with CADIA Clause v 1.0 ---
+--- HUMANOBS Open-Source BSD License, with CADIA Clause v 1.0 ---
 
- Redistribution and use in source and binary forms, with or without 
- modification, is permitted provided that the following conditions 
- are met:
+Redistribution and use in source and binary forms, with or without
+modification, is permitted provided that the following conditions
+are met:
+- Redistributions of source code must retain the above copyright
+  and collaboration notice, this list of conditions and the
+  following disclaimer.
+- Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer 
+  in the documentation and/or other materials provided with 
+  the distribution.
 
- - Redistributions of source code must retain the above copyright 
- and collaboration notice, this list of conditions and the 
- following disclaimer.
+- Neither the name of its copyright holders nor the names of its
+  contributors may be used to endorse or promote products
+  derived from this software without specific prior 
+  written permission.
+  
+- CADIA Clause: The license granted in and to the software 
+  under this agreement is a limited-use license. 
+  The software may not be used in furtherance of:
+   (i)   intentionally causing bodily injury or severe emotional 
+         distress to any person;
+   (ii)  invading the personal privacy or violating the human 
+         rights of any person; or
+   (iii) committing or preparing for any act of war.
 
- - Redistributions in binary form must reproduce the above copyright 
- notice, this list of conditions and the following
- disclaimer in the documentation and/or other materials provided 
- with the distribution.
-
- - Neither the name of its copyright holders nor the names of its 
- contributors may be used to endorse or promote products 
- derived from this software without specific prior written permission.
-
- - CADIA Clause: The license granted in and to the software under this 
- agreement is a limited-use license. The software may not be used in 
- furtherance of: 
- (i) intentionally causing bodily injury or severe emotional distress 
- to any person; 
- (ii) invading the personal privacy or violating the human rights of 
- any person; or 
- (iii) committing or preparing for any act of war.
-
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
- A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
- OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
- SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
- LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
- THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.

--- a/doc/meeting-notes.txt
+++ b/doc/meeting-notes.txt
@@ -731,10 +731,22 @@ Simulator
   * DONE. Change "attached C" to "attached [C]" and "anti-fact to "attached |[]" .
   * DONE. Babble to learn grab and release models.
 
+2021-11-19
+* Visualizer
+  * DONE. Merge pull request for tool tip hover (Karl)
+* DONE. Update the pull request so copyright years have a range. Merge. https://github.com/IIIM-IS/AERA/pull/197
+* DONE. Make Correlator branch. Remove Correlator code from master.
+* pong
+  *DONE. Merge request for the same repeated simulated command https://github.com/IIIM-IS/AERA/pull/200
+* Release
+  * DONE. Confirm name AERA Diagnostic Mode v0.1 . Commit CHANGELOG (AERA and AERA_Visualizer).
+  * DONE. Tag AERA and AERA_Visualizer.
+  * DONE. Make dev from master (AERA and AERA_Visualizer). Close the experimental branch.
+  * DONE! Make AERA and AERA_Visualizer public.
+
 next meeting
-* Update the pull request so copyright years have a range. Merge it. https://github.com/IIIM-IS/AERA/pull/197
-* Make Correlator branch. Remove Correlator code from master.
-* Close the experimental branch. Make dev from master.
+* pong
+  * Match timings between strong and weak requirements.
 
 TODO
 * PTPX: Learned cst may only have icsts. But using a cst for later model-building requires a non-icst fact. Should icst->contains be recursive? (Need limit.) Or always include a fact in new_cst?


### PR DESCRIPTION
In hand-grab-sphere model `M0`, simulated backward chaining matches a goal position P1 on the RHS and computes a DeltaP for the LHS move command based on the current position P0.

    M0:(mdl [H: P0: T0: T1:] []
       (fact (cmd move [H: DeltaP:] :) T2: T1_cmd: : :)
       (fact (mk.val H: position P1: :) T1_RHS: T3: : :))

It is possible that backward chaining can derive a subgoal for a position P1 (based on other criteria) which is the same as the current position P0. In this case the DeltaP for the move command would be 0. During simulated forward chaining, this can add one or more steps to simulate a move of 0 which doesn't change any state variables. It only adds unnecessary steps to the simulation. In general, a command should only be executed that changes the state. This pull request updates the backward guards of model `M0` to require P0 and P1 to be different, which makes DeltaP non-zero.