### PR TITLE
In abduce, allow switching to SIM_MANDATORY not at the sim root

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1846,7 +1846,12 @@ void PrimaryMDLController::abduce(HLPBindingMap *bm, Fact *super_goal, bool oppo
       sub_sim = new Sim(opposite ? SIM_MANDATORY : SIM_OPTIONAL, sim_thz, super_goal, opposite, sim->root_, 1, this, confidence, now + sim_thz);
       break;
     case SIM_OPTIONAL:
+      sub_sim = new Sim(opposite ? SIM_MANDATORY : SIM_OPTIONAL, sim_thz, super_goal, opposite, sim->root_, 1, this, sim->get_solution_cfd(), sim->get_solution_before());
+      break;
     case SIM_MANDATORY:
+      if (opposite)
+        // Already switched due to an opposite match. We don't yet support switching again.
+        return;
       sub_sim = new Sim(sim->get_mode(), sim_thz, super_goal, opposite, sim->root_, 1, this, sim->get_solution_cfd(), sim->get_solution_before());
       break;
     }


### PR DESCRIPTION
Currently, during simulated backward chaining, it is possible for a goal to have an "opposite" match to a RHS. In this case, the `abduce` method [sets the simulation mode](https://github.com/IIIM-IS/AERA/blob/47787aef06286d0d289be23252500b83d851f828/r_exec/mdl_controller.cpp#L1846) to `SIM_MANDATORY`:

    case SIM_ROOT:
      sub_sim = new Sim(opposite ? SIM_MANDATORY : SIM_OPTIONAL, sim_thz, super_goal, opposite, ...);

Note that it does this when backward chaining first begins at the root. But it is possible to have an opposite match at later steps in the backward chaining, for example to match the anti-fact RHS of a strong requirement. We want this to create a mandatory solution also.

This pull request updates the logic in `abduce` to allow the simulation mode to switch to mandatory at steps other than the simulation root. If the simulation mode is `SIM_OPTIONAL`, it means that backward chaining has not previously had an opposite match, so we switch to `SIM_MANDATORY` if the current match is opposite, similar to the case for `SIM_ROOT`. If the simulation mode is already `SIM_MANDATORY` and the current match is not an opposite match, then `abduce` simply continues with the backward chaining.

However, if the simulation mode is already `SIM_MANDATORY` and the current match is opposite, then it means that backward chaining would have two opposite matches. We don't have a use case for this yet and it is not clear what the logic should be, so we don't allow this case.