### PR TITLE
TPX find icst component recursion

### DIFF
--- a/r_exec/pattern_extractor.cpp
+++ b/r_exec/pattern_extractor.cpp
@@ -229,7 +229,7 @@ void _TPX::filter_icst_components(ICST *icst, uint32 icst_index, vector<Componen
   delete[] found;
 }
 
-_Fact* _TPX::find_f_icst_component(_Fact* fact, const _Fact *component) {
+_Fact* _TPX::find_f_icst_component(_Fact* fact, const _Fact *component, int max_depth) {
   Code* candidate = fact->get_reference(0);
   if (candidate->code(0).asOpcode() == Opcodes::ICst) {
     ICST* icst = (ICST*)candidate;
@@ -239,6 +239,16 @@ _Fact* _TPX::find_f_icst_component(_Fact* fact, const _Fact *component) {
       // The cst is packed, retrieve the pattern from the unpacked code.
       Code* unpacked_cst = cst->get_reference(cst->references_size() - CST_HIDDEN_REFS);
       return (_Fact*)unpacked_cst->get_reference(component_index);
+    }
+
+    if (max_depth > 0) {
+      // The component was not found, so recurse to search each member.
+      for (uint32 i = 0; i < icst->components_.size(); ++i) {
+        // This will check if the component is an icst.
+        _Fact* result = find_f_icst_component(icst->components_[i], component, max_depth - 1);
+        if (result)
+          return result;
+      }
     }
   }
 

--- a/r_exec/pattern_extractor.h
+++ b/r_exec/pattern_extractor.h
@@ -190,14 +190,14 @@ protected:
    */
   class FindFIcstResult {
   public:
-    FindFIcstResult(_Fact* f_icst, uint16 component_index)
+    FindFIcstResult(_Fact* f_icst, _Fact* component_pattern)
     {
       this->f_icst = f_icst;
-      this->component_index = component_index;
+      this->component_pattern = component_pattern;
     }
 
     P<_Fact> f_icst;
-    uint16 component_index;
+    _Fact* component_pattern;
   };
 
   r_code::list<Input> inputs_; // time-controlled buffer (inputs older than tpx_time_horizon from now are discarded).
@@ -209,19 +209,17 @@ protected:
 
   /**
    * If the fact is a (fact (icst ...)) then search the icst for the component.
-   * \param fact The fact to search for the component. If fact->get_reference(0) is not an icst, then return false.
+   * \param fact The fact to search for the component. If fact->get_reference(0) is not an icst, then return NULL.
    * \param component The component to search for by being the same object (not matching).
-   * \param component_index If the component is found, set component_index to the index of the component in the icst
-   * in found_f_icst.
-   * \return true if the component is found, where component_index has been set.
+   * \return The Code pattern in the unpacked cst that matches the component, if found. NULL if not found.
    */
-  static bool find_f_icst_component(_Fact* fact, const _Fact *component, uint16 &component_index);
+  static _Fact* find_f_icst_component(_Fact* fact, const _Fact* component);
 
   /**
    * Find an f_icst for the component by looking in inputs_ and f_icsts_.
    * \param component The cst component to search for.
    * \param results Call this with an empty vector<FindFIcstResult>. If no f_icst is found, then this is empty. Otherwise an
-   * entry has the found f_icst and the index in the f_icst of the component that matches the given component.
+   * entry has the found f_icst and the Code pattern in the unpacked cst that matches the given component.
    * \param find_multiple If true then add an entry to results for each f_icst found in  inputs_ and f_icsts_ . If false, then
    * results has at most one entry.
    */
@@ -231,7 +229,7 @@ protected:
    * Find an f_icst for the component by looking in inputs_ and f_icsts_.
    * \param component The cst component to search for.
    * \param results Call this with an empty vector<FindFIcstResult>. If no f_icst is found, then this is empty. Otherwise an
-   * entry has the found f_icst and the index in the f_icst of the component that matches the given component.
+   * entry has the found f_icst and the Code pattern in the unpacked cst that matches the given component.
    * \param find_multiple (optional) If true then add an entry to results for each f_icst found in  inputs_ and f_icsts_ .
    * If omitted or false, then results has at most one entry.
    */
@@ -241,7 +239,7 @@ protected:
    * Find an f_icst for the component by looking in inputs_ and f_icsts_, or if not found then try to make one with a new cst.
    * \param component The cst component to search for.
    * \param results Call this with an empty vector<FindFIcstResult>. If no f_icst is found, then this is empty. Otherwise an
-   * entry has the found f_icst and the index in the f_icst of the component that matches the given component.
+   * entry has the found f_icst and the Code pattern in the unpacked cst that matches the given component.
    * \param new_cst If no existing f_icst is found, then this sets new_cst to a new cst and results has one entry with the
    * new f_icst.
    * \param find_multiple (optional) If true then add an entry to results for each f_icst found in  inputs_ and f_icsts_ .
@@ -249,7 +247,7 @@ protected:
    */
   void find_f_icst(_Fact *component, std::vector<FindFIcstResult>& results, P<r_code::Code> &new_cst, bool find_multiple = false);
 
-  _Fact *make_f_icst(_Fact *component, uint16 &component_index, P<r_code::Code> &new_cst);
+  _Fact *make_f_icst(_Fact *component, _Fact*& component_pattern, P<r_code::Code> &new_cst);
   r_code::Code *build_cst(const std::vector<Component> &components, BindingMap *bm, _Fact *main_component);
 
   r_code::Code *build_mdl_head(HLPBindingMap *bm, uint16 tpl_arg_count, _Fact *lhs, _Fact *rhs, uint16 &write_index, bool allow_shared_timing_vars = true);

--- a/r_exec/pattern_extractor.h
+++ b/r_exec/pattern_extractor.h
@@ -208,12 +208,15 @@ protected:
   void filter_icst_components(ICST *icst, uint32 icst_index, std::vector<Component> &components);
 
   /**
-   * If the fact is a (fact (icst ...)) then search the icst for the component.
+   * If the fact is a (fact (icst ...)) then search the icst for the component. If not found, then
+   * recursively search all members which are (fact (icst ...)).
    * \param fact The fact to search for the component. If fact->get_reference(0) is not an icst, then return NULL.
    * \param component The component to search for by being the same object (not matching).
+   * \param max_depth (optional) The maximum recursion depth for when this calls itself to search members.
+   * If this is zero, then don't recurse. If omitted, use a default.
    * \return The Code pattern in the unpacked cst that matches the component, if found. NULL if not found.
    */
-  static _Fact* find_f_icst_component(_Fact* fact, const _Fact* component);
+  static _Fact* find_f_icst_component(_Fact* fact, const _Fact* component, int max_depth = 3);
 
   /**
    * Find an f_icst for the component by looking in inputs_ and f_icsts_.


### PR DESCRIPTION
When TPX is building a model, it needs an icst for the LHS of a requirement model which contains a candidate prerequisite fact. (It does a search of icsts which are in the input buffer.) TPX uses `find_f_icst_component` to search each of these icst to see if it has a matching component (the candidate prerequisite fact). If found, `find_f_icst_component` [returns the index](https://github.com/IIIM-IS/AERA/blob/3ac45a235e632f93a88ac5efee6ae525d9b06385/r_exec/pattern_extractor.h#L214-L215) of the matching component in the cst list of members. This index [is used](https://github.com/IIIM-IS/AERA/blob/3ac45a235e632f93a88ac5efee6ae525d9b06385/r_exec/pattern_extractor.cpp#L935) to get the `cause_pattern` which is hypothesized to be a needed [parameter potentially needed](https://github.com/IIIM-IS/AERA/blob/3ac45a235e632f93a88ac5efee6ae525d9b06385/r_exec/pattern_extractor.cpp#L801) by `build_mdl` to build a guard. (We say "hypothesized" because the guard building method is a virtual method which is implemented by various derived classes of `GuardBuilder` and they may or may not use the `cause_pattern` parameter.)

Right now, `find_f_icst_component` only searches the components in a candidate icst, so the list of cst members for the index of the matching component is clear. But an icst can have members which are other icsts, and the matching component may be in one of these nested icsts. We want to update `find_f_icst_component` to recursively search these nested icsts. The use case is where PTPX has created a cst for anti-requirement model, and when PTPX is invoked at a later time due to a different prediction failure, we want to re-use the cst if possible. The problem is that if the matching component is not in the "top" icst, then which list of cst members is the matching index for? This index is only used to get the `cause_pattern`, so we solve this problem by updating `find_f_icst_component` to return the pattern right away (instead of just the index of a member of some list of patterns). This requires `find_f_icst_component` to do a little more processing where the result may not be needed later, but solves the problem.

This pull request has two commits. The first commit updates `find_f_icst_component` to return the matching component pattern  (instead of just the index). Likewise, the `FindFIcstResult` structure stores this component pattern. The rest of this commit simplifies the code which uses `FindFIcstResult` to simply use the component pattern (instead of using the index to get the pattern from the list of cst members). This commit does not change functionality.

The second commit updates `find_f_icst_component` to recursively search for the component in nested icst members. Because we return the component pattern directly, it is OK if it is in a nested cst. We add the parameter `max_depth` to limit the search.