### PR TITLE
Add the defeasible consequence from weak requirements to its predictions

### DIFF
--- a/r_exec/factory.h
+++ b/r_exec/factory.h
@@ -468,7 +468,31 @@ public:
    */
   bool has_simulation(Sim* sim) const;
 
+  /**
+   * Check if this Pred has a defeasible consequence.
+   * \return True if this has a defeasible consequence.
+   */
+  bool has_defeasible_consequence() const { return !!defeasible_consequence_; }
+
+  /**
+   * Get this Pred's defeasible consequence, creating one if it doesn't already exist. If you don't want to
+   * create a defeasible consequence , check has_defeasible_consequence() first.
+   * \return This Pred's defeasible_consequence_.
+   */
+  DefeasibleValidity* get_defeasible_consequence() {
+    if (!defeasible_consequence_)
+      defeasible_consequence_ = new DefeasibleValidity();
+    return defeasible_consequence_;
+  }
+
 private:
+  /**
+   * defeasible_consequence_ is a unique DefeasibleValidity for this Pred which is attached to predicted consequences so
+   * that they can be invalidated if this Pred is defeated. (However, invalidating the DefeasibleValidity does not
+   * invalidate this Pred.)
+   */
+  P<DefeasibleValidity> defeasible_consequence_;
+
   void construct(_Fact *target, const std::vector<P<Sim> >& simulations, float32 psln_thr);
 };
 

