### PR TITLE
Remove support for enable_assumptions

### DIFF
--- a/AERA/main.cpp
+++ b/AERA/main.cpp
@@ -370,7 +370,6 @@ int32 main(int argc, char **argv) {
       settings.goal_pred_success_resilience_,
       settings.probe_level_,
       settings.trace_levels_,
-      settings.enable_assumptions_,
       settings.keep_invalidated_objects_);
 
     uint32 stdin_oid;

--- a/AERA/settings.h
+++ b/AERA/settings.h
@@ -137,7 +137,6 @@ public:
   //Run.
   core::uint32 run_time_;
   core::uint32 probe_level_;
-  bool enable_assumptions_;
   bool get_models_;
   bool decompile_models_;
   bool ignore_named_models_;
@@ -290,11 +289,9 @@ public:
 
       const char *run_time = run.getAttribute("run_time");
       const char *probe_level = run.getAttribute("probe_level");
-      const char *enable_assumptions = run.getAttribute("enable_assumptions");
 
       run_time_ = atoi(run_time);
       probe_level_ = atoi(probe_level);
-      enable_assumptions_ = (strcmp(enable_assumptions, "yes") == 0);
 
       core::XMLNode models = run.getChildNode("Models");
       if (!!models) {

--- a/AERA/settings.xml
+++ b/AERA/settings.xml
@@ -47,7 +47,7 @@
       test_objects="no"
     />
   </Debug>
-  <Run run_time="1000" probe_level="2" enable_assumptions="no">
+  <Run run_time="1000" probe_level="2">
     <Models
       get_models="yes"
       decompile_models="yes"
@@ -106,7 +106,6 @@ Debug
 Run
   run_time: in ms.
   probe_level: any probe set to a level >= this level will not be executed. 0 means no probe will be executed.
-  enable_assumptions: yes or no to enable injecting assumptions.
   Models
     same as for Debug/Objects.
 -->

--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -2597,9 +2597,6 @@ void PrimaryMDLController::rate_model(bool success) {
 
 void PrimaryMDLController::assume(_Fact *input) {
 
-  if (!_Mem::Get()->get_enable_assumptions())
-    // Assumptions are disabled in the global settings.
-    return;
   if (is_requirement() || is_reuse() || is_cmd())
     return;
 

--- a/r_exec/mem.cpp
+++ b/r_exec/mem.cpp
@@ -118,7 +118,6 @@ _Mem::_Mem() : r_code::Mem(),
   goal_pred_success_res_(1000),
   keep_invalidated_objects_(false),
   probe_level_(2),
-  enable_assumptions_(true),
   reduction_cores_(0),
   time_cores_(0),
   reduction_job_count_(0),
@@ -166,7 +165,6 @@ void _Mem::init(microseconds base_period,
   uint32 goal_pred_success_res,
   uint32 probe_level,
   uint32 traces,
-  bool enable_assumptions,
   bool keep_invalidated_objects) {
 
   base_period_ = base_period;
@@ -195,7 +193,6 @@ void _Mem::init(microseconds base_period,
   goal_pred_success_res_ = goal_pred_success_res;
 
   probe_level_ = probe_level;
-  enable_assumptions_ = enable_assumptions;
   keep_invalidated_objects_ = keep_invalidated_objects;
 
   reduction_job_count_ = time_job_count_ = 0;

--- a/r_exec/mem.h
+++ b/r_exec/mem.h
@@ -148,7 +148,6 @@ protected:
 
   // Parameters::Run.
   uint32 probe_level_;
-  bool enable_assumptions_;
 
   PipeNN<P<_ReductionJob>, 1024> *reduction_job_queue_;
   PipeNN<P<TimeJob>, 1024> *time_job_queue_;
@@ -232,7 +231,6 @@ public:
     uint32 goal_pred_success_res,
     uint32 probe_level,
     uint32 traces,
-    bool enable_assumptions,
     bool keep_invalidated_objects);
 
   /**
@@ -241,7 +239,6 @@ public:
    */
   std::chrono::microseconds get_sampling_period() const { return 2 * base_period_; }
   uint64 get_probe_level() const { return probe_level_; }
-  bool get_enable_assumptions() const { return enable_assumptions_; }
   uint32 get_reduction_core_count() const { return reduction_core_count_; }
   uint32 get_time_core_count() const { return time_core_count_; }
   float32 get_mdl_inertia_sr_thr() const { return mdl_inertia_sr_thr_; }


### PR DESCRIPTION
A [previous commi](https://github.com/IIIM-IS/AERA/commit/cab4eaf2aa107e0d27cc65c0a12e2b54f93bccc4)t added support for the `enable_assumptions` flag in `settings.xml` with a default of `no`. This was added when it was observed that a model controller would inject an assumption and then later make a prediction from the same assumption as if it were a normal fact. The controller code already had a mechanism to prevent this, but there was a bug which was recently discovered and fixed in pull request #220 . Therefore it is OK to let the model controller inject assumptions as designed, This pull request reverts the earlier commit to remove the `enable_assumptions` flag.