### PR TITLE
Add duration to Replicode syntax

### DIFF
--- a/AERA/replicode_v1.2/std.replicode
+++ b/AERA/replicode_v1.2/std.replicode
@@ -3,7 +3,7 @@
 ; utilities.
 !class (_obj :~ psln_thr:nb)
 !class (_grp (_obj {upr:nb sln_thr:nb act_thr:nb vis_thr:nb c_sln:nb c_sln_thr:nb c_act:nb c_act_thr:nb dcy_per:nb dcy_tgt:nb dcy_prd:nb dcy_auto:nb sln_chg_thr:nb sln_chg_prd:nb act_chg_thr:nb act_chg_prd:nb avg_sln:nb high_sln:nb low_sln:nb avg_act:nb high_act:nb low_act:nb high_sln_thr:nb low_sln_thr:nb sln_ntf_prd:nb high_act_thr:nb low_act_thr:nb act_ntf_prd:nb ntf_new:nb low_res_thr:nb ntf_grps:[::grp] :~}))
-!class (_fact (_obj {obj: after:us before:us cfd:nb :~}))
+!class (_fact (_obj {obj: after:ts before:ts cfd:nb :~}))
 !class (val (_obj val:))
 !class (val_hld val:)
 
@@ -12,9 +12,9 @@
 !class (ont (_obj nil))
 !class (dev (_obj nil))
 !class (nod (_obj id:nid))
-!class (view[] sync:nb ijt:us sln:nb res:nb grp:grp org:)
-!class (grp_view[] sync:nb ijt:us sln:nb res:nb grp:grp org: cov:bl vis:nb)
-!class (pgm_view[] sync:nb ijt:us sln:nb res:nb grp:grp org: act:nb)
+!class (view[] sync:nb ijt:ts sln:nb res:nb grp:grp org:)
+!class (grp_view[] sync:nb ijt:ts sln:nb res:nb grp:grp org: cov:bl vis:nb)
+!class (pgm_view[] sync:nb ijt:ts sln:nb res:nb grp:grp org: act:nb)
 !class (ptn skel:xpr guards:[::xpr])
 !class (|ptn skel:xpr guards:[::xpr])
 !class (pgm (_obj {tpl:[::ptn] inputs:[] guards:[::xpr] prods:}))
@@ -38,7 +38,7 @@
 !class (mk.new (_obj obj:))
 
 ; simulator
-!class (sim (_obj {mode:nb thz:us f_super_goal: opposite:bl root_model:mdl solution_model:mdl solution_cfd:nb solution_before:us}))
+!class (sim (_obj {mode:nb thz:us f_super_goal: opposite:bl root_model:mdl solution_model:mdl solution_cfd:nb solution_before:ts}))
 ; values for sim mode
 !def SIM_ROOT 0
 !def SIM_OPTIONAL 1
@@ -62,7 +62,7 @@
 !class (perf (_obj {rj_ltcy:nb d_rj_ltcy:nb tj_ltcy:nb d_tj_ltcy:nb})); latencies and derivatives in us encoded as floats.
 
 ; mapping operator opcodes -> r-atoms.
-!op (_now):us
+!op (_now):ts
 !op (rnd :nb):nb
 !op (equ : :):
 !op (neq : :):
@@ -159,6 +159,10 @@
 
 ; system internal constants.
 !def MAX_TIME 922337203685477580us; See Utils_MaxTime
+; EPOCH is used to convert between time stamp and duration.
+; To convert a duration to a time stamp, use: (+ duration EPOCH)
+; To convert a time stamp to a duration, use: (- timestamp EPOCH)
+!def EPOCH 0s:0ms:0us
 ; A gigasecond is about 31 years. This is to use as a time stamp which is way in
 ; the future. In the seed code, the system adds this to the session start time.
 !def GIGASEC 1000000000s:0ms:0us

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,8 @@
-replicode-syntax-v1.2 (2020-06-19)
-----------------------------------
+Interim change since AERA Diagnostic Mode v0.1
+----------------------------------------------
 
-* Rename the folder Test to AERA.
-  Note: To see changes before this renaming, browse at the earlier commit: 
-  https://github.com/IIIM-IS/replicode/tree/6154f1f2d0eac5543d760928b89bff4fd30adad3
-* Rename the file Test.cpp to main.cpp .
-* Rename the Test project to AERA.
-* Rename folders V1.1 and V1.2 to replicode_v1.1 and replicode_v1.2, to distinguish the
-  Replicode syntax version from the AERA system release version.
+Changes
+* Change the Replicode syntax to add durations, distinct from time stamps https://github.com/IIIM-IS/AERA/issues/138
 
 AERA Diagnostic Mode v0.1 (2021-11-19)
 -------------------------------------
@@ -18,3 +13,14 @@ A release optimized to run in "diagnostic time" which is now the default in sett
 * Added example hand-grab-sphere-learn.replicode which learns the grab and release models, as well
   as the anti-requirement model where grab fails if the sphere and cube are at the same position.
 * Make other bug fixes and enhancements. Please see https://github.com/IIIM-IS/AERA/blob/master/doc/meeting-notes.txt
+
+replicode-syntax-v1.2 (2020-06-19)
+----------------------------------
+
+* Rename the folder Test to AERA.
+  Note: To see changes before this renaming, browse at the earlier commit: 
+  https://github.com/IIIM-IS/replicode/tree/6154f1f2d0eac5543d760928b89bff4fd30adad3
+* Rename the file Test.cpp to main.cpp .
+* Rename the Test project to AERA.
+* Rename folders V1.1 and V1.2 to replicode_v1.1 and replicode_v1.2, to distinguish the
+  Replicode syntax version from the AERA system release version.

