### PR TITLE
Add duration support (but don't require it yet)

### DIFF
--- a/AERA/replicode_v1.2/ball.external.replicode
+++ b/AERA/replicode_v1.2/ball.external.replicode
@@ -5,7 +5,7 @@ b:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 ; The statement that b is a ball.
 b_is_a_ball:(mk.val b essence ball 1) |[]
 ; Make b_is_a_ball a fact from now to the maximum time. 
-f_b_is_a_ball:(fact b_is_a_ball 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+f_b_is_a_ball:(fact b_is_a_ball 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 
 ; The start program ejects the command to tell the I/O device it is ready for "ball". 
 ; The I/O device will simulate the motion and inject velocity_y and position_y for the ball b.

--- a/AERA/replicode_v1.2/ball.goal.external.replicode
+++ b/AERA/replicode_v1.2/ball.goal.external.replicode
@@ -5,9 +5,9 @@ b:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 ; The statement that b is a ball.
 b_is_a_ball:(mk.val b essence ball 1) |[]
 ; Make b_is_a_ball a fact from now to the maximum time. 
-f_b_is_a_ball:(fact b_is_a_ball 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+f_b_is_a_ball:(fact b_is_a_ball 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 
-!def inject_drive_time 500000us
+!def inject_drive_time 500ms
 
 ; The start program ejects the command to tell the I/O device it is ready for "ball". 
 ; The I/O device will simulate the motion and inject velocity_y and position_y for the ball b.
@@ -46,15 +46,15 @@ mdl_set_velocity_y:(mdl [B: P0: T0: T1:]
    (fact (cmd set_velocity_y [B: V:] 1) T0_cmd: T1_cmd: : :)
    (fact (mk.val B: position_y P1: :) T2: T3: : :)
 []
-   T2:(add T0 0s:100ms:0us)
-   T3:(add T1 0s:100ms:0us)
-   P1:(+ P0 (mul V 0s:100ms:0us))
+   T2:(add T0 100ms)
+   T3:(add T1 100ms)
+   P1:(+ P0 (mul V 100ms))
 []
-   V:(/ (- P1 P0) 0s:100ms:0us)
-   T0:(sub T2 0s:100ms:0us)
-   T1:(sub T3 0s:100ms:0us)
-   T0_cmd:(sub T2 0s:80ms:0us)
-   T1_cmd:(sub T3 0s:100ms:0us)
+   V:(/ (- P1 P0) 100ms)
+   T0:(sub T2 100ms)
+   T1:(sub T3 100ms)
+   T0_cmd:(sub T2 80ms)
+   T1_cmd:(sub T3 100ms)
 [stdin] 0 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 mdl_set_velocity_y_req:(mdl |[]
@@ -85,7 +85,7 @@ pgm_inject_drive:(pgm |[]
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
       ; The end of the time interval will be used in mdl_run_position as the end of the goal interval.
-      f_run:(fact run (+ after 10000us) (+ (+ this.vw.ijt inject_drive_time) 300000us) 1 1)
+      f_run:(fact run (+ after 10ms) (+ (+ this.vw.ijt inject_drive_time) 300ms) 1 1)
       |[]
    )
    (inj []
@@ -93,7 +93,7 @@ pgm_inject_drive:(pgm |[]
       |[]
    )
    (inj []
-      (fact g t1:(+ after 10000us) t1 1 1)
+      (fact g t1:(+ after 10ms) t1 1 1)
       [SYNC_ONCE t1 1 forever primary nil]
    )
    (prb [1 "print" "injected drive" |[]])

--- a/AERA/replicode_v1.2/drives.replicode
+++ b/AERA/replicode_v1.2/drives.replicode
@@ -3,7 +3,7 @@
 
 init_run_pgm:(pgm |[] |[] |[] []
    (inj []
-      f_run:(fact run t0:(+ now 50000us) (+ t0 sampling_period) 1 1)
+      f_run:(fact run t0:(+ now 50ms) (+ t0 sampling_period) 1 1)
       |[]
    )
    (inj []
@@ -17,7 +17,7 @@ init_run_pgm:(pgm |[] |[] |[] []
    (prb [1 "print" "init_run_pgm" |[]])
 1) |[]
 
-init_run_ipgm:(ipgm init_run_pgm |[] RUN_ONCE 50000us VOLATILE SILENT 1) [[SYNC_ONCE now 0 1 drives nil 1]]
+init_run_ipgm:(ipgm init_run_pgm |[] RUN_ONCE 50ms VOLATILE SILENT 1) [[SYNC_ONCE now 0 1 drives nil 1]]
 
 success_run_pgm:(pgm |[] []
    s:(ptn (fact (success (fact (goal (fact run after: before: ::) ::) ::) ::) ::) |[])

--- a/AERA/replicode_v1.2/hand-grab-sphere-learn.replicode
+++ b/AERA/replicode_v1.2/hand-grab-sphere-learn.replicode
@@ -8,19 +8,19 @@
 attached:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
 h:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 h_is_a_hand:(mk.val h essence hand 1) |[]
-(fact h_is_a_hand 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+(fact h_is_a_hand 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 c:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 c_is_a_cube:(mk.val c essence cube 1) |[]
-(fact c_is_a_cube 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+(fact c_is_a_cube 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 c_is_a_hand:(mk.val c essence hand 1) |[]
 ; This is needed for S3.
-(|fact c_is_a_hand 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+(|fact c_is_a_hand 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 s:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 s_is_a_sphere:(mk.val s essence sphere 1) |[]
-(fact s_is_a_sphere 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+(fact s_is_a_sphere 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 s_is_a_hand:(mk.val s essence hand 1) |[]
 ; This is needed for S3.
-(|fact s_is_a_hand 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+(|fact s_is_a_hand 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 
 ; Hand H has position P.
 S0:(cst |[]
@@ -38,15 +38,15 @@ M0:(mdl [H: P0: T0: T1:]
    (fact (mk.val H: position P1: :) T1_RHS: T3: : :); Change T1 to T1_RHS.
 []
    P1:(+ P0 DeltaP)
-   T1_RHS:(+ T0 0s:100ms:0us)
-   T3:(+ T1 0s:100ms:0us)
+   T1_RHS:(+ T0 100ms)
+   T3:(+ T1 100ms)
 []
    (<> P1 P0); Don't make a subgoal that doesn't change anything.
    DeltaP:(- P1 P0)
-   T2:(- T1_RHS 0s:80ms:0us); Change 50ms delay to 20ms.
-   T1_cmd:(- T3 0s:100ms:0us)
-   T0:(- T1_RHS 0s:100ms:0us)
-   T1:(- T3 0s:100ms:0us)
+   T2:(- T1_RHS 80ms); Change 50ms delay to 20ms.
+   T1_cmd:(- T3 100ms)
+   T0:(- T1_RHS 100ms)
+   T1:(- T3 100ms)
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; If we observe state S0 (hand H has position P0), then if M0 predicts something (position P1) it will be right.
@@ -84,13 +84,13 @@ S3:(cst |[]
 ;   (fact (cmd grab [H:] :) T2: T1_cmd: : :); Change T1 to T1_cmd.
 ;   (fact (mk.val H: attached [C:] :) T1_RHS: T3: : :); Change T1 to T1_RHS.
 ;[]
-;   T1_RHS:(+ T0 0s:100ms:0us); Copy from M0.
-;   T3:(+ T1 0s:100ms:0us);     Copy from M0.
+;   T1_RHS:(+ T0 100ms); Copy from M0.
+;   T3:(+ T1 100ms);     Copy from M0.
 ;[]
-;   T2:(- T1_RHS 0s:80ms:0us);  Copy from M0.
-;   T1_cmd:(- T3 0s:100ms:0us); Copy from M0.
-;   T0:(- T1_RHS 0s:100ms:0us); Copy from M0.
-;   T1:(- T3 0s:100ms:0us);     Copy from M0.
+;   T2:(- T1_RHS 80ms);  Copy from M0.
+;   T1_cmd:(- T3 100ms); Copy from M0.
+;   T0:(- T1_RHS 100ms); Copy from M0.
+;   T1:(- T3 100ms);     Copy from M0.
 ;[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 ;
 ;; M2 will work (something will be attached to hand H) if it is at the same position as hand H and it is not already attached.
@@ -120,13 +120,13 @@ S2:(cst |[]
 ;   (fact (cmd release [H:] :) T2: T1_cmd: : :); Change T1 to T1_cmd.
 ;   (fact (mk.val H: attached |[] :) T1_RHS: T3: : :); Change T1 to T1_RHS. Change anti-fact to fact of attached to |[].
 ;[]
-;   T1_RHS:(+ T0 0s:100ms:0us); Copy from M0.
-;   T3:(+ T1 0s:100ms:0us);     Copy from M0.
+;   T1_RHS:(+ T0 100ms); Copy from M0.
+;   T3:(+ T1 100ms);     Copy from M0.
 ;[]
-;   T2:(- T1_RHS 0s:80ms:0us);  Copy from M0.
-;   T1_cmd:(- T3 0s:100ms:0us); Copy from M0.
-;   T0:(- T1_RHS 0s:100ms:0us); Copy from M0.
-;   T1:(- T3 0s:100ms:0us);     Copy from M0.
+;   T2:(- T1_RHS 80ms);  Copy from M0.
+;   T1_cmd:(- T3 100ms); Copy from M0.
+;   T0:(- T1_RHS 100ms); Copy from M0.
+;   T1:(- T3 100ms);     Copy from M0.
 ;[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 ;
 ;; M4 will work (some C will not be attached to hand H) if it is at the same position as hand H and it is already attached.
@@ -144,15 +144,15 @@ M6:(mdl [H: C: P0: T0: T1:]
    (fact (imdl M0 [H: P0: T0_M0: T1_M0:] [DeltaP: P1: T1_RHS: T3:] : :) T0_cmd: T1_cmd: : :); Change timings from T1 T3 to T0_cmd T1_cmd. T2 is not exposed from M0. T1_RHS is also exposed. Distinguish T0_M0 and T1_M0.
    (fact (mk.val C: position P1: :) T1_RHS: T3: : :); Fix bug as explained: Change C to P1. Change T1 to T1_RHS.
 []
-   T1_RHS:(+ T0 0s:100ms:0us); Repeat from M0.
-   T3:(+ T1 0s:100ms:0us);     Repeat from M0.
+   T1_RHS:(+ T0 100ms); Repeat from M0.
+   T3:(+ T1 100ms);     Repeat from M0.
 []
-   T0_cmd:(- T1_RHS 0s:100ms:0us); Copy from M0, but subtract 100ms because the LHS is not a command.
-   T1_cmd:(- T3 0s:100ms:0us);     Copy from M0.
-   T0:(- T1_RHS 0s:100ms:0us);     Copy from M0.
-   T1:(- T3 0s:100ms:0us);         Copy from M0.
-   T0_M0:(- T1_RHS 0s:100ms:0us);  Duplicate T0.
-   T1_M0:(- T3 0s:100ms:0us);      Duplicate T0.
+   T0_cmd:(- T1_RHS 100ms); Copy from M0, but subtract 100ms because the LHS is not a command.
+   T1_cmd:(- T3 100ms);     Copy from M0.
+   T0:(- T1_RHS 100ms);     Copy from M0.
+   T1:(- T3 100ms);         Copy from M0.
+   T0_M0:(- T1_RHS 100ms);  Duplicate T0.
+   T1_M0:(- T3 100ms);      Duplicate T0.
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; When some C is attached to hand H and the hand moves to position P1, then C will also be at P1.
@@ -169,10 +169,10 @@ M7:(mdl |[]
 !def pS1 15
 
 ; Execute babble pass A commands.
-!def DRIVE_PASS1_START 0s:800ms:0us
-!def DRIVE_PASS1_END (+ DRIVE_PASS1_START 0s:400ms:0us)
+!def DRIVE_PASS1_START 800ms
+!def DRIVE_PASS1_END (+ DRIVE_PASS1_START 400ms)
 ; Execute babble pass B commands.
-!def DRIVE_PASS2_START (+ DRIVE_PASS1_END 1s:200ms:0us)
+!def DRIVE_PASS2_START (+ DRIVE_PASS1_END 1200ms)
 
 ; Initial conditions.
 start:(pgm |[] |[] |[] []
@@ -227,7 +227,7 @@ pgm_babbleA_1:(pgm |[]
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h essence hand :) after: before: ::) |[])
 []
-   (>= after (+ this.vw.ijt 100000us))
+   (>= after (+ this.vw.ijt 100ms))
 []
    (inj []
       Command:(cmd grab [h] 1)
@@ -243,7 +243,7 @@ pgm_babbleA_1:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      Debug:(fact g t0:(+ after 10000us) t0 1 1)
+      Debug:(fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected (cmd grab [h])" [Debug]])
@@ -256,7 +256,7 @@ pgm_babbleA_2:(pgm |[]
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h essence hand :) after: before: ::) |[])
 []
-   (>= after (+ this.vw.ijt 200000us))
+   (>= after (+ this.vw.ijt 200ms))
 []
    (inj []
       Command:(cmd release [h] 1)
@@ -272,7 +272,7 @@ pgm_babbleA_2:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected (cmd release [h])" |[]])
@@ -285,7 +285,7 @@ pgm_babbleA_3:(pgm |[]
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h essence hand :) after: before: ::) |[])
 []
-   (>= after (+ this.vw.ijt 300000us))
+   (>= after (+ this.vw.ijt 300ms))
 []
    (inj []
       Command:(cmd move [h 5] 1)
@@ -301,7 +301,7 @@ pgm_babbleA_3:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected (cmd move [h 5])" |[]])
@@ -314,7 +314,7 @@ pgm_babbleA_4:(pgm |[]
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h essence hand :) after: before: ::) |[])
 []
-   (>= after (+ this.vw.ijt 400000us))
+   (>= after (+ this.vw.ijt 400ms))
 []
    (inj []
       Command:(cmd grab [h] 1)
@@ -330,7 +330,7 @@ pgm_babbleA_4:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected (cmd grab [h])" |[]])
@@ -343,7 +343,7 @@ pgm_babbleA_5:(pgm |[]
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h essence hand :) after: before: ::) |[])
 []
-   (>= after (+ this.vw.ijt 500000us))
+   (>= after (+ this.vw.ijt 500ms))
 []
    (inj []
       Command:(cmd release [h] 1)
@@ -359,7 +359,7 @@ pgm_babbleA_5:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected (cmd release [h])" |[]])
@@ -372,7 +372,7 @@ pgm_babbleA_6:(pgm |[]
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h essence hand :) after: before: ::) |[])
 []
-   (>= after (+ this.vw.ijt 600000us))
+   (>= after (+ this.vw.ijt 600ms))
 []
    (inj []
       Command:(cmd grab [h] 1)
@@ -388,7 +388,7 @@ pgm_babbleA_6:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected (cmd grab [h])" |[]])
@@ -401,7 +401,7 @@ pgm_babbleA_7:(pgm |[]
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h essence hand :) after: before: ::) |[])
 []
-   (>= after (+ this.vw.ijt 700000us))
+   (>= after (+ this.vw.ijt 700ms))
 []
    (inj []
       Command:(cmd move [h 20] 1)
@@ -417,7 +417,7 @@ pgm_babbleA_7:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected (cmd move [h 20])" |[]])
@@ -435,7 +435,7 @@ pgm_inject_drive_pass1:(pgm |[]
 []
    (inj []
       ; The end of the time interval will be used in m_drive as the end of the goal interval.
-      f_run:(fact run after (+ before 0s:500ms:0us) 1 1)
+      f_run:(fact run after (+ before 500ms) 1 1)
       |[]
    )
    (inj []
@@ -444,7 +444,7 @@ pgm_inject_drive_pass1:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected drive" |[]])
@@ -461,7 +461,7 @@ pgm_inject_drive_pass2:(pgm |[]
 []
    (inj []
       ; The end of the time interval will be used in m_drive as the end of the goal interval.
-      f_run:(fact run after (+ before 0s:500ms:0us) 1 1)
+      f_run:(fact run after (+ before 500ms) 1 1)
       |[]
    )
    (inj []
@@ -470,7 +470,7 @@ pgm_inject_drive_pass2:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected drive" |[]])
@@ -499,7 +499,7 @@ pgm_babbleB_0:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected (cmd move [h 0.1])" |[]])
@@ -512,7 +512,7 @@ pgm_babbleB_1:(pgm |[]
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h essence hand :) after: before: ::) |[])
 []
-   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 100000us)))
+   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 100ms)))
 []
    (inj []
       Command:(cmd release [h] 1); Special case to invoke pgm_cmd_release_push_c.
@@ -528,7 +528,7 @@ pgm_babbleB_1:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected (cmd release [h])" |[]])
@@ -541,7 +541,7 @@ pgm_babbleB_2:(pgm |[]
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h essence hand :) after: before: ::) |[])
 []
-   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 200000us)))
+   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 200ms)))
 []
    (inj []
       Command:(cmd move [h -0.1] 1)
@@ -557,7 +557,7 @@ pgm_babbleB_2:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected (cmd move [h 0.1])" |[]])
@@ -570,7 +570,7 @@ pgm_babbleB_3:(pgm |[]
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h essence hand :) after: before: ::) |[])
 []
-   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 300000us)))
+   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 300ms)))
 []
    (inj []
       Command:(cmd grab [h] 1)
@@ -586,7 +586,7 @@ pgm_babbleB_3:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected (cmd grab [h])" |[]])
@@ -599,7 +599,7 @@ pgm_babbleB_4:(pgm |[]
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h essence hand :) after: before: ::) |[])
 []
-   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 400000us)))
+   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 400ms)))
 []
    (inj []
       Command:(cmd release [h] 1)
@@ -615,7 +615,7 @@ pgm_babbleB_4:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected (cmd release [h])" |[]])
@@ -628,7 +628,7 @@ pgm_babbleB_5:(pgm |[]
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h essence hand :) after: before: ::) |[])
 []
