### PR TITLE
Don't let old strong requirement disable a weak requirement

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -781,7 +781,8 @@ ChainingStatus MDLController::retrieve_simulated_imdl_bwd(HLPBindingMap *bm, Fac
             // Use match_fwd because the f_imdl time interval matches the binding map's fwd_after and fwd_before from the model LHS.
             if (_original.match_fwd_strict(_f_imdl, f_imdl)) {
 
-              if ((*e).confidence_ > negative_cfd) {
+              if ((*e).confidence_ > negative_cfd ||
+                  _f_imdl->get_after() >= strong_requirement_ground->get_pred()->get_target()->get_before()) {
 
                 r = WEAK_REQUIREMENT_ENABLED;
                 bm->load(&_original);


### PR DESCRIPTION
Background: During simulated chaining, `retrieve_simulated_imdl_bwd` matches a stored simulated requirement to a goal requirement. If a model has both strong and weak requirements, then during simulated forward chaining `retrieve_simulated_imdl_bwd` first [finds a matching strong requirement](https://github.com/IIIM-IS/AERA/blob/c2887c08f1548a33b565326627910f59af086b14/r_exec/mdl_controller.cpp#L743-L767) ("negative" requirement). Then it finds a matching weak requirement ("positive" requirement) and uses it if its confidence is [greater than the strong requirement](https://github.com/IIIM-IS/AERA/blob/c2887c08f1548a33b565326627910f59af086b14/r_exec/mdl_controller.cpp#L784). Otherwise the strong requirement "disables" the weak requirement. But it does not check the timings of the strong and weak requirements.

This works well for a simulation where the duration is only a few frames or where every step in the simulation uses different models. The problem is that, in more complex simulations (like hand-grab-sphere), a model may be relevant in multiple frames. A strong requirement may be stored with the timings of one frame, and a weak requirement for the same model may be stored with the timings of a later frame. In the later frame, the conditions that created the strong requirement may no longer hold. But `retrieve_simulated_imdl_bwd` will let the older strong requirement "disable" the weak requirement.

This pull request updates `retrieve_simulated_imdl_bwd` as follows. The weak requirement will be used if its confidence is greater than the strong requirement (as before). This condition applies the same whether the strong requirement is in the same frame with the weak requirement or earlier. In addition, we now use the weak requirement if its time interval begins after the time interval of the strong requirement (meaning that the strong requirement is for an earlier frame and shouldn't disable the weak requirement). (If there is a weak requirement with timings earlier than a strong requirement, it is already the case that `retrieve_simulated_imdl_bwd` will not use the "old" weak requirement, as desired.)