### PR TITLE
In assume_lhs, call EvaluateFWDTimings

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -2632,6 +2632,11 @@ void PrimaryMDLController::assume(_Fact *input) {
 
 void PrimaryMDLController::assume_lhs(HLPBindingMap *bm, bool opposite, _Fact *input, float32 confidence) { // produce an assumption and inject in primary; no rdx.
 
+  // retrieve_imdl_bwd needs the forward timings so evaluate them from the backward guards. We can't call
+  // evaluate_bwd_guards here because some variables from the requirement need to be bound by retrieve_imdl_bwd.
+  if (!HLPOverlay::EvaluateFWDTimings(this, bm))
+    return;
+
   P<Fact> f_imdl = get_f_ihlp(bm, false);
   Fact *ground;
   switch (retrieve_imdl_bwd(bm, f_imdl, ground)) {


### PR DESCRIPTION
Similar to `PrimaryMDLController::abduce`, `assume_lhs` needs to call `retrieve_imdl_bwd` to find a matching requirement. But values for the forward timings variables (in the LHS fact) have not been evaluated yet, so `retrieve_imdl_bwd` fails. This pull request updates `assume_lhs` to call `EvaluateFWDTimings`. (This is similar to how `abduce` [calls `abduction_allowed`](https://github.com/IIIM-IS/AERA/blob/584578bcfe95d973328dd1bfc9fae4a01bc3efad/r_exec/mdl_controller.cpp#L1893) which calls `EvaluateFWDTimings`.)