-   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 500000us)))
+   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 500ms)))
 []
    (inj []
       Command:(cmd grab [h] 1)
@@ -644,7 +644,7 @@ pgm_babbleB_5:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected (cmd grab [h]" |[]])
@@ -657,7 +657,7 @@ pgm_babbleB_6:(pgm |[]
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h essence hand :) after: before: ::) |[])
 []
-   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 600000us)))
+   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 600ms)))
 []
    (inj []
       Command:(cmd release [h] 1)
@@ -673,7 +673,7 @@ pgm_babbleB_6:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected (cmd release [h])" |[]])
@@ -686,7 +686,7 @@ pgm_babbleB_7:(pgm |[]
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h essence hand :) after: before: ::) |[])
 []
-   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 700000us)))
+   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 700ms)))
 []
    (inj []
       Command:(cmd move [h 5] 1)
@@ -702,7 +702,7 @@ pgm_babbleB_7:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected (cmd move [h 5])" |[]])
@@ -715,7 +715,7 @@ pgm_babbleB_8:(pgm |[]
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h essence hand :) after: before: ::) |[])
 []
-   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 800000us)))
+   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 800ms)))
 []
    (inj []
       Command:(cmd grab [h] 1)
@@ -731,7 +731,7 @@ pgm_babbleB_8:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected (cmd grab [h])" |[]])
@@ -744,7 +744,7 @@ pgm_babbleB_9:(pgm |[]
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h essence hand :) after: before: ::) |[])
 []
-   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 900000us)))
+   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 900ms)))
 []
    (inj []
       Command:(cmd release [h] 1)
@@ -760,7 +760,7 @@ pgm_babbleB_9:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected (cmd release [h])" |[]])
@@ -773,7 +773,7 @@ pgm_babbleB_10:(pgm |[]
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h essence hand :) after: before: ::) |[])
 []
