### PR TITLE
Compiler: Don't allow string as symbol so it doesn't restrict characters

### DIFF
--- a/r_comp/compiler.cpp
+++ b/r_comp/compiler.cpp
@@ -561,6 +561,7 @@ bool Compiler::symbol_expr(std::string &s) {
     case '(':
     case '[':
     case ']':
+    case '\"':
     case '.':
       if (s == "mk") {
 


### PR DESCRIPTION
In Replicode, here is a statement to print `"start: Inject fact"`:

    (prb [1 "print" "start: Inject fact" |[]])

However, the compiler prints the confusing message "error: no variables allowed outside a pattern skeleton". This is because it treats `"start` as a symbol which is followed by `:` and so it thinks it is a variable. The problem comes from [symbol_expr](https://github.com/IIIM-IS/AERA/blob/f8317c20d0af85553b6d44f2c70018f9cf1dbb7e/r_comp/compiler.cpp#L544-L581) which checks if a sequence of characters is a symbol. 

This pull request updates `symbol_expr` to exclude `"` as a symbol character. Therefore the start of the string is not a symbol and not treated as a variable. Now the message is printed as expected.