--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -794,6 +794,8 @@ ChainingStatus MDLController::retrieve_simulated_imdl_bwd(HLPBindingMap *bm, Fac
                 // the strong requirement is not earlier than the weak. Now make sure it is not later.
                 if (strong_requirement_ground &&
                     strong_requirement_ground->get_pred()->get_target()->get_after() < _f_imdl->get_before()) {
+                  if ((*e).evidence_->get_pred()->has_defeasible_consequence())
+                    (*e).evidence_->get_pred()->get_defeasible_consequence()->invalidate();
                   if (r != WEAK_REQUIREMENT_ENABLED) {
                     ground = (*e).evidence_;
                     r = STRONG_REQUIREMENT_DISABLED_WEAK_REQUIREMENT;
@@ -2257,12 +2259,11 @@ bool PrimaryMDLController::check_simulated_imdl(Fact *goal, HLPBindingMap *bm, S
         get_requirement_count(wr_count, sr_count);
         if (wr_count > 0 && sr_count > 0) {
           // Attach a DefeasibleValidity object to the prediction so that it can be invalidated later by a strong requirement.
-          P<DefeasibleValidity> defeasible_validity = new DefeasibleValidity();
-          injected_lhs->get_pred()->defeasible_validities_.insert(defeasible_validity);
+          injected_lhs->get_pred()->defeasible_validities_.insert(ground->get_pred()->get_defeasible_consequence());
 
           // Add to the list which is later checked if we match a strong requirement.
           defeasible_weak_requirements_.CS_.enter();
-          defeasible_weak_requirements_.list_.push_front(DefeasibleWeakRequirement(ground, defeasible_validity));
+          defeasible_weak_requirements_.list_.push_front(DefeasibleWeakRequirement(ground, ground->get_pred()->get_defeasible_consequence()));
           defeasible_weak_requirements_.CS_.leave();
         }
       }

--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1696,6 +1696,16 @@ void PrimaryMDLController::predict(HLPBindingMap *bm, _Fact *input, Fact *f_imdl
     }
   } else { // no monitoring for simulated predictions.
 
+    if (ground) {
+      // Check if there could be a strong requirement in the future that could defeat the ground.
+      uint32 wr_count;
+      uint32 sr_count;
+      get_requirement_count(wr_count, sr_count);
+      if (wr_count > 0 && sr_count > 0)
+        // Attach a DefeasibleValidity object to the prediction so that it can be invalidated later by a strong requirement.
+        pred->defeasible_validities_.insert(ground->get_pred()->get_defeasible_consequence());
+    }
+
     // In the Pred constructor, we already copied the simulations from prediction.
     if (!HLPController::inject_prediction(production, confidence)) // inject a simulated prediction in the primary group.
       return;

--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -2260,11 +2260,6 @@ bool PrimaryMDLController::check_simulated_imdl(Fact *goal, HLPBindingMap *bm, S
         if (wr_count > 0 && sr_count > 0) {
           // Attach a DefeasibleValidity object to the prediction so that it can be invalidated later by a strong requirement.
           injected_lhs->get_pred()->defeasible_validities_.insert(ground->get_pred()->get_defeasible_consequence());
-
-          // Add to the list which is later checked if we match a strong requirement.
-          defeasible_weak_requirements_.CS_.enter();
-          defeasible_weak_requirements_.list_.push_front(DefeasibleWeakRequirement(ground, ground->get_pred()->get_defeasible_consequence()));
-          defeasible_weak_requirements_.CS_.leave();
         }
       }
 
@@ -2274,26 +2269,6 @@ bool PrimaryMDLController::check_simulated_imdl(Fact *goal, HLPBindingMap *bm, S
   default: // WEAK_REQUIREMENT_DISABLED, STRONG_REQUIREMENT_NO_WEAK_REQUIREMENT or STRONG_REQUIREMENT_DISABLED_WEAK_REQUIREMENT.
     if (c_s == STRONG_REQUIREMENT_DISABLED_WEAK_REQUIREMENT && prediction_sim && ground && strong_requirement_ground) {
       // A strong requirement disabled the weak requirement.
-
-      // Check if the strong requirement defeats a result from a weak requirement.
-      defeasible_weak_requirements_.CS_.enter();
-      for (auto e = defeasible_weak_requirements_.list_.begin(); e != defeasible_weak_requirements_.list_.end();) {
-        if (e->weak_requirement_->is_invalidated() || e->defeasible_validity_->is_invalidated())
-          // Garbage collection.
-          e = defeasible_weak_requirements_.list_.erase(e);
-        else if (((_Fact*)e->weak_requirement_) == ground) {
-          // The strong requirement defeats the result based on the weak requirement, so invalidate the
-          // DefeasibleValidity object which was attached to the resulting and following predictions.
-          e->defeasible_validity_->invalidate();
-
-          // We are done checking the grounds for this result, so delete this entry.
-          e = defeasible_weak_requirements_.list_.erase(e);
-        }
-        else
-          ++e;
-      }
-      defeasible_weak_requirements_.CS_.leave();
-
 #ifdef WITH_DETAIL_OID
       OUTPUT_LINE(MDL_OUT, Utils::RelativeTime(Now()) << " mdl " << get_object()->get_oid() << ": fact (" <<
         to_string(ground->get_detail_oid()) << ") pred fact imdl, from goal req " << goal->get_oid() <<

--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -784,14 +784,21 @@ ChainingStatus MDLController::retrieve_simulated_imdl_bwd(HLPBindingMap *bm, Fac
               if ((*e).confidence_ > negative_cfd ||
                   _f_imdl->get_after() >= strong_requirement_ground->get_pred()->get_target()->get_before()) {
 
-                r = WEAK_REQUIREMENT_ENABLED;
-                bm->load(&_original);
-                ground = (*e).evidence_;
-                break;
+                if (r != WEAK_REQUIREMENT_ENABLED) {
+                  r = WEAK_REQUIREMENT_ENABLED;
+                  bm->load(&_original);
+                  ground = (*e).evidence_;
+                }
               } else {
-                // For informational purposes, set ground in case this returns STRONG_REQUIREMENT_DISABLED_WEAK_REQUIREMENT.
-                ground = (*e).evidence_;
-                r = STRONG_REQUIREMENT_DISABLED_WEAK_REQUIREMENT;
+                // Make sure the strong requirement timings overlap the weak requirement. We already made sure
+                // the strong requirement is not earlier than the weak. Now make sure it is not later.
+                if (strong_requirement_ground &&
+                    strong_requirement_ground->get_pred()->get_target()->get_after() < _f_imdl->get_before()) {
+                  if (r != WEAK_REQUIREMENT_ENABLED) {
+                    ground = (*e).evidence_;
+                    r = STRONG_REQUIREMENT_DISABLED_WEAK_REQUIREMENT;
+                  }
+                }
               }
             }
           }

--- a/r_exec/mdl_controller.h
+++ b/r_exec/mdl_controller.h
@@ -235,31 +235,6 @@ protected:
   CriticalSection active_requirementsCS_;
   std::unordered_map<P<_Fact>, RequirementsPair, r_code::PHash<_Fact> > active_requirements_; // Key: P<_Fact>: f1 as in f0->pred->f1->imdl; Value:requirements having allowed the production of prediction.
 
-  /**
-   * A DefeasibleWeakRequirement holds the weak requirement which is the ground for a defeasible
-   * prediction, and the DefeasibleValidity which is attached to the prediction and is invalidated if a
-   * strong requirement later defeats the weak requirement.
-   */
-  class DefeasibleWeakRequirement {
-  public:
-    DefeasibleWeakRequirement()
-      : weak_requirement_(NULL), defeasible_validity_(NULL)
-    {}
-
-    /**
-     * Create a DefeasibleWeakRequirement with the given values
-     * \param weak_requirement The weak requirement which is the ground for the defeasible prediction.
-     * \param defeasible_validity The DefeasibleValidity object that is attached to the defeasible prediction.
-     */
-    DefeasibleWeakRequirement(_Fact* weak_requirement, DefeasibleValidity* defeasible_validity)
-      : weak_requirement_(weak_requirement), defeasible_validity_(defeasible_validity)
-    {}
-
-    P<_Fact> weak_requirement_;
-    P<DefeasibleValidity> defeasible_validity_;
-  };
-  CriticalSectionList<DefeasibleWeakRequirement> defeasible_weak_requirements_;
-
   template<class C> void reduce_cache(Fact *f_p_f_imdl, MDLController *controller) { // fwd; controller is the controller of the requirement which produced f_p_f_imdl.
 
     BatchReductionJob<C, Fact, MDLController> *j = new BatchReductionJob<C, Fact, MDLController>((C *)this, f_p_f_imdl, controller);


### PR DESCRIPTION
Pull request #182 added support for `DefeasibleValidity` which is attached to the simulated predicted command that comes from a weak requirement. The `DefeasibleValidity` is attached to all simulated predictions which come from the command. If later in the simulation a strong requirement disables the weak requirement, then the `DefeasibleValidity` is invalidated, which invalidates all the predictions which came from the command.

This works as long as each model has a unique command on its LHS. But if multiple models have the same command on the LHS, then the following scenario is possible. Consider these two models from the Pong example (simplified):

    mdl_ball_position_y:(mdl [B: X0: Y0: VX: VY: T0: T1:] []
       (fact (cmd tick |[]) T0_cmd: T1_cmd:)
       (fact (mk.val B: position_y Y1:) T2: T3:))

    mdl_ball_bounce_wall_y:(mdl [B: X0: Y0: VX: VY: T0: T1:] []
       (fact (cmd tick |[]) T0_cmd: T1_cmd:)
       (fact (mk.val B: position_y Y1:) T2: T3:))

They both have the same LHS command `(cmd tick |[])`. Model `mdl_ball_position_y` predicts the ball's next Y position under "normal" motion after each tick. Model `mdl_ball_bounce_wall_y` predicts the ball's next Y position if the ball is at the position of a wall and bounces. In this example, the ball's Y position is 15 and so is the wall. The requirement model for `mdl_ball_position_y` makes a weak requirement `req1` (simplified):

    req1:(fact (pred (fact (imdl mdl_ball_position_y [b 30 15 1 1 3s:0ms:0us 3s:100ms:0us]))))

This instantiates model `mdl_ball_position_y` and a predicted command is made from its LHS:

    cmd1:(fact (pred (fact (cmd tick |[]))))   ; d1 is attached to the pred.

As explained in pull request #182, a new `DefeasibleValidity` object is created which we call `d1`, and is attached to `cmd1`. (The idea is that `d1` will be attached to all further predictions.)

Since the ball's Y position is the same as the wall, the "bounce" model `mdl_ball_bounce_wall_y` is also instantiated and a predicted command is made from its LHS:

    cmd2:(fact (pred (fact (cmd tick |[]))))   ; d2 is attached to the pred.

Even though `cmd2` has the same structure as `cmd1`, they are independent objects, and a different `DefeasibleValidity` object is attached, called `d2`. In general, for a model to make a prediction, a command is matched to its LHS. But predicted commands by themselves are independent of the model. In this case `cmd1` and `cmd2` are independent of models such as `mdl_ball_position_y`. So, it is possible for `cmd2` to match the LHS of `mdl_ball_position_y` and make the predicted Y position for "normal" motion:

    fact1:(fact (pred (fact (mk.val b position_y 16))))   ; d2 is attached to the pred.

Note that `d2` is attached to `cmd2`, so it is also attached to `fact1`. This fact can trigger further predictions which all have `d2` attached. At a later step, a composite state is instantiated and creates a strong requirement which disables `req1`. In this example, the strong requirement on model `mdl_ball_position_y` occurs because the ball and the wall both have Y position 15, so the prediction that the ball will continue to 16 will fail. (It will "bounce" to 14.) As explained in pull request #182, when the strong requirement disables weak requirement `req1`, it invalidates `d1`. However, predictions such as `fact1` do not have this `DefeasibleValidity` object. Instead they have `d2` which came from `cmd2`, and `d2` is not invalidated. The problem is that the predictions from a defeated weak requirement are not invalidated as expected, since the predictions were made from the LHS command of a different model.

This pull request has five commits. The first four commits update the way in which a `DefeasibleValidity` from a weak requirement is attached to the command, but does not change functionality. With this in place, the final commit adds some functionality to solve the problem described above.

The first commit updates the `Pred` class to support a "defeasible consequence" which is a unique `DefeasibleValidity` for the `Pred` object, and can be attached to following predicted consequences so that they can be invalidated if the `Pred` is defeated. This commit does not change functionality.

The second commit updates the logic in `retrieve_simulated_imdl_bwd` which currently loops through the list of weak requirements and returns when the first weak requirement is found which is not disabled by the strong requirement. The updated logic returns the same weak requirement, but allows the loop to continue through the entire list. (This is needed for the following commit.)

The third commit updates the logic for handling a weak requirement's `DefeasibleValidity` as follows. Currently, when a simulated predicted command is made from a model's LHS, a new `DefeasbileValidity` is attached and [independently associated with the weak requirement](https://github.com/IIIM-IS/AERA/blob/master/r_exec/mdl_controller.cpp#L2253-L2259) with a separate list and data structure. This commit simplifies the logic to simply attach the weak requirement's "defeasible consequence" object. (In the example above, `d1` is the "defeasible consequence" which belongs to `req1`.) And now it is `retrieve_simulated_imdl_bwd` which [invalidates the weak requirement's "defeasible consequence"](https://github.com/IIIM-IS/AERA/blob/60fb2f2ca0e540c30dc9dfc34c54fbcb15a60715/r_exec/mdl_controller.cpp#L797-L798) when it is disabled by a strong requirement. Since this now loops through all weak requirements, this is done for each weak requirements which is disabled by the strong requirement, even if it is not the one returned by `retrieve_simulated_imdl_bwd`. This simplifies the logic (and prepares for the solution in the final commit) but does not change functionality.

The fourth commit removes support for `defeasible_weak_requirements_` (that was added in pull request #182) which associates the new `DefeasibleValidity` with the weak requirement. This is now done by the simpler "defeasible consequence" which comes directly from the weak requirement.

Finally, the fifth commit solves the problem described above as follows. `PrimaryMDLController::predict` matches a command to the model's LHS and uses a weak requirement to make a simulated prediction from the RHS. If the model can have a strong requirement, we attach the weak requirement's "defeasible consequence" to the prediction. (In the example above, `d1` from `req1` is attached to the prediction `fact1`.) Note that this is independent of any `DefeasibleValidity` attached to the command that matched the LHS. When the weak requirement is later disabled by a strong requirement, the prediction from the RHS (and all following predictions) is invalidated as expected. (In the example above, the strong requirement invalidates `d1`, which is now attached to `fact1`. This invalidates `fact1` as expected.)