### PR TITLE
Move definition of std_grp to std.replicode

### DIFF
--- a/AERA/replicode_v1.2/std.replicode
+++ b/AERA/replicode_v1.2/std.replicode
@@ -169,6 +169,7 @@
 
 ; initial groups.
 
+!def (std_grp _upr _sln_thr _act_thr _vis_thr _ntf_grps) (grp _upr _sln_thr _act_thr _vis_thr 1 0 1 0 0 1 0 0 1 1 1 1 0 0 0 0 0 0 1 0 1 1 0 1 0 0 _ntf_grps 1); c-salient and c-active.
 root:(std_grp 0 0 0 0 [nil]) [[SYNC_ONCE now 0 forever nil nil COV_OFF 0]]
 
 primary:(std_grp 2 0 0.4 0 |[]) [[SYNC_ONCE now 0 forever root nil COV_OFF 0]]; ensure primary.upr=stdin.upr.

--- a/AERA/replicode_v1.2/user.classes.replicode
+++ b/AERA/replicode_v1.2/user.classes.replicode
@@ -1,11 +1,5 @@
 !load std.replicode
 
-
-; utilities.
-
-!def (std_grp _upr _sln_thr _act_thr _vis_thr _ntf_grps) (grp _upr _sln_thr _act_thr _vis_thr 1 0 1 0 0 1 0 0 1 1 1 1 0 0 0 0 0 0 1 0 1 1 0 1 0 0 _ntf_grps 1); c-salient and c-active.
-
-
 ; domain-dependent classes.
 
 !class (vec3 x:nb y:nb z:nb)


### PR DESCRIPTION
`user.classes.replicode` loads `std.replicode` which defines groups like `primary`. These are defined in `std.replicode` like this using `std_grp`:

    primary:(std_grp 2 0 0.4 0 |[])

Even though `std_grp` is used in `std.replicode`, the `!def` for it is in `user.classes.replicode`. This works because Replicode first runs a preprocessor on all the `!def`, then uses them. So it is possible for a `!def` to appear after it is used. But this is counter-intuitive. This pull request moves the `!def` for `std_grp` from `user.classes.replicode` to `std.replicode`.