### PR TITLE
In reduce, ignore home made assumptions

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1826,7 +1826,7 @@ void PrimaryMDLController::reduce(r_exec::View *input) { // no lock.
 
       a = assumptions_.erase(a);
       assumptionsCS_.leave();
-      break;
+      return;
     } else
       ++a;
   }


### PR DESCRIPTION
When the model controller makes an assumption, it [adds it to the list of assumptions](https://github.com/IIIM-IS/AERA/blob/584578bcfe95d973328dd1bfc9fae4a01bc3efad/r_exec/mdl_controller.cpp#L2653). When `reduce` is called with an input, it checks the list of assumptions. [The comment](https://github.com/IIIM-IS/AERA/blob/584578bcfe95d973328dd1bfc9fae4a01bc3efad/r_exec/mdl_controller.cpp#L1821) says "ignore home-made assumptions". This makes sense because the model should not make predictions from an assumption that it generated. However, currently the code does not actually ignore the input if it is an assumption. This appears to be an error. Way back in July of 2012, the [code was](https://github.com/IIIM-IS/AERA/blob/4fd3feaeeea6863bfbcb26f050ddc8805bfcbf2b/r_exec/mdl_controller.cpp#L1467-L1482) (simplified):

    bool ignore_input = false;
    assumptionsCS_.enter();
    for (a = assumptions_.begin(); a != assumptions_.end();) { // ignore home-made assumptions.
      if (((Code *)*a) == input->object_) {
        a = assumptions_.erase(a);
        ignore_input = true;
      } else
        ++a;
    }
    assumptionsCS_.leave();

    if (ignore_input)
      return;

This scans the list of assumptions. If the input is one of the assumptions, the code removes it from the list and sets the `ignore_input` flag. After the loop, if the flag has been set, the code returns. This is expected. However in the [commit of July 27, 2012](https://github.com/IIIM-IS/AERA/commit/4240385ace1b054ac91c5b4d3a6d8570c77525cd), this code was changed to the following which we still have today (simplified):

    assumptionsCS_.enter();
    for (a = assumptions_.begin(); a != assumptions_.end();) { // ignore home-made assumptions.
      if (((Code *)*a) == input->object_) {
        a = assumptions_.erase(a);
        assumptionsCS_.leave();
        break;
      } else
        ++a;
    }
    assumptionsCS_.leave();

The loop was changed to quit when the input is found in the list of assumption (instead of setting the `ignore_input` and continuing to scan the assumptions). But this code uses `break` which breaks out of the loop and continues to process the input. It is not ignored. This appears to be a mistake that was made when changing the code to remove the need for the `ignore_input` flag. Notice that, before `break`, the code calls `assumptionsCS_.leave()` to leave the critical section, yet `break` exits the loop and calls `assumptionsCS_.leave()` again. This does not make sense. This pull request changes `break` to `return` so that the function returns if the input is an assumption. Thus it now makes sense to call `assumptionsCS_.leave()` before returning.