### PR TITLE
In store_requirement, don't need to signal for strong requirement

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1594,10 +1594,8 @@ void PrimaryMDLController::store_requirement(_Fact *f_p_f_imdl, MDLController *c
     }
   }
 
-  // In case of a positive non-simulated requirement or any simulated requirement (positive or negative),
-  // tell monitors they can check for chaining again. Even a simulated negative (strong) requirement may cause
-  // check_simulated_imdl to take some action (such as to invalidate a defeasible prediction).
-  if (f_imdl->is_fact() || is_simulation) {
+  // In case of a positive requirement, tell monitors they can check for chaining again, which may fire a model.
+  if (f_imdl->is_fact()) {
     r_code::list<P<_GMonitor> >::const_iterator m;
     g_monitorsCS_.enter();
     for (m = r_monitors_.begin(); m != r_monitors_.end();) { // signal r-monitors.


### PR DESCRIPTION
Pull request #216 updated `store_requirement` to check if a new strong requirement disables a weak requirement which already made a prediction. Previously, this check was done by calling `signal` for all requirement monitors, which calls `retrieve_simulated_imdl_bwd` to do the check. But now doing this check in `retrieve_simulated_imdl_bwd` is redundant.

This pull request updates `store_requirement` to only call `signal` for all requirement monitors if the requirement being stored is a weak (positive) requirement. This improves efficiency by not doing the loop in this case to call `signal` multiple times . (This simply reverts the logic for this case to [what it was](https://github.com/IIIM-IS/AERA/blob/67b7023cd6f2abb662f3a10916961f023e47a439/r_exec/mdl_controller.cpp#L1532) before updating `retrieve_simulated_imdl_bwd` to do this check.)