-   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 1000000us)))
+   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 1000ms)))
 []
    (inj []
       Command:(cmd grab [h] 1)
@@ -789,7 +789,7 @@ pgm_babbleB_10:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected (cmd grab [h])" |[]])
@@ -802,7 +802,7 @@ pgm_babbleB_11:(pgm |[]
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h essence hand :) after: before: ::) |[])
 []
-   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 1100000us)))
+   (>= after (+ this.vw.ijt (+ DRIVE_PASS1_END 1100ms)))
 []
    (inj []
       Command:(cmd move [h 20] 1)
@@ -818,7 +818,7 @@ pgm_babbleB_11:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected (cmd move [h 2])" |[]])
@@ -851,7 +851,7 @@ pgm_cmd_move_h_attached_c:(pgm |[]
       |[]
    )
    (inj []
-      (fact Command (+ After 20000us) Before 1 1)
+      (fact Command (+ After 20ms) Before 1 1)
       [SYNC_ONCE After 1 1 stdin nil]
    )
    (inj []
@@ -916,7 +916,7 @@ pgm_cmd_move_h_attached_s:(pgm |[]
       |[]
    )
    (inj []
-      (fact Command (+ After 20000us) Before 1 1)
+      (fact Command (+ After 20ms) Before 1 1)
       [SYNC_ONCE After 1 1 stdin nil]
    )
    (inj []
@@ -981,7 +981,7 @@ pgm_cmd_move_h_not_attached:(pgm |[]
       |[]
    )
    (inj []
-      (fact Command (+ After 20000us) Before 1 1)
+      (fact Command (+ After 20ms) Before 1 1)
       [SYNC_ONCE After 1 1 stdin nil]
    )
    (inj []
@@ -1041,7 +1041,7 @@ pgm_cmd_release_h:(pgm |[]
 []
    ; Inject the fact that the command was executed.
    (inj []
-      (fact Command (+ After 20000us) Before 1 1)
+      (fact Command (+ After 20ms) Before 1 1)
       [SYNC_ONCE After 1 1 stdin nil]
    )
    (inj []
@@ -1102,7 +1102,7 @@ pgm_cmd_release_h_not_attached:(pgm |[]
 []
    ; Inject the fact that the command was executed.
    (inj []
-      (fact Command (+ After 20000us) Before 1 1)
+      (fact Command (+ After 20ms) Before 1 1)
       [SYNC_ONCE After 1 1 stdin nil]
    )
    (inj []
@@ -1164,7 +1164,7 @@ pgm_cmd_release_push_c:(pgm |[]
 []
    ; Inject the fact that the command was executed.
    (inj []
-      (fact Command (+ After 20000us) Before 1 1)
+      (fact Command (+ After 20ms) Before 1 1)
       [SYNC_ONCE After 1 1 stdin nil]
    )
    (inj []
@@ -1226,7 +1226,7 @@ pgm_cmd_grab_h_s:(pgm |[]
 []
    ; Inject the fact that the command was executed.
    (inj []
-      (fact Command (+ After 20000us) Before 1 1)
+      (fact Command (+ After 20ms) Before 1 1)
       [SYNC_ONCE After 1 1 stdin nil]
    )
    (inj []
@@ -1288,7 +1288,7 @@ pgm_cmd_grab_h_c:(pgm |[]
 []
    ; Inject the fact that the command was executed.
    (inj []
-      (fact Command (+ After 20000us) Before 1 1)
+      (fact Command (+ After 20ms) Before 1 1)
       [SYNC_ONCE After 1 1 stdin nil]
    )
    (inj []
@@ -1350,7 +1350,7 @@ pgm_cmd_grab_h_fail:(pgm |[]
 []
    ; Inject the fact that the command was executed.
    (inj []
-      (fact Command (+ After 20000us) Before 1 1)
+      (fact Command (+ After 20ms) Before 1 1)
       [SYNC_ONCE After 1 1 stdin nil]
    )
    (inj []

--- a/AERA/replicode_v1.2/hand-grab-sphere.replicode
+++ b/AERA/replicode_v1.2/hand-grab-sphere.replicode
@@ -8,19 +8,19 @@
 attached:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
 h:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 h_is_a_hand:(mk.val h essence hand 1) |[]
-(fact h_is_a_hand 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+(fact h_is_a_hand 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 c:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 c_is_a_cube:(mk.val c essence cube 1) |[]
-(fact c_is_a_cube 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+(fact c_is_a_cube 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 c_is_a_hand:(mk.val c essence hand 1) |[]
 ; This is needed for S3.
-(|fact c_is_a_hand 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+(|fact c_is_a_hand 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 s:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 s_is_a_sphere:(mk.val s essence sphere 1) |[]
-(fact s_is_a_sphere 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+(fact s_is_a_sphere 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 s_is_a_hand:(mk.val s essence hand 1) |[]
 ; This is needed for S3.
-(|fact s_is_a_hand 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+(|fact s_is_a_hand 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 
 ; Hand H has position P.
 S0:(cst |[]
@@ -38,15 +38,15 @@ M0:(mdl [H: P0: T0: T1:]
    (fact (mk.val H: position P1: :) T1_RHS: T3: : :); Change T1 to T1_RHS.
 []
    P1:(+ P0 DeltaP)
-   T1_RHS:(+ T0 0s:100ms:0us)
-   T3:(+ T1 0s:100ms:0us)
+   T1_RHS:(+ T0 100ms)
+   T3:(+ T1 100ms)
 []
    (<> P1 P0); Don't make a subgoal that doesn't change anything.
    DeltaP:(- P1 P0)
-   T2:(- T1_RHS 0s:80ms:0us); Change 50ms delay to 20ms.
-   T1_cmd:(- T3 0s:100ms:0us)
-   T0:(- T1_RHS 0s:100ms:0us)
-   T1:(- T3 0s:100ms:0us)
+   T2:(- T1_RHS 80ms); Change 50ms delay to 20ms.
+   T1_cmd:(- T3 100ms)
+   T0:(- T1_RHS 100ms)
+   T1:(- T3 100ms)
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; If we observe state S0 (hand H has position P0), then if M0 predicts something (position P1) it will be right.
@@ -84,13 +84,13 @@ M2:(mdl [H: C: T0: T1:]
    (fact (cmd grab [H:] :) T2: T1_cmd: : :); Change T1 to T1_cmd.
    (fact (mk.val H: attached [C:] :) T1_RHS: T3: : :); Change T1 to T1_RHS.
 []
-   T1_RHS:(+ T0 0s:100ms:0us); Copy from M0.
-   T3:(+ T1 0s:100ms:0us);     Copy from M0.
+   T1_RHS:(+ T0 100ms); Copy from M0.
+   T3:(+ T1 100ms);     Copy from M0.
 []
-   T2:(- T1_RHS 0s:80ms:0us);  Copy from M0.
-   T1_cmd:(- T3 0s:100ms:0us); Copy from M0.
-   T0:(- T1_RHS 0s:100ms:0us); Copy from M0.
-   T1:(- T3 0s:100ms:0us);     Copy from M0.
+   T2:(- T1_RHS 80ms);  Copy from M0.
+   T1_cmd:(- T3 100ms); Copy from M0.
+   T0:(- T1_RHS 100ms); Copy from M0.
+   T1:(- T3 100ms);     Copy from M0.
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; M2 will work (something will be attached to hand H) if it is at the same position as hand H and it is not already attached.
@@ -120,13 +120,13 @@ M4:(mdl [H: C: T0: T1:]
    (fact (cmd release [H:] :) T2: T1_cmd: : :); Change T1 to T1_cmd.
    (fact (mk.val H: attached |[] :) T1_RHS: T3: : :); Change T1 to T1_RHS. Change anti-fact to fact of attached to |[].
 []
-   T1_RHS:(+ T0 0s:100ms:0us); Copy from M0.
-   T3:(+ T1 0s:100ms:0us);     Copy from M0.
+   T1_RHS:(+ T0 100ms); Copy from M0.
+   T3:(+ T1 100ms);     Copy from M0.
 []
-   T2:(- T1_RHS 0s:80ms:0us);  Copy from M0.
-   T1_cmd:(- T3 0s:100ms:0us); Copy from M0.
-   T0:(- T1_RHS 0s:100ms:0us); Copy from M0.
-   T1:(- T3 0s:100ms:0us);     Copy from M0.
+   T2:(- T1_RHS 80ms);  Copy from M0.
+   T1_cmd:(- T3 100ms); Copy from M0.
+   T0:(- T1_RHS 100ms); Copy from M0.
+   T1:(- T3 100ms);     Copy from M0.
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; M4 will work (some C will not be attached to hand H) if it is at the same position as hand H and it is already attached.
@@ -144,15 +144,15 @@ M6:(mdl [H: C: P0: T0: T1:]
    (fact (imdl M0 [H: P0: T0_M0: T1_M0:] [DeltaP: P1: T1_RHS: T3:] : :) T0_cmd: T1_cmd: : :); Change timings from T1 T3 to T0_cmd T1_cmd. T2 is not exposed from M0. T1_RHS is also exposed. Distinguish T0_M0 and T1_M0.
    (fact (mk.val C: position P1: :) T1_RHS: T3: : :); Fix bug as explained: Change C to P1. Change T1 to T1_RHS.
 []
-   T1_RHS:(+ T0 0s:100ms:0us); Repeat from M0.
-   T3:(+ T1 0s:100ms:0us);     Repeat from M0.
+   T1_RHS:(+ T0 100ms); Repeat from M0.
+   T3:(+ T1 100ms);     Repeat from M0.
 []
-   T0_cmd:(- T1_RHS 0s:100ms:0us); Copy from M0, but subtract 100ms because the LHS is not a command.
-   T1_cmd:(- T3 0s:100ms:0us);     Copy from M0.
-   T0:(- T1_RHS 0s:100ms:0us);     Copy from M0.
-   T1:(- T3 0s:100ms:0us);         Copy from M0.
-   T0_M0:(- T1_RHS 0s:100ms:0us);  Duplicate T0.
-   T1_M0:(- T3 0s:100ms:0us);      Duplicate T0.
+   T0_cmd:(- T1_RHS 100ms); Copy from M0, but subtract 100ms because the LHS is not a command.
+   T1_cmd:(- T3 100ms);     Copy from M0.
+   T0:(- T1_RHS 100ms);     Copy from M0.
+   T1:(- T3 100ms);         Copy from M0.
+   T0_M0:(- T1_RHS 100ms);  Duplicate T0.
+   T1_M0:(- T3 100ms);      Duplicate T0.
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; When some C is attached to hand H and the hand moves to position P1, then C will also be at P1.
@@ -168,7 +168,7 @@ M7:(mdl |[]
 !def pS0 0
 !def pS1 15
 
-!def DRIVE_START 0s:300ms:0us
+!def DRIVE_START 300ms
 
 ; Initial conditions.
 start:(pgm |[] |[] |[] []
@@ -227,7 +227,7 @@ pgm_inject_drive:(pgm |[]
 []
    (inj []
       ; The end of the time interval will be used in m_drive as the end of the goal interval.
-      f_run:(fact run after (+ before 0s:500ms:0us) 1 1)
+      f_run:(fact run after (+ before 500ms) 1 1)
       |[]
    )
    (inj []
@@ -236,7 +236,7 @@ pgm_inject_drive:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t0:(+ after 10000us) t0 1 1)
+      (fact g t0:(+ after 10ms) t0 1 1)
       [SYNC_ONCE t0 1 forever primary nil]
    )
    (prb [1 "print" "injected drive" |[]])
@@ -321,7 +321,7 @@ pgm_cmd_move_h_attached_c:(pgm |[]
       |[]
    )
    (inj []
-      (fact Command (+ After 20000us) Before 1 1)
+      (fact Command (+ After 20ms) Before 1 1)
       [SYNC_ONCE After 1 1 stdin nil]
    )
    (inj []
@@ -386,7 +386,7 @@ pgm_cmd_move_h_attached_s:(pgm |[]
       |[]
    )
    (inj []
-      (fact Command (+ After 20000us) Before 1 1)
+      (fact Command (+ After 20ms) Before 1 1)
       [SYNC_ONCE After 1 1 stdin nil]
    )
    (inj []
@@ -451,7 +451,7 @@ pgm_cmd_move_h_not_attached:(pgm |[]
       |[]
    )
    (inj []
-      (fact Command (+ After 20000us) Before 1 1)
+      (fact Command (+ After 20ms) Before 1 1)
       [SYNC_ONCE After 1 1 stdin nil]
    )
    (inj []
@@ -511,7 +511,7 @@ pgm_cmd_release_h:(pgm |[]
 []
    ; Inject the fact that the command was executed.
    (inj []
-      (fact Command (+ After 20000us) Before 1 1)
+      (fact Command (+ After 20ms) Before 1 1)
       [SYNC_ONCE After 1 1 stdin nil]
    )
    (inj []
@@ -572,7 +572,7 @@ pgm_cmd_grab_h:(pgm |[]
 []
    ; Inject the fact that the command was executed.
    (inj []
-      (fact Command (+ After 20000us) Before 1 1)
+      (fact Command (+ After 20ms) Before 1 1)
       [SYNC_ONCE After 1 1 stdin nil]
    )
    (inj []

--- a/AERA/replicode_v1.2/hello.world.1.replicode
+++ b/AERA/replicode_v1.2/hello.world.1.replicode
@@ -9,4 +9,4 @@ pgm0:(pgm |[] |[] |[] []
 
 ;                                                         [sync:SYNC_ONCE ijt:now sln:0 res:1 grp:stdin org:nil act:1]
 ;     (ipgm code:pgm0 args:[] run:bl tsc:us res:bl nfr:bl psln_thr:nb) ; bl is boolean, us is timestamp and nb is number
-ipgm0:(ipgm pgm0 |[] RUN_ONCE 50000us VOLATILE SILENT 1) [[SYNC_ONCE now 0 1 stdin nil 1]]
+ipgm0:(ipgm pgm0 |[] RUN_ONCE 50ms VOLATILE SILENT 1) [[SYNC_ONCE now 0 1 stdin nil 1]]

--- a/AERA/replicode_v1.2/hello.world.2.replicode
+++ b/AERA/replicode_v1.2/hello.world.2.replicode
@@ -10,7 +10,7 @@ pgm1:(pgm |[] |[] |[] []
    )
 1) |[]
 
-ipgm1:(ipgm pgm1 |[] RUN_ONCE 50000us VOLATILE SILENT 1) [[SYNC_ONCE now 0 1 stdin nil 1]]
+ipgm1:(ipgm pgm1 |[] RUN_ONCE 50ms VOLATILE SILENT 1) [[SYNC_ONCE now 0 1 stdin nil 1]]
 
 pgm2:(pgm |[] []
    (ptn (ent ::) |[])

--- a/AERA/replicode_v1.2/hello.world.3.replicode
+++ b/AERA/replicode_v1.2/hello.world.3.replicode
@@ -5,10 +5,10 @@
 
 pgm3:(pgm |[] |[] |[] []
    (inj []
-      (ins pgm3 |[] RUN_ONCE 50000us VOLATILE SILENT)
+      (ins pgm3 |[] RUN_ONCE 50ms VOLATILE SILENT)
       [SYNC_ONCE now 0 forever stdin nil 1]
    )
    (prb [1 "print" "hello world 3" |[]])
 1) |[]
 
-ipgm3:(ipgm pgm3 |[] RUN_ONCE 50000us VOLATILE SILENT 1) [[SYNC_ONCE now 0 1 stdin nil 1]]
+ipgm3:(ipgm pgm3 |[] RUN_ONCE 50ms VOLATILE SILENT 1) [[SYNC_ONCE now 0 1 stdin nil 1]]

--- a/AERA/replicode_v1.2/hello.world.replicode
+++ b/AERA/replicode_v1.2/hello.world.replicode
@@ -10,7 +10,7 @@ pgm0:(pgm |[] |[] |[] []
 ; Set act to 1 or 0 in the ipgm view (instantiated program) to either activate or deactivate the program
 ;                                                         [sync:SYNC_ONCE ijt:now sln:0 res:1 grp:stdin org:nil act:1]
 ;     (ipgm code:pgm0 args:[] run:bl tsc:us res:bl nfr:bl) ; bl is boolean and us is timestamp
-ipgm0:(ipgm pgm0 |[] RUN_ONCE 50000us VOLATILE SILENT 1) [[SYNC_ONCE now 0 1 stdin nil 1]]
+ipgm0:(ipgm pgm0 |[] RUN_ONCE 50ms VOLATILE SILENT 1) [[SYNC_ONCE now 0 1 stdin nil 1]]
 
 
 ; Method 2: one object injected at a point in time, caught by another program.
@@ -22,7 +22,7 @@ pgm1:(pgm |[] |[] |[] []
    )
 1) |[]
 
-ipgm1:(ipgm pgm1 |[] RUN_ONCE 50000us VOLATILE SILENT 1) [[SYNC_ONCE now 0 1 stdin nil 0]]
+ipgm1:(ipgm pgm1 |[] RUN_ONCE 50ms VOLATILE SILENT 1) [[SYNC_ONCE now 0 1 stdin nil 0]]
 
 pgm2:(pgm |[] []
    (ptn (ent ::) |[])
@@ -37,10 +37,10 @@ ipgm2:(ipgm pgm2 |[] RUN_ONCE 0us VOLATILE SILENT 1) [[SYNC_ONCE now 0 1 stdin n
 
 pgm3:(pgm |[] |[] |[] []
    (inj []
-      (ins pgm3 |[] RUN_ONCE 50000us VOLATILE SILENT)
+      (ins pgm3 |[] RUN_ONCE 50ms VOLATILE SILENT)
       [SYNC_ONCE now 0 forever stdin nil 1]
    )
    (prb [1 "print" "hello world 3" |[]])
 1) |[]
 
-ipgm3:(ipgm pgm3 |[] RUN_ONCE 50000us VOLATILE SILENT 1) [[SYNC_ONCE now 0 1 stdin nil 0]]
+ipgm3:(ipgm pgm3 |[] RUN_ONCE 50ms VOLATILE SILENT 1) [[SYNC_ONCE now 0 1 stdin nil 0]]

--- a/AERA/replicode_v1.2/pattern.replicode
+++ b/AERA/replicode_v1.2/pattern.replicode
@@ -12,9 +12,9 @@ B:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 data:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
 
 A_is_data:(mk.val A essence data 1) |[]; (mk.val an_object a_property a_value)
-f_A_is_data:(fact A_is_data 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+f_A_is_data:(fact A_is_data 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 B_is_data:(mk.val B essence data 1) |[]
-f_B_is_data:(fact B_is_data 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+f_B_is_data:(fact B_is_data 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 
 ;;;;;;;;;;;;;;;;
 ;; attributes ;;

--- a/AERA/replicode_v1.2/pong.1.replicode
+++ b/AERA/replicode_v1.2/pong.1.replicode
@@ -7,7 +7,7 @@
 b:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 ball:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
 b_is_a_ball:(mk.val b essence ball 1) |[]
-f_b_is_a_ball:(fact b_is_a_ball 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+f_b_is_a_ball:(fact b_is_a_ball 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 
 wall_detected:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
 

--- a/AERA/replicode_v1.2/pong.2.replicode
+++ b/AERA/replicode_v1.2/pong.2.replicode
@@ -18,7 +18,7 @@ b:(ent 1)
 ball:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
 b_is_a_ball:(mk.val b essence ball 1) |[]
 ; Even though (fact b_is_a_ball ::) is not used in this file, the pattern extractor needs it.
-f_b_is_a_ball:(fact b_is_a_ball 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+f_b_is_a_ball:(fact b_is_a_ball 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 
 ;;;;;;;;;;;;;;;;;;;;;
 ;; Top-level model ;;
@@ -91,7 +91,7 @@ ipgm0:(ipgm
 pgm0;       the code
 |[];        instantiation values
 RUN_ALWAYS; boolean RUN_ALWAYS/ONCE
-20000us;   time scope
+20ms;   time scope
 VOLATILE;
 NOTIFY;     notify flag
 1) [[SYNC_ONCE now 0 forever stdin nil 1]]

--- a/AERA/replicode_v1.2/pong.2.simplified.replicode
+++ b/AERA/replicode_v1.2/pong.2.simplified.replicode
@@ -18,7 +18,7 @@ b:(ent 1)
 ball:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
 b_is_a_ball:(mk.val b essence ball 1) |[]
 ; Even though (fact b_is_a_ball ::) is not used in this file, the pattern extractor needs it.
-f_b_is_a_ball:(fact b_is_a_ball 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+f_b_is_a_ball:(fact b_is_a_ball 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 
 ;;;;;;;;;;;;;;;;;;;;;
 ;; Top-level model ;;
@@ -91,7 +91,7 @@ ipgm0:(ipgm
 pgm0;       the code
 |[];        instantiation values
 RUN_ALWAYS; boolean RUN_ALWAYS/ONCE
-20000us;   time scope
+20ms;   time scope
 VOLATILE;
 NOTIFY;     notify flag
 1) [[SYNC_ONCE now 0 forever stdin nil 1]]

--- a/AERA/replicode_v1.2/pong.3.replicode
+++ b/AERA/replicode_v1.2/pong.3.replicode
@@ -10,11 +10,11 @@
 b:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 ball:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
 b_is_a_ball:(mk.val b essence ball 1) |[]
-f_b_is_a_ball:(fact b_is_a_ball 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+f_b_is_a_ball:(fact b_is_a_ball 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 
 last_known:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
 
-!def update_period 500000us
+!def update_period 500ms
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; P1 and P2 are the main programs for keeping track of the last position for each ball ;;
@@ -53,7 +53,7 @@ P2:(pgm
    (set [this.vw.res 0])
 1) |[]
 
-iP2:(ipgm P2 [nil] RUN_ONCE 500000us VOLATILE SILENT 1) [[SYNC_ONCE now 0 forever stdin nil 1]]
+iP2:(ipgm P2 [nil] RUN_ONCE 500ms VOLATILE SILENT 1) [[SYNC_ONCE now 0 forever stdin nil 1]]
 
 ;;;;;;;;;;;;;;;;;;;;;;
 ;; input generators ;;
@@ -71,7 +71,7 @@ start:(pgm |[] |[] |[] []
    )
 1) |[]
 
-istart:(ipgm start |[] RUN_ONCE 1000000us VOLATILE SILENT 1) [[SYNC_ONCE now 0 forever stdin nil 1]]
+istart:(ipgm start |[] RUN_ONCE 1000ms VOLATILE SILENT 1) [[SYNC_ONCE now 0 forever stdin nil 1]]
 
 ; The main loop, updates the position
 pgm0:(pgm |[] []

--- a/AERA/replicode_v1.2/pong.discrete.cmd.external.replicode
+++ b/AERA/replicode_v1.2/pong.discrete.cmd.external.replicode
@@ -4,7 +4,7 @@ p1:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 paddle:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
 p1_is_a_paddle:(mk.val p1 essence paddle 1) |[]
 ; Even though (fact p1_is_a_paddle ::) is not used in this file, the pattern extractor needs it.
-f_p1_is_a_paddle:(fact p1_is_a_paddle 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+f_p1_is_a_paddle:(fact p1_is_a_paddle 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 
 ; Make the discrete positions using ont instead of ent so that we don't need essence statements.
 y0:(ont 1) [[SYNC_ONCE now 1 forever root nil]]
@@ -18,7 +18,7 @@ y7:(ont 1) [[SYNC_ONCE now 1 forever root nil]]
 y8:(ont 1) [[SYNC_ONCE now 1 forever root nil]]
 y9:(ont 1) [[SYNC_ONCE now 1 forever root nil]]
 
-!def inject_drive_time 4000000us
+!def inject_drive_time 4000ms
 
 m_run_position:(mdl |[] []
    ; The goal target timings are the same as the drive timings.
@@ -90,11 +90,11 @@ pgm_inject_drive:(pgm |[]
    (ptn (fact (mk.val p1 essence paddle :) after: before: ::) |[])
 []
    (>= after (+ this.vw.ijt inject_drive_time))
-   (<= after (+ (+ this.vw.ijt inject_drive_time) 1150000us))
+   (<= after (+ (+ this.vw.ijt inject_drive_time) 1150ms))
 []
    (inj []
       ; The end of the time interval will be used in m_run_position as the end of the goal interval.
-      f_run:(fact run after (+ (+ this.vw.ijt inject_drive_time) 1000000us) 1 1)
+      f_run:(fact run after (+ (+ this.vw.ijt inject_drive_time) 1000ms) 1 1)
       |[]
    )
    (inj []
@@ -103,7 +103,7 @@ pgm_inject_drive:(pgm |[]
    )
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
-      (fact g t1:(+ after 10000us) t1 1 1)
+      (fact g t1:(+ after 10ms) t1 1 1)
       [SYNC_ONCE t1 1 forever primary nil]
    )
    (prb [1 "print" "injected drive" |[]])

--- a/AERA/replicode_v1.2/std.replicode
+++ b/AERA/replicode_v1.2/std.replicode
@@ -159,7 +159,9 @@
 
 ; system internal constants.
 !def MAX_TIME 922337203685477580us; See Utils_MaxTime
-
+; A gigasecond is about 31 years. This is to use as a time stamp which is way in
+; the future. In the seed code, the system adds this to the session start time.
+!def GIGASEC 1000000000s:0ms:0us
 
 ; initial groups.
 

--- a/AERA/replicode_v1.2/test.1.2011-04-13.v1_2.replicode
+++ b/AERA/replicode_v1.2/test.1.2011-04-13.v1_2.replicode
@@ -11,13 +11,13 @@ some_object_1:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 some_hand_1_pos:(mk.val some_hand_1 position (vec3 0 0 0) 1) |[]
 
 ; A fact indicating that the state described in the marker holds true NOW. Let us call this fact F1.
-fact_some_hand_1_pos:(fact some_hand_1_pos 0us 0us 1 1) |[]
+fact_some_hand_1_pos:(fact some_hand_1_pos 0s:0ms:0us 0s:0ms:0us 1 1) |[]
 
 ; A marker indicating that the position of B is (0,0,0)
 some_object_1_pos:(mk.val some_object_1 position (vec3 0 0 0) 1) |[]
 
 ; A fact indicating that the state described in the marker above holds true NOW. Let us call this fact F2.
-fact_some_object_1_pos:(fact some_object_1_pos 0us 0us 1 1) |[]
+fact_some_object_1_pos:(fact some_object_1_pos 0s:0ms:0us 0s:0ms:0us 1 1) |[]
 
 ; A definition of a composite state that holds true when F1 and F2 are true. That fact that the position values for
 ; A and B are identical is detected and will be useful later for abstraction.
@@ -31,19 +31,19 @@ same_pos_cst:(cst |[] [fact_some_hand_1_pos fact_some_object_1_pos] |[] |[] [std
 some_hand:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 some_object:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 
-; A grab command is created. It specifies A as the target entity (doing the grabbing) and 10000us as the 
+; A grab command is created. It specifies A as the target entity (doing the grabbing) and 10ms as the 
 ; deadline for execution.
 cmd_grab:(cmd grab_hand [some_hand] 1) |[]
 
 ; This fact indicates that existence of this command is true NOW. Let us call this fact F1.
-fact_cmd_grab:(fact cmd_grab 0us 0us 1 1) |[]
+fact_cmd_grab:(fact cmd_grab 0s:0ms:0us 0s:0ms:0us 1 1) |[]
 
 ; A marker that indicates that A and B have an attachment relation.
 attached:(mk.val some_hand attachment some_object 1) |[]
 
 ; This fact indicates that attachment marker above is true 100000 microseconds in the FUTURE. 
 ; Let us call this fact F2.
-fact_attached:(fact attached 100000us 100000us 1 1) |[]
+fact_attached:(fact attached 0s:100ms:0us 0s:100ms:0us 1 1) |[]
 
 ; Defines a model from F1 and F2. 
 ; This can be viewed as: 
@@ -65,13 +65,13 @@ some_object_2:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 i_same_pos_cst:(icst same_pos_cst |[] [some_hand_2 some_object_2 (vec3 0 0 0) 0us] false 1) |[]
 
 ; This fact indicates that the instansiated composite state is true NOW. Let us call this fact F1.
-f_i_same_pos_cst:(fact i_same_pos_cst 0us 0us 1 1) |[]
+f_i_same_pos_cst:(fact i_same_pos_cst 0s:0ms:0us 0s:0ms:0us 1 1) |[]
 
 ; Instansiates the model "grab_mdl" with A and B as parameters and 100000 microseconds as the deadline.
-i_grab_mdl:(imdl grab_mdl |[] [some_hand_2 some_object_2 100000us 0us] false 1) |[]
+i_grab_mdl:(imdl grab_mdl |[] [some_hand_2 some_object_2 100ms 0us] false 1) |[]
 
 ; This fact indicates that model just created exists NOW. Let us call it F2.
-f_i_grab_mdl:(fact i_grab_mdl 0us 0us 1 1) |[]
+f_i_grab_mdl:(fact i_grab_mdl 0s:0ms:0us 0s:0ms:0us 1 1) |[]
 
 ; Define a new model with facts F1 and F2. This can be viewed as: "F1 causes F2" or "To achieve F2, F1 is necessary".
 ; More clearly: If I have an instansiated compositate state that indicates two objects share the same position, 
@@ -103,7 +103,7 @@ test_fwd_same_pos:(pgm |[] |[] |[] []
 1) |[]
 
 ; This program has ACTIVATION=1 and will thus run.
-i_test_fwd_same_pos:(ipgm test_fwd_same_pos |[] RUN_ONCE 150000us VOLATILE NOTIFY 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+i_test_fwd_same_pos:(ipgm test_fwd_same_pos |[] RUN_ONCE 150ms VOLATILE NOTIFY 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ;----------------------------------------------------------------------
 
@@ -118,7 +118,7 @@ inj_goal:(pgm |[] |[] |[] []
       [SYNC_ONCE now 0 forever stdin nil]
    )
    (inj []
-      v1:(fact v0 (+ now 30000us) (+ now 30000us) 1 1)
+      v1:(fact v0 (+ now 30ms) (+ now 30ms) 1 1)
       [SYNC_ONCE now 0 forever stdin nil]
    )
    (inj []
@@ -132,7 +132,7 @@ inj_goal:(pgm |[] |[] |[] []
 1) |[]
 
 ; This program has ACTIVATION=1 and will thus run.
-i_inj_goal:(ipgm inj_goal |[] RUN_ONCE 150000us VOLATILE SILENT 1) [[SYNC_ONCE now 0 forever stdin nil 1]]
+i_inj_goal:(ipgm inj_goal |[] RUN_ONCE 150ms VOLATILE SILENT 1) [[SYNC_ONCE now 0 forever stdin nil 1]]
 
 ;----------------------------------------------------------------------
 
@@ -170,7 +170,7 @@ i_environment_resp:(ipgm environment_resp |[] RUN_ALWAYS 0us VOLATILE NOTIFY 1) 
 
 ;----------------------------------------------------------------------
 
-; This program injects the grab command and a fact indicating that it has 30000us as its deadline.
+; This program injects the grab command and a fact indicating that it has 30ms as its deadline.
 ; Only present for testing - we do not need this if have the inj_goal program running.
 
 inj_cmd:(pgm |[] |[] |[] []
@@ -179,10 +179,10 @@ inj_cmd:(pgm |[] |[] |[] []
       [SYNC_ONCE now 0 forever stdin nil]
    )
    (inj []
-      v1:(fact v0 (+ now 30000us) (+ now 30000us) 1 1)
+      v1:(fact v0 (+ now 30ms) (+ now 30ms) 1 1)
       [SYNC_ONCE now 1 forever stdin nil]
    )
 1) |[]
 
 ; Note that this instansiated program has ACTIVATION=0 and thus does nothing
-i_inj_cmd:(ipgm inj_cmd |[] RUN_ONCE 150000us VOLATILE NOTIFY 1) [[SYNC_ONCE now 0 forever stdin nil 0]]
+i_inj_cmd:(ipgm inj_cmd |[] RUN_ONCE 150ms VOLATILE NOTIFY 1) [[SYNC_ONCE now 0 forever stdin nil 0]]

--- a/AERA/replicode_v1.2/test.1.replicode
+++ b/AERA/replicode_v1.2/test.1.replicode
@@ -51,7 +51,7 @@ m_run_0:(mdl |[] []
 |[]
 []
    t0:(now)
-   t1:(+ t0 100000us)
+   t1:(+ t0 100ms)
 [stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 
@@ -77,13 +77,13 @@ pgm1:(pgm |[] |[] |[] []
       |[]
    )
    (inj []
-      (fact c now (+ now 200000us) 1 1)
+      (fact c now (+ now 200ms) 1 1)
       [SYNC_ONCE now 1 1 stdin nil]
    )
    (prb [1 "print" "pgm1 running (lifting hand)" |[]])
 1) |[]
 
-ipgm1:(ipgm pgm1 |[] RUN_ONCE 150000us VOLATILE SILENT 1) [[SYNC_ONCE now 0 forever stdin nil 1]]
+ipgm1:(ipgm pgm1 |[] RUN_ONCE 150ms VOLATILE SILENT 1) [[SYNC_ONCE now 0 forever stdin nil 1]]
 
 pgm2:(pgm |[] []
    (ptn (fact (cmd lift_hand [h: z:] :) t0: t1: ::) |[])

--- a/AERA/replicode_v1.2/test.2.replicode
+++ b/AERA/replicode_v1.2/test.2.replicode
@@ -39,7 +39,7 @@ m_run_0:(mdl |[] []
 |[]
 []
    t0:(now)
-   t1:(+ t0 100000us)
+   t1:(+ t0 100ms)
 [stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 0]]
 
 
@@ -65,7 +65,7 @@ pgm1:(pgm |[] |[] |[] []
       |[]
    )
    (inj []
-      (fact c now (+ now 10000us) 1 1)
+      (fact c now (+ now 10ms) 1 1)
       [SYNC_ONCE now 1 1 stdin nil]
    )
    (inj []
@@ -79,4 +79,4 @@ pgm1:(pgm |[] |[] |[] []
    (prb [1 "print" "pgm1" |[]])
 1) |[]
 
-ipgm1:(ipgm pgm1 |[] RUN_ONCE 160000us VOLATILE NOTIFY 1) [[SYNC_ONCE now 0 2 stdin nil 1]]
+ipgm1:(ipgm pgm1 |[] RUN_ONCE 160ms VOLATILE NOTIFY 1) [[SYNC_ONCE now 0 2 stdin nil 1]]

--- a/AERA/replicode_v1.2/test.3.replicode
+++ b/AERA/replicode_v1.2/test.3.replicode
@@ -42,7 +42,7 @@ pgm1:(pgm |[] |[] |[] []
       |[]
    )
    (inj []
-      (fact c now (+ now 10000us) 1 1)
+      (fact c now (+ now 10ms) 1 1)
       [SYNC_ONCE now 1 1 stdin nil]
    )
    (inj []
@@ -55,4 +55,4 @@ pgm1:(pgm |[] |[] |[] []
    )
 1) |[]
 
-ipgm1:(ipgm pgm1 |[] RUN_ONCE 160000us VOLATILE NOTIFY 1) [[SYNC_ONCE now 0 2 stdin nil 1]]
+ipgm1:(ipgm pgm1 |[] RUN_ONCE 160ms VOLATILE NOTIFY 1) [[SYNC_ONCE now 0 2 stdin nil 1]]

--- a/AERA/replicode_v1.2/test.4.replicode
+++ b/AERA/replicode_v1.2/test.4.replicode
@@ -25,12 +25,12 @@ pgm1:(pgm |[] |[] |[] []
       |[]
    )
    (inj []
-      (fact c now 200000us 1 1)
+      (fact c now 200ms 1 1)
       [SYNC_ONCE now 1 1 stdin nil]
    )
 1) |[]
 
-ipgm1:(ipgm pgm1 |[] RUN_ONCE 150000us VOLATILE SILENT 1) [[SYNC_ONCE now 0 2 stdin nil 1]]
+ipgm1:(ipgm pgm1 |[] RUN_ONCE 150ms VOLATILE SILENT 1) [[SYNC_ONCE now 0 2 stdin nil 1]]
 
 pgm2:(pgm |[] []
    (ptn (fact (cmd lift_hand [h: z:] :) t0: t1: ::) |[])
@@ -47,7 +47,7 @@ pgm2:(pgm |[] []
    )
 1) |[]
 
-ipgm2:(ipgm pgm2 |[] RUN_ONCE 100000us VOLATILE NOTIFY 1) [[SYNC_ONCE now 0 2 stdin nil 1]]
+ipgm2:(ipgm pgm2 |[] RUN_ONCE 100ms VOLATILE NOTIFY 1) [[SYNC_ONCE now 0 2 stdin nil 1]]
 
 ; ---------------------------------------
 
@@ -78,7 +78,7 @@ pgm3:(pgm |[] |[] |[] []
    )
 1) |[]
 
-ipgm3:(ipgm pgm3 |[] RUN_ONCE 200000us VOLATILE NOTIFY 1) [[SYNC_ONCE now 0 1 stdin nil 1]]
+ipgm3:(ipgm pgm3 |[] RUN_ONCE 200ms VOLATILE NOTIFY 1) [[SYNC_ONCE now 0 1 stdin nil 1]]
 
 pgm4:(pgm |[] |[] |[] []
    (inj []
@@ -86,7 +86,7 @@ pgm4:(pgm |[] |[] |[] []
       |[]
    )
    (inj []
-      (fact c now (+ now 10000us) 1 1)
+      (fact c now (+ now 10ms) 1 1)
       [SYNC_ONCE now 1 1 stdin nil]
    )
    (inj []
@@ -99,7 +99,7 @@ pgm4:(pgm |[] |[] |[] []
    )
 1) |[]
 
-ipgm4:(ipgm pgm4 |[] RUN_ONCE 260000us VOLATILE NOTIFY 1) [[SYNC_ONCE now 0 2 stdin nil 1]]
+ipgm4:(ipgm pgm4 |[] RUN_ONCE 260ms VOLATILE NOTIFY 1) [[SYNC_ONCE now 0 2 stdin nil 1]]
 
 ; ---------------------------------------
 
@@ -109,7 +109,7 @@ pgm6:(pgm |[] |[] |[] []
       |[]
    )
    (inj []
-      (fact c now (+ now 10000us) 1 1)
+      (fact c now (+ now 10ms) 1 1)
       [SYNC_ONCE now 1 1 stdin nil]
    )
    (inj []
@@ -122,4 +122,4 @@ pgm6:(pgm |[] |[] |[] []
    )
 1) |[]
 
-ipgm6:(ipgm pgm6 |[] RUN_ONCE 360000us VOLATILE NOTIFY 1) [[SYNC_ONCE now 0 2 stdin nil 1]]
+ipgm6:(ipgm pgm6 |[] RUN_ONCE 360ms VOLATILE NOTIFY 1) [[SYNC_ONCE now 0 2 stdin nil 1]]

--- a/AERA/replicode_v1.2/test.domain.replicode
+++ b/AERA/replicode_v1.2/test.domain.replicode
@@ -2,10 +2,10 @@
 
 self_right_hand:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 self_right_hand_is_a_hand:(mk.val self_right_hand essence hand 1) |[]
-f_self_right_hand_is_a_hand:(fact self_right_hand_is_a_hand 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+f_self_right_hand_is_a_hand:(fact self_right_hand_is_a_hand 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 ; self_head:(ent 1) [[SYNC_FRONT now 1 forever root nil]]
 ; self_head_is_a_head(mk.val self_head essence head 1) [[SYNC_STATE now 1 forever stdin nil]]
-; f_self_head_is_a_head:(fact self_head_is_a_head 0us MAX_TIME 1 1) [[SYNC_STATE now 1 forever stdin nil]]
+; f_self_head_is_a_head:(fact self_head_is_a_head 0s:0ms:0us GIGASEC 1 1) [[SYNC_STATE now 1 forever stdin nil]]
 
 ; programmer:(ont 1) [[SYNC_FRONT now 1 forever root nil]]
 
@@ -25,4 +25,4 @@ f_self_right_hand_is_a_hand:(fact self_right_hand_is_a_hand 0us MAX_TIME 1 1) [[
 
 cube0:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 cube0_is_a_cube:(mk.val cube0 essence cube 1) |[]
-f_cube0_is_a_cube:(fact cube0_is_a_cube 0us MAX_TIME 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+f_cube0_is_a_cube:(fact cube0_is_a_cube 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]

--- a/AERA/replicode_v1.2/user.classes.replicode
+++ b/AERA/replicode_v1.2/user.classes.replicode
@@ -38,7 +38,7 @@
 !dfn (tick :)
 
 ; The sampling_period should be 2 * base_period, where base_period is from settings.xml.
-!def sampling_period 100000us
+!def sampling_period 100ms
 
 ; application ontology.
 

--- a/r_code/atom.h
+++ b/r_code/atom.h
@@ -159,7 +159,8 @@ public:
     INSTANTIATED_ANTI_PROGRAM = 0xCC,
     COMPOSITE_STATE = 0xCD,
     MODEL = 0xCE,
-    NULL_PROGRAM = 0xCF
+    NULL_PROGRAM = 0xCF,
+    DURATION = 0xD0
   }Type;
 
   // encoders
@@ -203,6 +204,7 @@ public:
   static Atom UndefinedString();
   static Atom Timestamp();
   static Atom UndefinedTimestamp();
+  static Atom Duration();
   static Atom InstantiatedProgram(uint16 opcode, uint8 arity);
   static Atom Group(uint16 opcode, uint8 arity);
   static Atom InstantiatedCPPProgram(uint16 opcode, uint8 arity);

--- a/r_code/atom.inline.cpp
+++ b/r_code/atom.inline.cpp
@@ -290,6 +290,10 @@ inline Atom Atom::UndefinedTimestamp() {
   return Atom(0xC7FFFFFF);
 }
 
+inline Atom Atom::Duration() {
+  return Atom(DURATION << 24);
+}
+
 inline Atom Atom::InstantiatedProgram(uint16 opcode, uint8 arity) {
 
   return Atom((INSTANTIATED_PROGRAM << 24) + ((opcode & 0x0FFF) << 8) + arity);

--- a/r_code/code_utils.cpp
+++ b/r_code/code_utils.cpp
@@ -127,24 +127,21 @@ bool Utils::Synchronous(Timestamp l, Timestamp r) {
 
 Timestamp Utils::GetTimestamp(const Atom *iptr) {
 
-  uint64 high = iptr[1].atom_;
-  return Timestamp(microseconds(high << 32 | iptr[2].atom_));
+  return Timestamp(microseconds(GetInt64(iptr, 1)));
 }
 
 void Utils::SetTimestamp(Atom *iptr, Timestamp timestamp) {
 
-  uint64 t = duration_cast<microseconds>(timestamp.time_since_epoch()).count();
   iptr[0] = Atom::Timestamp();
-  iptr[1].atom_ = t >> 32;
-  iptr[2].atom_ = t & 0x00000000FFFFFFFF;
+  SetInt64(iptr, 1, duration_cast<microseconds>(timestamp.time_since_epoch()).count());
 }
 
 void Utils::SetTimestampStruct(Code *object, uint16 index, Timestamp timestamp) {
 
-  uint64 t = duration_cast<microseconds>(timestamp.time_since_epoch()).count();
   object->code(index) = Atom::Timestamp();
-  object->code(++index) = Atom(t >> 32);
-  object->code(++index) = Atom(t & 0x00000000FFFFFFFF);
+  // This will resize the code array if needed.
+  object->code(index + 2) = 0;
+  SetInt64(&object->code(0), index + 1, duration_cast<microseconds>(timestamp.time_since_epoch()).count());
 }
 
 std::string Utils::GetString(const Atom *iptr) {

--- a/r_code/code_utils.cpp
+++ b/r_code/code_utils.cpp
@@ -87,6 +87,7 @@
 
 #include <math.h>
 
+using namespace std;
 using namespace std::chrono;
 
 namespace r_code {
@@ -144,10 +145,47 @@ void Utils::SetTimestampStruct(Code *object, uint16 index, Timestamp timestamp) 
   SetInt64(&object->code(0), index + 1, duration_cast<microseconds>(timestamp.time_since_epoch()).count());
 }
 
+string Utils::ToString_s_ms_us(Timestamp timestamp, Timestamp time_reference) {
+  auto duration = timestamp - time_reference;
+  uint64 t = abs(duration_cast<microseconds>(duration).count());
+
+  uint64 us = t % 1000;
+  uint64 ms = t / 1000;
+  uint64 s = ms / 1000;
+  ms = ms % 1000;
+
+  std::string result = (duration < microseconds(0) ? "-" : "");
+  result += std::to_string(s);
+  result += "s:";
+  result += std::to_string(ms);
+  result += "ms:";
+  result += std::to_string(us);
+  result += "us";
+
+  return result;
+}
+
 void Utils::SetDurationStruct(Code *object, uint16 index, microseconds duration) {
   object->resize_code(index + 3);
   object->code(index) = Atom::Duration();
   SetInt64(&object->code(0), index + 1, duration.count());
+}
+
+string Utils::ToString_us(microseconds duration) {
+  uint64 us = abs(duration_cast<microseconds>(duration).count());
+
+  std::string sign = (duration < microseconds(0) ? "-" : "");
+  if (us % 1000 != 0)
+    return sign + std::to_string(us) + "us";
+  else {
+    uint64 ms = us / 1000;
+    if (ms % 1000 != 0)
+      return sign + std::to_string(ms) + "ms";
+    else {
+      uint64 s = ms / 1000;
+      return sign + std::to_string(s) + "s";
+    }
+  }
 }
 
 std::string Utils::GetString(const Atom *iptr) {
@@ -210,7 +248,7 @@ int32 Utils::GetResilience(float32 resilience, float32 origin_upr, float32 desti
 
 std::string Utils::RelativeTime(Timestamp t) {
 
-  return Time::ToString_seconds(t - TimeReference);
+  return ToString_s_ms_us(t, TimeReference);
 }
 
 bool Utils::has_reference(const Atom* code, uint16 index) {

--- a/r_code/code_utils.cpp
+++ b/r_code/code_utils.cpp
@@ -144,6 +144,12 @@ void Utils::SetTimestampStruct(Code *object, uint16 index, Timestamp timestamp) 
   SetInt64(&object->code(0), index + 1, duration_cast<microseconds>(timestamp.time_since_epoch()).count());
 }
 
+void Utils::SetDurationStruct(Code *object, uint16 index, microseconds duration) {
+  object->resize_code(index + 3);
+  object->code(index) = Atom::Duration();
+  SetInt64(&object->code(0), index + 1, duration.count());
+}
+
 std::string Utils::GetString(const Atom *iptr) {
 
   std::string s;

--- a/r_code/utils.h
+++ b/r_code/utils.h
@@ -219,6 +219,16 @@ public:
   }
 
   /**
+   * Make a string from (timestamp - time_reference) in the form XXXs:YYYms:ZZZus, with a minus sign
+   * if it is negative.
+   * \param timestamp The time stamp.
+   * \param time_reference The reference time to subtract from timestamp, usuall the session start time.
+   * We do this because timestamp is seconds since 01/01/1970, so the seconds would be very large.
+   * \return The formatted time string.
+   */
+  static std::string ToString_s_ms_us(Timestamp timestamp, Timestamp time_reference);
+
+  /**
    * Interpret iptr[1] and iptr[2] as an signed 64-bit integer and return it as a duration.
    * This assumes that the caller has already checked iptr[0] == Atom::DURATION, if needed.
    * \param iptr A pointer into the Atom array.
@@ -277,6 +287,15 @@ public:
     object->code(t_index + 2).atom_ = 0;
     SetInt64(&object->code(0), t_index + 1, duration.count());
   }
+
+  /**
+   * Make a string from duration in the form XXXus, with a minus sign if it is negative. However if
+   * the microseconds portion is zero, then use YYYms. Or if the microseconds and milliseconds portions
+   * are zero, then use ZZZs. (This is the complement to how the compiler parses durations.)
+   * \param duration The duration.
+   * \return The formatted time string.
+   */
+  static std::string ToString_us(std::chrono::microseconds duration);
 
   static std::string GetString(const Atom *iptr);
   static void SetString(Atom *iptr, const std::string &s);

--- a/r_comp/compiler.h
+++ b/r_comp/compiler.h
@@ -211,18 +211,18 @@ private:
   bool tail_wildcard();
   /**
    * Read a timestamp of the form XXXus, where XXX is a decimal.
-   * \param ts Set ts to the timestamp in microseconds.
+   * \param result Set result to the timestamp in microseconds.
    * \return True for success, false if this is not a timestamp (and in_stream_ is not advanced).
    */
-  bool timestamp(uint64 &ts);
+  bool timestamp(int64 &result);
   /**
    * Read a timestamp of the form XXXs:YYYms:ZZZus, where XXX, YYY and ZZZ are decimal
    * seconds, milliseconds and microseconds. This is the reverse of the output of
-   * Time::ToString_seconds used by the decompiler.
+   * Utils::ToString_s_ms_us used by the decompiler.
    * \param ts Set ts to the timestamp in microseconds.
    * \return True for success, false if this is not a timestamp (and in_stream_ is not advanced).
    */
-  bool timestamp_s_ms_us(uint64 &ts);
+  bool timestamp_s_ms_us(int64 &ts);
   bool str(std::string &s);
   bool number(float32 &n);
   bool hex(uint32 &h);

--- a/r_comp/decompiler.h
+++ b/r_comp/decompiler.h
@@ -109,7 +109,7 @@ private:
   r_comp::Metadata *metadata_;
   r_comp::Image *image_;
 
-  std::chrono::microseconds time_offset_; // 0 means no offset.
+  Timestamp time_reference_;
 
   std::unordered_map<uint16, std::string> variable_names_; // in the form vxxx where xxx is an integer representing the order of referencing of the variable/label in the code.
   uint16 last_variable_id_;
@@ -154,11 +154,11 @@ public:
   void init(r_comp::Metadata *metadata);
   uint32 decompile(r_comp::Image *image,
     std::ostringstream *stream,
-    Timestamp::duration time_offset,
+    Timestamp time_reference,
     bool ignore_named_objects); // decompiles the whole image; returns the number of objects.
   uint32 decompile(r_comp::Image *image,
     std::ostringstream *stream,
-    Timestamp::duration time_offset,
+    Timestamp time_reference,
     std::vector<r_code::SysObject *> &imported_objects,
     bool include_oid = true, bool include_label = true, bool include_views = true); // idem, ignores named objects if in the imported object list.
 
@@ -177,16 +177,16 @@ public:
    * Decompile a single object.
    * \param object_index The position of the object in image_->code_segment_.objects_.
    * \param stream The output stream.
-   * \param time_offset The time since the start of the run for showing relative times.
+   * \param time_reference The timestamp of the start of the run for showing relative times.
    * \param include_oid (optional) If true, prepend with the OID (and detail OID if enabled). If omitted, include the OID.
    * \param include_label (optional) If true, prepend the label and ':'. If omitted, include the label.
    * \param include_views (optional) If true, include the set of view, or |[] if there are not views. If omitted, include the views.
    */
   void decompile_object(
-    uint16 object_index, std::ostringstream *stream, Timestamp::duration time_offset, bool include_oid = true, 
+    uint16 object_index, std::ostringstream *stream, Timestamp time_reference, bool include_oid = true, 
     bool include_label = true, bool include_views = true);
 
-  void decompile_object(const std::string object_name, std::ostringstream *stream, Timestamp::duration time_offset); // decompiles a single object given its name: use this function to follow references.
+  void decompile_object(const std::string object_name, std::ostringstream *stream, Timestamp time_reference); // decompiles a single object given its name: use this function to follow references.
 };
 }
 

--- a/r_exec/_context.cpp
+++ b/r_exec/_context.cpp
@@ -84,6 +84,7 @@
 
 #include "_context.h"
 
+using namespace std::chrono;
 using namespace r_code;
 
 namespace r_exec {
@@ -99,6 +100,13 @@ void _Context::setTimestampResult(Timestamp t) const { // patch code with a VALU
   overlay_->values_.as_std()->resize(overlay_->values_.size() + 3);
   uint16 value_index = overlay_->values_.size() - 3;
   Utils::SetTimestamp(&overlay_->values_[value_index], t);
+}
+
+void _Context::setDurationResult(microseconds d) const { // patch code with a VALUE_PTR
+  overlay_->patch_code(index_, Atom::ValuePointer(overlay_->values_.size()));
+  overlay_->values_.as_std()->resize(overlay_->values_.size() + 3);
+  uint16 value_index = overlay_->values_.size() - 3;
+  Utils::SetDuration(&overlay_->values_[value_index], d);
 }
 
 void _Context::setCompoundResultHead(Atom a) const { // patch code with a VALUE_PTR.

--- a/r_exec/_context.h
+++ b/r_exec/_context.h
@@ -141,6 +141,7 @@ public:
 
   void setAtomicResult(Atom a) const;
   void setTimestampResult(Timestamp t) const;
+  void setDurationResult(std::chrono::microseconds d) const;
   void setCompoundResultHead(Atom a) const;
   void addCompoundResultPart(Atom a) const;
 

--- a/r_exec/init.cpp
+++ b/r_exec/init.cpp
@@ -177,7 +177,7 @@ thread_ret TDecompiler::Decompile(void *args) {
   image->object_names_.symbols_ = r_exec::Seed.object_names_.symbols_;
 
   std::ostringstream decompiled_code;
-  decompiler.decompile(image, &decompiled_code, duration_cast<microseconds>(Utils::GetTimeReference().time_since_epoch()), imported_objects);
+  decompiler.decompile(image, &decompiled_code, Utils::GetTimeReference(), imported_objects);
 
   if (_this->ostream_id_ == 0) {
 

--- a/r_exec/operator.h
+++ b/r_exec/operator.h
@@ -123,6 +123,7 @@ public:
 
   void setAtomicResult(Atom a) const { implementation_->setAtomicResult(a); }
   void setTimestampResult(Timestamp t) const { implementation_->setTimestampResult(t); }
+  void setDurationResult(std::chrono::microseconds d) const { implementation_->setDurationResult(d); }
   void setCompoundResultHead(Atom a) const { implementation_->setCompoundResultHead(a); }
   void addCompoundResultPart(Atom a) const { implementation_->addCompoundResultPart(a); }
 

--- a/r_exec/pattern_extractor.cpp
+++ b/r_exec/pattern_extractor.cpp
@@ -470,7 +470,7 @@ void _TPX::inject_hlps(Timestamp analysis_starting_time) {
     auto d = duration_cast<microseconds>(analysis_end - analysis_starting_time);
     char _timing[255];
     itoa(d.count(), _timing, 10);
-    header = Time::ToString_seconds(Now() - Utils::GetTimeReference());
+    header = Utils::ToString_s_ms_us(Now(), Utils::GetTimeReference());
     std::string s0 = (" > ");
     s0 += get_header() + std::string(":production [");
     std::string timing(_timing);

--- a/usr_operators/Callbacks/callbacks.cpp
+++ b/usr_operators/Callbacks/callbacks.cpp
@@ -96,7 +96,7 @@ using namespace r_code;
 bool print(microseconds relative_time, bool suspended, const char *msg, uint8 object_count, Code **objects) { // return true to resume the executive (applies when called from a suspend call, i.e. suspended==true).
 
   ostringstream out;
-  out << Time::ToString_seconds(relative_time) << ": " << msg << std::endl;
+  out << Utils::ToString_s_ms_us(Timestamp(relative_time), Timestamp(seconds(0))) << ": " << msg << std::endl;
   for (uint8 i = 0; i < object_count; ++i)
     objects[i]->trace(out);
 


### PR DESCRIPTION
This pull request partially resolves issue #138 to add support to distinguish duration from time stamp. But this does not yet require the distinction in Replicode syntax, so this does not change existing functionality. A future pull request will update the compiler and std.replicode definitions to require the distinction of duration and time stamp.

This pull request has five commits. Each of them adds functionality but does not change existing functionality. The first commit updates `Utils` to add functions `GetInt64 ` and `SetInt64` and changes the existing methods `GetTimestamp`, etc. to use them. This is preparation for functions like `GetDuration` which also store a 64-bit integer.

The second commit adds support for the DURATION byte code to store a duration in a Code object. In `Utils` we add `GetDuration` and `SetDuration` which access Code for a DURATION. This only adds the DURATION utilities but it is not used yet.

The third commit updates the math operators to support duration, as explained in issue #138. For example adding a time stamp plus a duration returns a time stamp. This is in preparation for when DURATION is actually used in a Code object. However, this commit does not change the functionality of existing math operators that use time stamp.

The fourth commit updates the compiler to allow negative durations and time stamps such as `-500us` and `-2s:100ms:0us`. We also update `Utils` to add `ToString_s_ms_us` and `ToString_us` which distinguish printing the time stamp and duration formats, including negative values. We update the rest of the code to use these when printing to the runtime output and decompiled code so that we "close the loop" for formatting/parsing negative durations. (In the decompiler we rename `time_offset` to `time_reference` to be consistent with the rest of the code.) And we update the compiler to support duration constants of millisecond and second such as `100ms` and `-2s` .

Finally, the fifth commit updates the Replicode files to take advantage of these changes. Even though the compiler does not yet enforce the distinction of duration and time stamp, we can now update the Replicode files in preparation for this. For example, in model guards we change `(+ T0 0s:100ms:0us)` to `(+ T0 100ms)` to use a duration constant and is more readable. (As a test, note that the following now works with a negative constant: `(- T0 -100ms)` ). Finally, we resolve an existing issue for defining facts in the seed code, for example:

    (fact h_is_a_hand 0us MAX_TIME)

The values `0us` and `MAX_TIME` are the time interval of the fact. AERA automatically adds the session start time to these values (so that they are microseconds since 1/1/1970) and also subtracts the session start time when writing the decompiled output. This works as expected for the interval begin time `0us` which becomes the session start time. But `MAX_TIME` is the maximum duration which is properly used when defining the lifetime of a View. But when used as a time stamp, AERA adds the session start time which overflows the 64-bit integer and is basically random. Therefore, this commit defines the constant `GIGASEC` which is a time stamp with 1 billion seconds (about 31 years). This is large enough to meet our needs but does not overflow the 64-bit integer when AERA adds the session start time. Therefore the example above becomes:

    (fact h_is_a_hand 0s:0ms:0us GIGASEC)