--- a/r_code/atom.cpp
+++ b/r_code/atom.cpp
@@ -96,6 +96,7 @@ namespace r_code {
 Atom::TraceContext::TraceContext() {
   members_to_go_ = 0;
   timestamp_data_ = 0;
+  duration_data_ = 0;
   string_data_ = 0;
   char_count_ = 0;
 }
@@ -111,11 +112,26 @@ void Atom::trace(TraceContext& context, std::ostream& out) const {
 
     if (context.timestamp_data_ == 1)
       // Save for the next step.
-      context.timestamp_high_ = atom_;
+      context.int64_high_ = atom_;
     else {
       // Imitate Utils::GetTimestamp.
-      auto timestamp = core::Timestamp(microseconds(context.timestamp_high_ << 32 | atom_));
+      auto timestamp = core::Timestamp(microseconds(context.int64_high_ << 32 | atom_));
       out << " " << Utils::RelativeTime(timestamp);
+    }
+    return;
+  }
+  if (context.duration_data_) {
+    // Output the duration value now. Otherwise, it could be interpreted as an op code, etc.
+    --context.duration_data_;
+    out << atom_;
+
+    if (context.duration_data_ == 1)
+      // Save for the next step.
+      context.int64_high_ = atom_;
+    else {
+      // Imitate Utils::GetDuration.
+      auto duration = microseconds(context.int64_high_ << 32 | atom_);
+      out << " " << Utils::ToString_us(duration);
     }
     return;
   }
@@ -150,7 +166,8 @@ void Atom::trace(TraceContext& context, std::ostream& out) const {
   case MARKER: out << "mk: " << std::dec << asOpcode() << " (" << GetOpcodeName(asOpcode()).c_str() << ") " << (uint16)getAtomCount(); context.members_to_go_ = getAtomCount(); return;
   case OPERATOR: out << "op: " << std::dec << asOpcode() << " (" << GetOpcodeName(asOpcode()).c_str() << ") " << (uint16)getAtomCount(); context.members_to_go_ = getAtomCount(); return;
   case STRING: out << "st: " << std::dec << (uint16)getAtomCount(); context.members_to_go_ = context.string_data_ = getAtomCount(); context.char_count_ = (atom_ & 0x000000FF); return;
-  case TIMESTAMP: out << "us"; context.members_to_go_ = context.timestamp_data_ = 2; return;
+  case TIMESTAMP: out << "ts"; context.members_to_go_ = context.timestamp_data_ = 2; return;
+  case DURATION: out << "us"; context.members_to_go_ = context.duration_data_ = 2; return;
   case GROUP: out << "grp: " << std::dec << asOpcode() << " (" << GetOpcodeName(asOpcode()).c_str() << ") " << (uint16)getAtomCount(); context.members_to_go_ = getAtomCount(); return;
   case INSTANTIATED_PROGRAM:
   case INSTANTIATED_ANTI_PROGRAM:

--- a/r_code/atom.h
+++ b/r_code/atom.h
@@ -113,9 +113,10 @@ public:
   public:
     uint8 members_to_go_;
     uint8 timestamp_data_;
+    uint8 duration_data_;
     uint8 string_data_;
     uint8 char_count_;
-    uint64 timestamp_high_;
+    uint64 int64_high_;
 
     TraceContext();
     void write_indents(std::ostream& out);

--- a/r_code/atom.inline.cpp
+++ b/r_code/atom.inline.cpp
@@ -485,6 +485,7 @@ inline uint8 Atom::getAtomCount() const {
   case S_SET: return atom_ & 0x000000FF;
   case STRING: return (atom_ & 0x0000FF00) >> 8;
   case TIMESTAMP: return 2;
+  case DURATION: return 2;
   default:
     return 0;
   }

--- a/r_code/code_utils.cpp
+++ b/r_code/code_utils.cpp
@@ -266,6 +266,7 @@ bool Utils::has_reference(const Atom* code, uint16 index) {
   case Atom::MARKER:
   case Atom::OPERATOR:
   case Atom::TIMESTAMP:
+  case Atom::DURATION:
   case Atom::GROUP: {
     uint16 count = atom.getAtomCount();
     for (uint16 i = 1; i <= count; ++i) {

--- a/r_comp/compiler.h
+++ b/r_comp/compiler.h
@@ -153,7 +153,7 @@ private:
   bool read_nil(uint16 write_index, uint16 &extent_index, bool write);
   bool read_nil_set(uint16 write_index, uint16 &extent_index, bool write);
   bool read_nil_nb(uint16 write_index, uint16 &extent_index, bool write);
-  bool read_nil_us(uint16 write_index, uint16 &extent_index, bool write);
+  bool read_nil_ts(uint16 write_index, uint16 &extent_index, bool write);
   bool read_forever_nb(uint16 write_index, uint16 &extent_index, bool write);
   bool read_nil_nid(uint16 write_index, uint16 &extent_index, bool write);
   bool read_nil_did(uint16 write_index, uint16 &extent_index, bool write);
@@ -191,7 +191,7 @@ private:
         // Lexical units.
   bool nil();
   bool nil_nb();
-  bool nil_us();
+  bool nil_ts();
   bool forever();
   bool nil_nid();
   bool nil_did();
@@ -210,11 +210,11 @@ private:
   bool wildcard();
   bool tail_wildcard();
   /**
-   * Read a timestamp of the form XXXus, where XXX is a decimal.
-   * \param result Set result to the timestamp in microseconds.
-   * \return True for success, false if this is not a timestamp (and in_stream_ is not advanced).
+   * Read a duration of the form XXXus, where XXX is a decimal.
+   * \param result Set result to the duration in microseconds.
+   * \return True for success, false if this is not a duration (and in_stream_ is not advanced).
    */
-  bool timestamp(int64 &result);
+  bool duration(int64 &result);
   /**
    * Read a timestamp of the form XXXs:YYYms:ZZZus, where XXX, YYY and ZZZ are decimal
    * seconds, milliseconds and microseconds. This is the reverse of the output of
@@ -281,6 +281,7 @@ public:
   bool read_any(bool &indented, bool enforce, const Class *p, uint16 write_index, uint16 &extent_index, bool write); // calls all of the functions below.
   bool read_number(bool &indented, bool enforce, const Class *p, uint16 write_index, uint16 &extent_index, bool write);
   bool read_timestamp(bool &indented, bool enforce, const Class *p, uint16 write_index, uint16 &extent_index, bool write);
+  bool read_duration(bool &indented, bool enforce, const Class *p, uint16 write_index, uint16 &extent_index, bool write);
   bool read_boolean(bool &indented, bool enforce, const Class *p, uint16 write_index, uint16 &extent_index, bool write);
   bool read_string(bool &indented, bool enforce, const Class *p, uint16 write_index, uint16 &extent_index, bool write);
   bool read_node(bool &indented, bool enforce, const Class *p, uint16 write_index, uint16 &extent_index, bool write);

--- a/r_comp/decompiler.cpp
+++ b/r_comp/decompiler.cpp
@@ -188,8 +188,6 @@ void Decompiler::init(r_comp::Metadata *metadata) {
       renderers_[i] = &Decompiler::write_hlp;
     else if (class_name == "icst" || class_name == "imdl")
       renderers_[i] = &Decompiler::write_ihlp;
-    else if (class_name == "sim")
-      renderers_[i] = &Decompiler::write_sim;
     else
       renderers_[i] = &Decompiler::write_expression;
   }
@@ -447,7 +445,7 @@ void Decompiler::write_expression_head(uint16 read_index) {
   }
 }
 
-void Decompiler::write_expression_tail(uint16 read_index, bool apply_time_offset, bool vertical) { // read_index points initially to the head.
+void Decompiler::write_expression_tail(uint16 read_index) { // read_index points initially to the head.
 
   uint16 arity = current_object_->code_[read_index].getAtomCount();
   bool after_tail_wildcard = false;
@@ -455,7 +453,7 @@ void Decompiler::write_expression_tail(uint16 read_index, bool apply_time_offset
   for (uint16 i = 0; i < arity; ++i) {
 
     if (after_tail_wildcard)
-      write_any(++read_index, after_tail_wildcard, apply_time_offset);
+      write_any(++read_index, after_tail_wildcard);
     else {
 
       if (closing_set_) {
@@ -465,13 +463,10 @@ void Decompiler::write_expression_tail(uint16 read_index, bool apply_time_offset
           write_indent(indents_);
         else
           *out_stream_ << ' ';
-      } else if (!vertical)
+      } else
         *out_stream_ << ' ';
 
-      write_any(++read_index, after_tail_wildcard, apply_time_offset);
-
-      if (!closing_set_ && vertical)
-        *out_stream_ << NEWLINE;
+      write_any(++read_index, after_tail_wildcard);
     }
   }
 }
@@ -485,7 +480,7 @@ void Decompiler::write_expression(uint16 read_index) {
   }
   out_stream_->push('(', read_index);
   write_expression_head(read_index);
-  write_expression_tail(read_index, true);
+  write_expression_tail(read_index);
   if (closing_set_) {
 
     closing_set_ = false;
@@ -503,7 +498,7 @@ void Decompiler::write_group(uint16 read_index) {
   }
   out_stream_->push('(', read_index);
   write_expression_head(read_index);
-  write_expression_tail(read_index, false);
+  write_expression_tail(read_index);
   if (closing_set_) {
 
     closing_set_ = false;
@@ -521,7 +516,7 @@ void Decompiler::write_marker(uint16 read_index) {
   }
   out_stream_->push('(', read_index);
   write_expression_head(read_index);
-  write_expression_tail(read_index, false);
+  write_expression_tail(read_index);
   if (closing_set_) {
 
     closing_set_ = false;
@@ -539,7 +534,7 @@ void Decompiler::write_pgm(uint16 read_index) {
   }
   out_stream_->push('(', read_index);
   write_expression_head(read_index);
-  write_expression_tail(read_index, true);
+  write_expression_tail(read_index);
   if (closing_set_) {
 
     closing_set_ = false;
@@ -558,7 +553,7 @@ void Decompiler::write_ipgm(uint16 read_index) {
   }
   out_stream_->push('(', read_index);
   write_expression_head(read_index);
-  write_expression_tail(read_index, false);
+  write_expression_tail(read_index);
   if (closing_set_) {
 
     closing_set_ = false;
@@ -585,7 +580,7 @@ void Decompiler::write_hlp(uint16 read_index) {
   for (uint16 i = 0; i < arity; ++i) {
 
     if (after_tail_wildcard)
-      write_any(++read_index, after_tail_wildcard, false);
+      write_any(++read_index, after_tail_wildcard);
     else {
 
       if (closing_set_) {
@@ -602,7 +597,7 @@ void Decompiler::write_hlp(uint16 read_index) {
       if (i == 0 || i == 4)
         // Write the set of template arguments and set of output groups horizontally.
         horizontal_set_ = true;
-      write_any(++read_index, after_tail_wildcard, false);
+      write_any(++read_index, after_tail_wildcard);
       hlp_postfix_ = true;
       horizontal_set_ = save_horizontal_set;
 
@@ -631,7 +626,7 @@ void Decompiler::write_ihlp(uint16 read_index) {
   }
   out_stream_->push('(', read_index);
   write_expression_head(read_index);
-  write_expression_tail(read_index, true);
+  write_expression_tail(read_index);
   if (closing_set_) {
 
     closing_set_ = false;
@@ -651,7 +646,6 @@ void Decompiler::write_icmd(uint16 read_index) {
   }
   out_stream_->push('(', read_index);
   write_expression_head(read_index);
-  //write_expression_tail(read_index,true);
 
   uint16 write_as_view_index = 0;
   if (current_object_->code_[read_index + 1].asOpcode() == metadata_->classes_.find("_inj")->second.atom_.asOpcode()) {
@@ -666,7 +660,7 @@ void Decompiler::write_icmd(uint16 read_index) {
   for (uint16 i = 0; i < arity; ++i) {
 
     if (after_tail_wildcard)
-      write_any(++read_index, after_tail_wildcard, true);
+      write_any(++read_index, after_tail_wildcard);
     else {
 
       if (closing_set_) {
@@ -676,7 +670,7 @@ void Decompiler::write_icmd(uint16 read_index) {
       } else
         *out_stream_ << ' ';
 
-      write_any(++read_index, after_tail_wildcard, true, write_as_view_index);
+      write_any(++read_index, after_tail_wildcard, write_as_view_index);
     }
   }
 
@@ -699,7 +693,7 @@ void Decompiler::write_cmd(uint16 read_index) {
   }
   out_stream_->push('(', read_index);
   write_expression_head(read_index);
-  write_expression_tail(read_index, false);
+  write_expression_tail(read_index);
   if (closing_set_) {
 
     closing_set_ = false;
@@ -721,7 +715,7 @@ void Decompiler::write_fact(uint16 read_index) {
   }
   out_stream_->push('(', read_index);
   write_expression_head(read_index);
-  write_expression_tail(read_index, true);
+  write_expression_tail(read_index);
   if (closing_set_) {
 
     closing_set_ = false;
@@ -744,64 +738,14 @@ void Decompiler::write_view(uint16 read_index, uint16 arity) {
   *out_stream_ << "[";
   for (uint16 j = 1; j <= arity; ++j) {
 
-    write_any(read_index + j, after_tail_wildcard, true);
+    write_any(read_index + j, after_tail_wildcard);
     if (j < arity)
       *out_stream_ << " ";
   }
   *out_stream_ << "]";
 }
 
-void Decompiler::write_sim(uint16 read_index) {
-  // Imitate write_expression, except set apply_time_offset false for the time horizon.
-
-  if (closing_set_) {
-
-    closing_set_ = false;
-    write_indent(indents_);
-  }
-  out_stream_->push('(', read_index);
-  write_expression_head(read_index);
-
-  // Imitate write_expression_tail, except set apply_time_offset false for the time horizon.
-  bool vertical = false;
-  uint16 arity = current_object_->code_[read_index].getAtomCount();
-  bool after_tail_wildcard = false;
-
-  for (uint16 i = 0; i < arity; ++i) {
-    // Don't use the time offset for the time horizon.
-    bool apply_time_offset = (i != (SIM_THZ - 1));
-
-    if (after_tail_wildcard)
-      write_any(++read_index, after_tail_wildcard, apply_time_offset);
-    else {
-
-      if (closing_set_) {
-
-        closing_set_ = false;
-        if (!horizontal_set_)
-          write_indent(indents_);
-        else
-          *out_stream_ << ' ';
-      }
-      else if (!vertical)
-        *out_stream_ << ' ';
-
-      write_any(++read_index, after_tail_wildcard, apply_time_offset);
-
-      if (!closing_set_ && vertical)
-        *out_stream_ << NEWLINE;
-    }
-  }
-
-  if (closing_set_) {
-
-    closing_set_ = false;
-    write_indent(indents_);
-  }
-  *out_stream_ << ')';
-}
-
-void Decompiler::write_set(uint16 read_index, bool apply_time_offset, uint16 write_as_view_index) { // read_index points to a set atom.
+void Decompiler::write_set(uint16 read_index, uint16 write_as_view_index) { // read_index points to a set atom.
 
   uint16 arity = current_object_->code_[read_index].getAtomCount();
   bool after_tail_wildcard = false;
@@ -809,7 +753,7 @@ void Decompiler::write_set(uint16 read_index, bool apply_time_offset, uint16 wri
   if (arity == 1) { // write [element]
 
     out_stream_->push('[', read_index);
-    write_any(++read_index, after_tail_wildcard, apply_time_offset);
+    write_any(++read_index, after_tail_wildcard);
     *out_stream_ << ']';
   } else if (write_as_view_index > 0 && write_as_view_index == read_index)
     write_view(read_index, arity);
@@ -821,9 +765,9 @@ void Decompiler::write_set(uint16 read_index, bool apply_time_offset, uint16 wri
       if (i > 0)
         *out_stream_ << ' ';
       if (after_tail_wildcard)
-        write_any(++read_index, after_tail_wildcard, apply_time_offset);
+        write_any(++read_index, after_tail_wildcard);
       else
-        write_any(++read_index, after_tail_wildcard, apply_time_offset, write_as_view_index);
+        write_any(++read_index, after_tail_wildcard, write_as_view_index);
     }
     *out_stream_ << ']';
     closing_set_ = true;
@@ -834,11 +778,11 @@ void Decompiler::write_set(uint16 read_index, bool apply_time_offset, uint16 wri
     for (uint16 i = 0; i < arity; ++i) {
 
       if (after_tail_wildcard)
-        write_any(++read_index, after_tail_wildcard, apply_time_offset);
+        write_any(++read_index, after_tail_wildcard);
       else {
 
         write_indent(indents_);
-        write_any(++read_index, after_tail_wildcard, apply_time_offset, write_as_view_index);
+        write_any(++read_index, after_tail_wildcard, write_as_view_index);
       }
     }
     closing_set_ = true;
@@ -846,7 +790,7 @@ void Decompiler::write_set(uint16 read_index, bool apply_time_offset, uint16 wri
   }
 }
 
-void Decompiler::write_any(uint16 read_index, bool &after_tail_wildcard, bool apply_time_offset, uint16 write_as_view_index) { // after_tail_wildcard meant to avoid printing ':' after "::".
+void Decompiler::write_any(uint16 read_index, bool &after_tail_wildcard, uint16 write_as_view_index) { // after_tail_wildcard meant to avoid printing ':' after "::".
 
   Atom a = current_object_->code_[read_index];
 
@@ -915,7 +859,7 @@ void Decompiler::write_any(uint16 read_index, bool &after_tail_wildcard, bool ap
       if (atom.readsAsNil())
         out_stream_->push("|[]", read_index);
       else
-        write_set(index, apply_time_offset, write_as_view_index);
+        write_set(index, write_as_view_index);
       break;
     case Atom::STRING:
       if (atom.readsAsNil())

--- a/r_comp/decompiler.cpp
+++ b/r_comp/decompiler.cpp
@@ -922,23 +922,18 @@ void Decompiler::write_any(uint16 read_index, bool &after_tail_wildcard, bool ap
         out_stream_->push("|st", read_index);
       else {
 
-        Atom first = current_object_->code_[index + 1];
         std::string s = Utils::GetString(&current_object_->code_[index]);
         *out_stream_ << '\"' << s << '\"';
       }
       break;
     case Atom::TIMESTAMP:
       if (atom.readsAsNil())
-        out_stream_->push("|us", read_index);
-      else {
-
-        Atom first = current_object_->code_[index + 1];
-        auto ts = Utils::GetTimestamp(&current_object_->code_[index]);
-        if (!in_hlp_ && ts.time_since_epoch() > seconds(0) && apply_time_offset)
-          out_stream_->push(Utils::ToString_s_ms_us(ts, time_reference_), read_index);
-        else
-          out_stream_->push(Utils::ToString_s_ms_us(ts, Timestamp(seconds(0))), read_index);
-      }
+        out_stream_->push("|ts", read_index);
+      else
+        out_stream_->push(Utils::ToString_s_ms_us(Utils::GetTimestamp(&current_object_->code_[index]), time_reference_), read_index);
+      break;
+    case Atom::DURATION:
+      out_stream_->push(Utils::ToString_us(Utils::GetDuration(&current_object_->code_[index])), read_index);
       break;
     case Atom::C_PTR: {
 

--- a/r_comp/decompiler.h
+++ b/r_comp/decompiler.h
@@ -122,9 +122,9 @@ private:
 
   void write_indent(uint16 i);
   void write_expression_head(uint16 read_index); // decodes the leading atom of an expression.
-  void write_expression_tail(uint16 read_index, bool apply_time_offset, bool vertical = false); // decodes the elements of an expression following the head.
-  void write_set(uint16 read_index, bool apply_time_offset, uint16 write_as_view_index = 0);
-  void write_any(uint16 read_index, bool &after_tail_wildcard, bool apply_time_offset, uint16 write_as_view_index = 0); // decodes any element in an expression or a set.
+  void write_expression_tail(uint16 read_index); // decodes the elements of an expression following the head.
+  void write_set(uint16 read_index, uint16 write_as_view_index = 0);
+  void write_any(uint16 read_index, bool &after_tail_wildcard, uint16 write_as_view_index = 0); // decodes any element in an expression or a set.
 
   typedef void (Decompiler::*Renderer)(uint16);
   r_code::resized_vector<Renderer> renderers_; // indexed by opcodes; when not there, write_expression() is used.
@@ -140,7 +140,6 @@ private:
   void write_fact(uint16 read_index);
   void write_hlp(uint16 read_index);
   void write_ihlp(uint16 read_index);
-  void write_sim(uint16 read_index);
   void write_view(uint16 read_index, uint16 arity);
 
   bool partial_decompilation_; // used when decompiling on-the-fly.

--- a/r_comp/preprocessor.cpp
+++ b/r_comp/preprocessor.cpp
@@ -1221,8 +1221,10 @@ void Preprocessor::getMember(vector<StructureMember> &members, RepliStruct *m, s
       members.push_back(StructureMember(&Compiler::read_any, name));
     else if (type == "nb")
       members.push_back(StructureMember(&Compiler::read_number, name));
-    else if (type == "us")
+    else if (type == "ts")
       members.push_back(StructureMember(&Compiler::read_timestamp, name));
+    else if (type == "us")
+      members.push_back(StructureMember(&Compiler::read_duration, name));
     else if (type == "bl")
       members.push_back(StructureMember(&Compiler::read_boolean, name));
     else if (type == "st")
@@ -1286,8 +1288,10 @@ ReturnType Preprocessor::getReturnType(RepliStruct *s) {
 
   if (s->tail_ == ":nb")
     return NUMBER;
-  else if (s->tail_ == ":us")
+  else if (s->tail_ == ":ts")
     return TIMESTAMP;
+  else if (s->tail_ == ":us")
+    return DURATION;
   else if (s->tail_ == ":bl")
     return BOOLEAN;
   else if (s->tail_ == ":st")

--- a/r_comp/structure_member.cpp
+++ b/r_comp/structure_member.cpp
@@ -102,6 +102,7 @@ StructureMember::StructureMember(_Read r,
   if (read_ == &Compiler::read_any) type_ = ANY;
   else if (read_ == &Compiler::read_number) type_ = NUMBER;
   else if (read_ == &Compiler::read_timestamp) type_ = TIMESTAMP;
+  else if (read_ == &Compiler::read_duration) type_ = DURATION;
   else if (read_ == &Compiler::read_boolean) type_ = BOOLEAN;
   else if (read_ == &Compiler::read_string) type_ = STRING;
   else if (read_ == &Compiler::read_node) type_ = NODE_ID;
@@ -145,6 +146,8 @@ void StructureMember::write(word32 *storage) const {
     storage[0] = R_NUMBER;
   else if (read_ == &Compiler::read_timestamp)
     storage[0] = R_TIMESTAMP;
+  else if (read_ == &Compiler::read_duration)
+    storage[0] = R_DURATION;
   else if (read_ == &Compiler::read_boolean)
     storage[0] = R_BOOLEAN;
   else if (read_ == &Compiler::read_string)
@@ -175,6 +178,7 @@ void StructureMember::read(word32 *storage) {
   case R_ANY: read_ = &Compiler::read_any; break;
   case R_NUMBER: read_ = &Compiler::read_number; break;
   case R_TIMESTAMP: read_ = &Compiler::read_timestamp; break;
+  case R_DURATION: read_ = &Compiler::read_duration; break;
   case R_BOOLEAN: read_ = &Compiler::read_boolean; break;
   case R_STRING: read_ = &Compiler::read_string; break;
   case R_NODE: read_ = &Compiler::read_node; break;

--- a/r_comp/structure_member.h
+++ b/r_comp/structure_member.h
@@ -105,7 +105,8 @@ typedef enum {
   NODE_ID = 6,
   DEVICE_ID = 7,
   FUNCTION_ID = 8,
-  CLASS = 9
+  CLASS = 9,
+  DURATION = 10
 }ReturnType;
 
 typedef bool (Compiler::*_Read)(bool &, bool, const Class *, uint16, uint16 &, bool); // reads from the stream and writes in an object.
@@ -131,7 +132,8 @@ private:
     R_FUNCTION = 7,
     R_EXPRESSION = 8,
     R_SET = 9,
-    R_CLASS = 10
+    R_CLASS = 10,
+    R_DURATION = 11
   }ReadID; // used for serialization
   _Read read_;
   ReturnType type_;

--- a/r_exec/binding_map.cpp
+++ b/r_exec/binding_map.cpp
@@ -242,6 +242,12 @@ StructureValue::StructureValue(BindingMap *map, Timestamp time) : BoundValue(map
   Utils::SetTimestamp(&structure_->code(0), time);
 }
 
+StructureValue::StructureValue(BindingMap *map, microseconds duration) : BoundValue(map) {
+  structure_ = new LocalObject();
+  structure_->resize_code(3);
+  Utils::SetDuration(&structure_->code(0), duration);
+}
+
 Value *StructureValue::copy(BindingMap *map) const {
 
   return new StructureValue(map, structure_);
@@ -1102,6 +1108,7 @@ Code *HLPBindingMap::bind_pattern(Code *pattern) const {
       map_[p_atom.asIndex()]->valuate(bound_pattern, i, extent_index);
       break;
     case Atom::TIMESTAMP:
+    case Atom::DURATION:
     case Atom::STRING: { // avoid misinterpreting raw data that could be lead by descriptors.
       bound_pattern->code(i) = p_atom;
       uint16 atom_count = p_atom.getAtomCount();
@@ -1139,6 +1146,7 @@ bool HLPBindingMap::need_binding(Code *pattern) const {
     case Atom::VL_PTR:
       return true;
     case Atom::TIMESTAMP:
+    case Atom::DURATION:
     case Atom::STRING:
       i += p_atom.getAtomCount();
       break;

--- a/r_exec/binding_map.h
+++ b/r_exec/binding_map.h
@@ -182,6 +182,7 @@ public:
   StructureValue(BindingMap *map, const r_code::Code *source, uint16 structure_index);
   StructureValue(BindingMap *map, Atom *source, uint16 structure_index);
   StructureValue(BindingMap *map, Timestamp time);
+  StructureValue(BindingMap *map, std::chrono::microseconds duration);
 
   Value *copy(BindingMap *map) const;
   void valuate(r_code::Code *destination, uint16 write_index, uint16 &extent_index) const;

--- a/r_exec/context.cpp
+++ b/r_exec/context.cpp
@@ -344,6 +344,10 @@ void IPGMContext::copy_structure_to_value_array(bool prefix, uint16 write_index,
       for (uint16 i = 1; i <= atom_count; ++i)
         overlay_->values_[write_index++] = code_[index_ + i];
       break;
+    case Atom::DURATION:
+      for (uint16 i = 1; i <= atom_count; ++i)
+        overlay_->values_[write_index++] = code_[index_ + i];
+      break;
     case Atom::C_PTR:
       if (!dereference_cptr) {
 

--- a/r_exec/context.h
+++ b/r_exec/context.h
@@ -173,6 +173,10 @@ private:
         for (uint16 i = 1; i <= atom_count; ++i)
           destination->code(write_index++) = (*this)[i];
         break;
+      case Atom::DURATION: // copy members as is (no dereference).
+        for (uint16 i = 1; i <= atom_count; ++i)
+          destination->code(write_index++) = (*this)[i];
+        break;
       default:
         if (is_cmd_with_cptr()) {
 
@@ -299,6 +303,7 @@ private:
     case Atom::SET:
     case Atom::S_SET:
     case Atom::TIMESTAMP:
+    case Atom::DURATION:
     case Atom::STRING:
       destination->code(write_index) = Atom::IPointer(extent_index);
       if (pgm_index > 0 && index_ > pgm_index && data_ == STEM)

--- a/r_exec/factory.cpp
+++ b/r_exec/factory.cpp
@@ -740,8 +740,7 @@ Sim::Sim(SimMode mode, microseconds thz, Fact *super_goal, bool opposite, Contro
   code(SIM_SOLUTION_BEFORE) = Atom::IPointer(SIM_ARITY + 4);
   code(SIM_ARITY) = Atom::Float(psln_thr);
 
-  // The time horizon is stored as a timestamp, but it is actually a duration.
-  Utils::SetTimestamp<Code>(this, SIM_THZ, Timestamp(thz));
+  Utils::SetDuration<Code>(this, SIM_THZ, thz);
   Utils::SetTimestamp<Code>(this, SIM_SOLUTION_BEFORE, solution_before);
 }
 

--- a/r_exec/factory.h
+++ b/r_exec/factory.h
@@ -232,15 +232,15 @@ class r_exec_dll Sim :
 public:
   Sim(Sim *s); // is_requirement=false (not copied).
   // For SIM_MANDATORY or SIM_OPTIONAL, provide solution_controller, solution_cfd and solution_before. Otherwise, defaults for SIM_ROOT.
-  Sim(SimMode mode, std::chrono::microseconds thz, Fact *super_goal, bool opposite, Controller *root, float32 psln_thr, Controller *solution_controller = NULL, float32 solution_cfd = 0, Timestamp solution_before = Timestamp(std::chrono::seconds(0)));
+  // For SIM_ROOT, solution_before is unused so use Utils::GetTimeReference() which is 0s:0ms:0us in the decompiled output.
+  Sim(SimMode mode, std::chrono::microseconds thz, Fact *super_goal, bool opposite, Controller *root, float32 psln_thr, Controller *solution_controller = NULL, float32 solution_cfd = 0, Timestamp solution_before = r_code::Utils::GetTimeReference());
   bool invalidate();
   bool is_invalidated();
   // If SIM_MANDATORY or SIM_OPTIONAL: qualifies a sub-goal of the branch's root.
   SimMode get_mode() const { return (SimMode)(int)code(SIM_MODE).asFloat(); }
   // simulation time allowance (this is not the goal deadline); 0 indicates no time for simulation.
   std::chrono::microseconds get_thz() const {
-    // The time horizon is stored as a timestamp, but it is actually a duration.
-    return std::chrono::duration_cast<std::chrono::microseconds>(r_code::Utils::GetTimestamp<Code>(this, SIM_THZ).time_since_epoch());
+    return r_code::Utils::GetDuration<Code>(this, SIM_THZ);
   }
 
   /**

--- a/r_exec/group.cpp
+++ b/r_exec/group.cpp
@@ -639,13 +639,12 @@ void Group::update(Timestamp planned_time) {
 
       switch (new_controllers_[i]->get_object()->code(0).getDescriptor()) {
       case Atom::INSTANTIATED_ANTI_PROGRAM: { // inject signaling jobs for |ipgm (tsc).
-        // The time scope is stored as a timestamp, but it is actually a duration.
-        P<TimeJob> j = new AntiPGMSignalingJob((r_exec::View *)new_controllers_[i]->get_view(), now + Utils::GetTimestamp<Code>(new_controllers_[i]->get_object(), IPGM_TSC).time_since_epoch());
+        P<TimeJob> j = new AntiPGMSignalingJob((r_exec::View *)new_controllers_[i]->get_view(), now + Utils::GetDuration<Code>(new_controllers_[i]->get_object(), IPGM_TSC));
         _Mem::Get()->push_time_job(j);
         break;
       }case Atom::INSTANTIATED_INPUT_LESS_PROGRAM: { // inject a signaling job for an input-less pgm.
 
-        P<TimeJob> j = new InputLessPGMSignalingJob((r_exec::View *)new_controllers_[i]->get_view(), now + Utils::GetTimestamp<Code>(new_controllers_[i]->get_object(), IPGM_TSC).time_since_epoch());
+        P<TimeJob> j = new InputLessPGMSignalingJob((r_exec::View *)new_controllers_[i]->get_view(), now + Utils::GetDuration<Code>(new_controllers_[i]->get_object(), IPGM_TSC));
         _Mem::Get()->push_time_job(j);
         break;
       }
@@ -945,8 +944,7 @@ void Group::inject(View *view) { // the view can hold anything but groups and no
       std::multiset<P<View>, _View::Less>::const_iterator v;
       for (v = newly_salient_views_.begin(); v != newly_salient_views_.end(); ++v)
         c->_take_input(*v); // view will be copied.
-      // The time scope is stored as a timestamp, but it is actually a duration.
-      _Mem::Get()->push_time_job(new AntiPGMSignalingJob(view, now + Utils::GetTimestamp<Code>(c->get_object(), IPGM_TSC).time_since_epoch()));
+      _Mem::Get()->push_time_job(new AntiPGMSignalingJob(view, now + Utils::GetDuration<Code>(c->get_object(), IPGM_TSC)));
     }
     break;
   }case Atom::INSTANTIATED_INPUT_LESS_PROGRAM: {
@@ -956,7 +954,7 @@ void Group::inject(View *view) { // the view can hold anything but groups and no
     if (is_active_pgm(view)) {
 
       c->gain_activation();
-      _Mem::Get()->push_time_job(new InputLessPGMSignalingJob(view, now + Utils::GetTimestamp<Code>(view->object_, IPGM_TSC).time_since_epoch()));
+      _Mem::Get()->push_time_job(new InputLessPGMSignalingJob(view, now + Utils::GetDuration<Code>(view->object_, IPGM_TSC)));
     }
     break;
   }case Atom::MARKER: // the marker has already been added to the mks of its references.

--- a/r_exec/guard_builder.cpp
+++ b/r_exec/guard_builder.cpp
@@ -118,7 +118,7 @@ void TimingGuardBuilder::write_guard(Code *mdl, uint16 l, uint16 r, uint16 opcod
   mdl->code(extent_index) = Atom::Operator(opcode, 2); // l:(opcode r offset)
   mdl->code(++extent_index) = Atom::VLPointer(r);
   mdl->code(++extent_index) = Atom::IPointer(extent_index + 1);
-  Utils::SetTimestampStruct(mdl, ++extent_index, Timestamp(offset));
+  Utils::SetDurationStruct(mdl, ++extent_index, offset);
   extent_index += 2;
 }
 
@@ -202,7 +202,7 @@ void SGuardBuilder::_build(Code *mdl, uint16 q0, uint16 t0, uint16 t1, uint16 &w
   mdl->code(++extent_index) = Atom::Operator(Opcodes::Mul, 2);
   mdl->code(++extent_index) = Atom::VLPointer(speed_value);
   mdl->code(++extent_index) = Atom::IPointer(extent_index + 1);
-  Utils::SetTimestampStruct(mdl, ++extent_index, Timestamp(period_));
+  Utils::SetDurationStruct(mdl, ++extent_index, period_);
   extent_index += 2;
 
   write_index = extent_index;
@@ -224,7 +224,7 @@ void SGuardBuilder::_build(Code *mdl, uint16 q0, uint16 t0, uint16 t1, uint16 &w
   mdl->code(++extent_index) = Atom::Operator(Opcodes::Sub, 2);
   mdl->code(++extent_index) = Atom::VLPointer(q1);
   mdl->code(++extent_index) = Atom::VLPointer(q0);
-  Utils::SetTimestampStruct(mdl, ++extent_index, Timestamp(period_));
+  Utils::SetDurationStruct(mdl, ++extent_index, period_);
   extent_index += 2;
 
   write_index = extent_index;

--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -454,10 +454,10 @@ public:
     auto other_template_before_index = other_template_set_index + other_template_set_count;
 
     Timestamp other_f_imdl_template_after, other_f_imdl_template_before;
-    if (!getTimestamp(
+    if (!get_timestamp(
         other_imdl, other_template_set_index + (other_template_set_count - 1), other_f_imdl_template_after, bm))
       return;
-    if (!getTimestamp(other_imdl, other_template_set_index + other_template_set_count, 
+    if (!get_timestamp(other_imdl, other_template_set_index + other_template_set_count, 
         other_f_imdl_template_before, bm))
       return;
 
@@ -483,7 +483,7 @@ public:
    * imdl->code(index) is an I_PTR to a timestamp struct, then set timestamp to it.
    * Return true if timestamp was set, otherwise false.
    */
-  static bool getTimestamp(Code* imdl, int index, Timestamp& timestamp, const HLPBindingMap *bm) {
+  static bool get_timestamp(Code* imdl, int index, Timestamp& timestamp, const HLPBindingMap *bm) {
     if (imdl->code(index).getDescriptor() == Atom::VL_PTR &&
         bm->is_timestamp(imdl->code(index).asIndex())) {
       timestamp = Utils::GetTimestamp(bm->get_code(imdl->code(index).asIndex()));

--- a/r_exec/mem.cpp
+++ b/r_exec/mem.cpp
@@ -472,8 +472,7 @@ Timestamp _Mem::start() {
         for (v = g->input_less_ipgm_views_.begin(); v != g->input_less_ipgm_views_.end(); ++v) {
 
           if (v->second->controller_ != NULL && v->second->controller_->is_activated()) {
-            // The time scope is stored as a timestamp, but it is actually a duration.
-            P<TimeJob> j = new InputLessPGMSignalingJob(v->second, now + Utils::GetTimestamp<Code>(v->second->object_, IPGM_TSC).time_since_epoch());
+            P<TimeJob> j = new InputLessPGMSignalingJob(v->second, now + Utils::GetDuration<Code>(v->second->object_, IPGM_TSC));
             time_job_queue_->push(j);
           }
         }
@@ -482,8 +481,7 @@ Timestamp _Mem::start() {
         for (v = g->anti_ipgm_views_.begin(); v != g->anti_ipgm_views_.end(); ++v) {
 
           if (v->second->controller_ != NULL && v->second->controller_->is_activated()) {
-            // The time scope is stored as a timestamp, but it is actually a duration.
-            P<TimeJob> j = new AntiPGMSignalingJob(v->second, now + Utils::GetTimestamp<Code>(v->second->object_, IPGM_TSC).time_since_epoch());
+            P<TimeJob> j = new AntiPGMSignalingJob(v->second, now + Utils::GetDuration<Code>(v->second->object_, IPGM_TSC));
             time_job_queue_->push(j);
           }
         }

--- a/r_exec/mem.cpp
+++ b/r_exec/mem.cpp
@@ -393,46 +393,47 @@ bool _Mem::load(vector<r_code::Code *> *objects, uint32 stdin_oid, uint32 stdout
   return true;
 }
 
-void _Mem::init_timings(Timestamp now, const r_code::list<P<Code>>& objects) {
+/**
+ * If the code at index is a time stamp then add time_reference to it. If it is an
+ * I_PTR the recursively call this again to update it. Don't follow references.
+ * \param time_reference The value to add to the time stamp.
+ * \param code The code to check.
+ * \param index Check at code[index].
+ */
+static void update_timestamps(Timestamp time_reference, Atom* code, uint16 index) {
+  Atom atom = code[index];
 
-  auto time_tolerance = Utils::GetTimeTolerance() * 2;
-  r_code::list<P<Code> >::const_iterator o;
-  for (o = objects.begin(); o != objects.end(); ++o) {
-
-    uint16 opcode = (*o)->code(0).asOpcode();
-    if (opcode == Opcodes::Fact || opcode == Opcodes::AntiFact) {
-
-      // Use these as offsets from now.
-      auto after = Utils::GetTimestamp<Code>(*o, FACT_AFTER).time_since_epoch();
-      auto before = Utils::GetTimestamp<Code>(*o, FACT_BEFORE).time_since_epoch();
-
-      if (after < Utils_MaxTime - now)
-        Utils::SetTimestamp<Code>(*o, FACT_AFTER, after + now);
-      if (before < Utils_MaxTime - now - time_tolerance)
-        Utils::SetTimestamp<Code>(*o, FACT_BEFORE, before + now + time_tolerance);
-      else
-        Utils::SetTimestamp<Code>(*o, FACT_BEFORE, Utils_MaxTime);
-    }
-    else if (opcode == Opcodes::IMdl || opcode == Opcodes::ICst) {
-      // Look for timestamps in the template values and exposed values, and add now.
-      // TODO: There should be a more general mechanism to locate timestamps in facts, imdls, and elsewhere.
-      for (int pass = 1; pass <= 2; ++pass) {
-        auto set_index = (pass == 1 ? (*o)->code(I_HLP_TPL_ARGS).asIndex()
-                                    : (*o)->code(I_HLP_EXPOSED_ARGS).asIndex());
-        auto set_count = (*o)->code(set_index).getAtomCount();
-        for (int i = 1; i <= set_count; ++i) {
-          auto index = set_index + i;
-          if ((*o)->code(set_index + i).getDescriptor() == Atom::I_PTR) {
-            auto timestamp_index = (*o)->code(set_index + i).asIndex();
-            if ((*o)->code(timestamp_index).getDescriptor() == Atom::TIMESTAMP) {
-              auto timestamp = Utils::GetTimestamp<Code>(*o, set_index + i).time_since_epoch();
-              Utils::SetTimestampStruct(*o, timestamp_index, timestamp + now);
-            }
-          }
-        }
-      }
-    }
+  switch (atom.getDescriptor()) {
+  case Atom::TIMESTAMP: {
+    auto ts = Utils::GetTimestamp(code + index).time_since_epoch();
+    if (ts >= Utils_MaxTime - time_reference)
+      // Adding time_reference would overflow, so just set to the max time stamp.
+      Utils::SetTimestamp(code + index, Utils_MaxTime);
+    else
+      Utils::SetTimestamp(code + index, ts + time_reference);
+    break;
   }
+  case Atom::I_PTR:
+    update_timestamps(time_reference, code, atom.asIndex());
+    break;
+  case Atom::C_PTR:
+  case Atom::SET:
+  case Atom::OBJECT:
+  case Atom::S_SET:
+  case Atom::MARKER:
+  case Atom::OPERATOR:
+  case Atom::GROUP: {
+    uint16 count = atom.getAtomCount();
+    for (uint16 i = 1; i <= count; ++i)
+      update_timestamps(time_reference, code, index + i);
+    break;
+  }
+  }
+}
+
+void _Mem::init_timestamps(Timestamp time_reference, const r_code::list<P<Code>>& objects) {
+  for (auto o = objects.begin(); o != objects.end(); ++o)
+    update_timestamps(time_reference, &(*o)->code(0), 0);
 }
 
 Timestamp _Mem::start() {
@@ -452,7 +453,7 @@ Timestamp _Mem::start() {
   auto now = Now();
   Utils::SetTimeReference(now);
   ModelBase::Get()->set_thz(secondary_thz_);
-  init_timings(now, objects_);
+  init_timestamps(now, objects_);
 
   for (i = 0; i < initial_groups_.size(); ++i) {
 

--- a/r_exec/mem.h
+++ b/r_exec/mem.h
@@ -594,13 +594,14 @@ public:
   bool matches_axiom(r_code::Code* obj);
 
   /**
-   * This is called on starting the executive to adjust the timestamps of all the initial
-   * user-supplied facts by adding now. Therefore, if a the initial fact is defined with a
-   * timestamp of 100us, it is changed to now + 100us.
-   * \param now The value to add to the timestamps of all the initial facts.
-   * \param objects he list of objects to search for facts.
+   * This is called on starting the executive to adjust all user-defined objects by
+   * adding time_reference to any time stamp (fact timings as well as other time stamps).
+   * Therefore, if the object is defined with a time stamp of 100ms, it is changed to
+   * time_reference + 100ms.
+   * \param time_reference The value to add to the time stamps of all objects.
+   * \param objects The list of objects to search for time stamps.
    */
-  static void init_timings(Timestamp now, const r_code::list<P<r_code::Code>>& objects);
+  static void init_timestamps(Timestamp time_reference, const r_code::list<P<r_code::Code>>& objects);
 
   //std::vector<uint64> timings_report; // debug facility.
 

--- a/r_exec/overlay.cpp
+++ b/r_exec/overlay.cpp
@@ -197,12 +197,10 @@ Controller::Controller(_View *view) : _Object(), invalidated_(0), activated_(0),
   case Atom::INSTANTIATED_PROGRAM:
   case Atom::INSTANTIATED_INPUT_LESS_PROGRAM:
   case Atom::INSTANTIATED_ANTI_PROGRAM:
-    // The time scope is stored as a timestamp, but it is actually a duration.
-    time_scope_ = duration_cast<microseconds>(Utils::GetTimestamp<Code>(get_object(), IPGM_TSC).time_since_epoch());
+    time_scope_ = Utils::GetDuration<Code>(get_object(), IPGM_TSC);
     break;
   case Atom::INSTANTIATED_CPP_PROGRAM:
-    // The time scope is stored as a timestamp, but it is actually a duration.
-    time_scope_ = duration_cast<microseconds>(Utils::GetTimestamp<Code>(get_object(), ICPP_PGM_TSC).time_since_epoch());
+    time_scope_ = Utils::GetDuration<Code>(get_object(), ICPP_PGM_TSC);
     break;
   }
 }

--- a/r_exec/pgm_controller.cpp
+++ b/r_exec/pgm_controller.cpp
@@ -292,8 +292,7 @@ void AntiPGMController::push_new_signaling_job() {
     host->get_c_sln() > host->get_c_sln_thr()) { // c-salient group.
 
     host->leave();
-    // The time scope is stored as a timestamp, but it is actually a duration.
-    TimeJob *next_job = new AntiPGMSignalingJob((r_exec::View*)view_, Now() + Utils::GetTimestamp<Code>(get_object(), IPGM_TSC).time_since_epoch());
+    TimeJob *next_job = new AntiPGMSignalingJob((r_exec::View*)view_, Now() + Utils::GetDuration<Code>(get_object(), IPGM_TSC));
     _Mem::Get()->push_time_job(next_job);
   } else
     host->leave();


### PR DESCRIPTION
This pull request resolves issue #138. It completes the changes started in pull request #205 which added support for the DURATION type in Replicode, but didn't change to use it yet.

This pull request has three commits. The first commit changes the Replicode compiler and Code representations to distinguish duration from time stamp. If the compiler reads a duration constant like `100ms` it is represented in Code as a DURATION. The rest of the AERA code is changed to expect this. For example, the `Sim` method for `get_thz` [is changed](https://github.com/IIIM-IS/AERA/blob/872d69249aecc962e5b7f166563d15d4c25d79f1/r_exec/factory.h#L242-L244) to use `GetDuration` instead of `GetTimestamp`. The compiler also adds support for `ts` to specify in `std.replicode` that a parameter is a time stamp. (`us` now means a parameter is a duration.) For example we change the definition of the `fact` object from

    !class (_fact (_obj {obj: after:us before:us cfd:nb :~}))

to

    !class (_fact (_obj {obj: after:ts before:ts cfd:nb :~}))

because the `after` and `before` parameters are time stamps. This pull request updates the math operators to return a duration where appropriate and to disallow other operations as described in issue #138. For example the difference of two time stamps is a duration, and adding two time stamps is not allowed. This pull request also updates the decompiler to write a duration as a duration constant such as `100ms` (instead of `0s:100ms:0us`). For example, a math expression using a duration is written as `(+ v1 100ms)` as expected.

The second and third pull requests take advantage of the distinction between duration and time stamp to further simplify the code. The decompiler outputs a time stamp as an offset from the session start time, for example so that a fact timing appears as `0s:300ms:0us` if the time stamp is 300ms after the start time. Without a clear distinction between duration and time stamp, the decompiler needs [special logic](https://github.com/IIIM-IS/AERA/blob/f8317c20d0af85553b6d44f2c70018f9cf1dbb7e/r_comp/decompiler.cpp#L937-L940) to discern whether a value is a duration or is a time stamp which needs to use the offset, including passing the `apply_time_offset` parameter throughout the code. This pull request simplifies the decompiler to use this distinction by removing the unneeded special logic and the `apply_time_offset` parameter. It also removes the unneeded `write_sim` function which had special logic to write a `Sim` object which has both duration and time stamp values. These are now handled by the default function to write an expression.

Finally, when the compiler has placed all the objects in memory, AERA calls `init_timings` to add the session start time to the time stamp values in the seed code (as explained above). With a clear distinction between durations and time stamps, this code can be greatly simplified. This pull request renames `init_timings` to `init_timestamps` because it applies to all time stamps in the seed code, not just fact timings. It just calls the utility function `update_timestamps` on every object which scans the structure of the object and adds the session start time to every time stamp.