### PR TITLE
If LHS command is already signalled, update its set of DefeasibleValidities

### DIFF
--- a/r_exec/factory.h
+++ b/r_exec/factory.h
@@ -329,8 +329,8 @@ public:
   // (For a critical section, expect to use defeasible_promoted_facts_.CS_ .)
   r_code::list<P<_Fact> > defeating_facts_;
 
-  // A list of pairs of controller and (fact (cmd ::)) to check if a command has already been signalled in this sim by the controller.
-  std::vector<std::pair<Controller*, P<_Fact> > > already_signalled_;
+  // A list of (fact (pred (fact (cmd ::)))) to check if a command has already been signalled in this sim.
+  std::vector<P<_Fact> > already_signalled_;
 
 private:
   std::vector<P<_Fact> > goalTargets_;

--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -2099,12 +2099,12 @@ _Fact* PrimaryMDLController::abduce_simulated_lhs(HLPBindingMap *bm, Fact *super
           Fact* fact_pred_bound_lhs = new Fact(pred, now, now, 1, 1);
           if (ground_pred && ground_pred->get_simulations_size() == 1) {
             // Check if a call to signal already caused this same LHS to be abduced with the same conditions, in this Sim by this controller.
-            vector<pair<Controller*, P<_Fact> > >& sim_already_signalled = ground_pred->get_simulation((uint16)0)->already_signalled_;
+            vector<P<_Fact> >& sim_already_signalled = ground_pred->get_simulation((uint16)0)->already_signalled_;
             bool found = false;
             // TODO: Do we need a critical section for this loop?
             for (auto signalled = sim_already_signalled.begin(); signalled != sim_already_signalled.end(); ++signalled) {
               // TODO: Check if signalled is invalidated?
-              Pred* signalled_pred = signalled->second->get_pred();
+              Pred* signalled_pred = (*signalled)->get_pred();
               if (_Fact::MatchObject(bound_lhs, signalled_pred->get_target())) {
                 // Use the existing command but remove DefeasibleValidities which are not in the new command. This effectively
                 // sets the defeasible_validities_ of the existing command to the intersection of it and the
@@ -2126,7 +2126,7 @@ _Fact* PrimaryMDLController::abduce_simulated_lhs(HLPBindingMap *bm, Fact *super
               // Don't signal again.
               break;
             // Save for checking later and continue.
-            sim_already_signalled.push_back(pair<Controller*, P<_Fact> >(this, fact_pred_bound_lhs));
+            sim_already_signalled.push_back(fact_pred_bound_lhs);
           }
 
           inject_simulation(fact_pred_bound_lhs, now);

--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -2094,6 +2094,9 @@ _Fact* PrimaryMDLController::abduce_simulated_lhs(HLPBindingMap *bm, Fact *super
           // This was called from check_simulated_imdl. Keep simulating forward. Don't loop by abducing the LHS as a goal again.
           // TODO: Handle the case when there are other than one Sim in the prediction.
           Pred* ground_pred = ground->get_pred();
+          // Copy all the Sims from ground.
+          Pred *pred = new Pred(bound_lhs, ground_pred, 1);
+          Fact* fact_pred_bound_lhs = new Fact(pred, now, now, 1, 1);
           if (ground_pred && ground_pred->get_simulations_size() == 1) {
             // Check if a call to signal already caused this same LHS to be abduced with the same conditions, in this Sim by this controller.
             vector<pair<Controller*, P<_Fact> > >& sim_already_signalled = ground_pred->get_simulation((uint16)0)->already_signalled_;
@@ -2101,7 +2104,19 @@ _Fact* PrimaryMDLController::abduce_simulated_lhs(HLPBindingMap *bm, Fact *super
             // TODO: Do we need a critical section for this loop?
             for (auto signalled = sim_already_signalled.begin(); signalled != sim_already_signalled.end(); ++signalled) {
               // TODO: Check if signalled is invalidated?
-              if (signalled->first == this && _Fact::MatchObject(bound_lhs, signalled->second)) {
+              Pred* signalled_pred = signalled->second->get_pred();
+              if (_Fact::MatchObject(bound_lhs, signalled_pred->get_target())) {
+                // Use the existing command but remove DefeasibleValidities which are not in the new command. This effectively
+                // sets the defeasible_validities_ of the existing command to the intersection of it and the
+                // defeasible_validities_ of the new command, so that a command will survive unless it would be
+                // defeated in both cases.
+                for (auto d = signalled_pred->defeasible_validities_.begin();
+                     d != signalled_pred->defeasible_validities_.end();) {
+                  if (ground_pred->defeasible_validities_.find(*d) == ground_pred->defeasible_validities_.end())
+                    d = signalled_pred->defeasible_validities_.erase(d);
+                  else
+                    ++d;
+                }
                 found = true;
                 break;
               }
@@ -2111,12 +2126,9 @@ _Fact* PrimaryMDLController::abduce_simulated_lhs(HLPBindingMap *bm, Fact *super
               // Don't signal again.
               break;
             // Save for checking later and continue.
-            sim_already_signalled.push_back(pair<Controller*, P<_Fact> >(this, (_Fact*)bound_lhs));
+            sim_already_signalled.push_back(pair<Controller*, P<_Fact> >(this, fact_pred_bound_lhs));
           }
 
-          // Copy all the Sims from ground.
-          Pred *pred = new Pred(bound_lhs, ground_pred, 1);
-          Fact* fact_pred_bound_lhs = new Fact(pred, now, now, 1, 1);
           inject_simulation(fact_pred_bound_lhs, now);
           injected_lhs = fact_pred_bound_lhs;
 


### PR DESCRIPTION
During simulated forward chaining, when a simulated requirement is attached to a model controller, the existing simulated goal monitors [are signalled](https://github.com/IIIM-IS/AERA/blob/ea6eca6889be8b9a176a04482e23ae781e75427b/r_exec/mdl_controller.cpp#L1541-L1552) which may create a simulated predicted command from the LHS. This can happen multiple times for the same model. There is [existing code](https://github.com/IIIM-IS/AERA/blob/ffcd6ded25a990bd40c53d48cba71ab9bd33164a/r_exec/mdl_controller.cpp#L2102-L2108) to check if the same LHS command has already been signalled and to avoid injecting another identical command. This code does this check separately for each model controller because different models have different requirement and anti-requirement models attached and would be signalled under different circumstances.

But it is possible for two different model controllers to signal the same simulated predicted command from the LHS.  Consider these two models from the Pong example (simplified):

    mdl_ball_position_y:(mdl [B: X0: Y0: VX: VY: T0: T1:] []
       (fact (cmd tick |[]) T0_cmd: T1_cmd:)
       (fact (mk.val B: position_y Y1:) T2: T3:))

    mdl_ball_bounce_wall_y:(mdl [B: X0: Y0: VX: VY: T0: T1:] []
       (fact (cmd tick |[]) T0_cmd: T1_cmd:)
       (fact (mk.val B: position_y Y1:) T2: T3:))

They both have the same LHS command `(cmd tick |[])`. Model `mdl_ball_position_y` predicts the ball's next Y position under "normal" motion after each tick. Model `mdl_ball_bounce_wall_y` predicts the ball's next Y position if the ball is at the position of a wall and bounces. It is possible that they are both signalled, producing the following two facts from the LHS where `fact1` is made from `mdl_ball_position_y` and `fact2` is made from `mdl_ball_bounce_wall_y`.

    fact1:(fact (pred (fact (cmd tick |[]))));  d0 and d1 are attached to the pred
    fact2:(fact (pred (fact (cmd tick |[]))));  d0 and d2 are attached to the pred

In this example, both have the same `DefeasibleValidity` object `d0` attached. Perhaps this comes from a fact that was produced at an earlier step in the simulation that both share. Also, a new `DefeasibleValidity` object is also added to each in case that a strong requirement might defeat the weak requirement: `d1` is attached to one that comes from the weak requirement of model `mdl_ball_position_y` and  `d2` is attached to one that comes from the weak requirement of model `mdl_ball_bounce_wall_y`.

However, even though they come from different models, the simulated predicted commands are identical, `(cmd tick |[])`. The problem is that during simulated forward chaining both of these can match the LHS of one model which "fires" once for each copy of the LHS, and injects the prediction from their respective RHS, resulting in two copies of the same RHS. After several frames this can happen multiple times causing a runaway effect of duplicated processing. We would like the check for "already signalled" to avoid duplicating the identical LHS command, even though it comes from a different model.

This pull request has two commits. The first commit updates the check for "already signalled" to only check if the new candidate command matches an already-signalled command regardless of which model controller created it. In this example, it means that we would keep `fact1` and not inject `fact2`. But `fact1` has `DefeasibleValidity` object `d1` attached which came from the weak requirement for model `mdl_ball_position_y`. This can be defeated in a later step by a strong requirement on this model. But `fact2` comes from a different model and shouldn't be defeated. The solution is to keep `fact1` but updates its set of `DefeasibleValidity` objects to the intersection of it with the set for `fact2` (and to not inject `fact2`). In this case `fact1` is updated to only have `d0` which is a `DefeasibleValidity` which is common to both.

The second commit simply updates the `already_signalled_` structure to remove the `Controller` since we don't need to keep track of this anymore.