### PR TITLE
Predict simulated imdl for resuse model

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1768,7 +1768,7 @@ void PrimaryMDLController::predict(HLPBindingMap *bm, _Fact *input, Fact *f_imdl
     OUTPUT_LINE(MDL_OUT, Utils::RelativeTime(Now()) << " mdl " << get_object()->get_oid() << ": fact " <<
       input->get_oid() << " pred -> fact " << production->get_oid() << " simulated pred" << ground_info);
 
-    if (is_cmd()) {
+    if (is_cmd() || is_reuse()) {
       // Inject the predicted imdl, in case other models are reusing this model.
       Fact *f_pred_f_imdl = new Fact(new Pred(f_imdl, prediction, 1), now, now, 1, 1);
       if (!HLPController::inject_prediction(f_pred_f_imdl, confidence))


### PR DESCRIPTION
During simulated forward chaining, a model such as the following (simplified) can fire to predict the consequence of the command on its LHS:

    M0:(mdl [H: P0: T0: T1:] []
       (fact (cmd move [H: DeltaP:] :) T2: T1_cmd: : :)
       (fact (mk.val H: position P1: :) T1_RHS: T3: : :)

In addition to the simulated prediction for the RHS, the controller injects a simulated imdl showing that the model fired with certain template values:

    (imdl M0 [h 0 0s:700ms:0us 0s:800ms:0us] [15 15 0s:800ms:0us 0s:900ms:0us])

This imdl can match the LHS of a "reuse" model such as:

    M6:(mdl [H: T: P0: T0: T1:] []
       (fact (imdl M0 [H: P0: T0_M0: T1_M0:] [DeltaP: P1: T1_RHS: T3:] : :) T0_cmd: T1_cmd: : :)
       (fact (mk.val T: position P1: :) T1_RHS: T3: : :)

This reuse model predicts that, under certain preconditions established by a requirement model, there are further consequences of executing the command on the LHS of model M0. To prevent excessive processing during simulation, we don't want the controller to inject a simulated imdl for all types of models, but only when a reuse model might need it. Therefore, the controller code only injects a simulated imdl [for a "command model"](https://github.com/IIIM-IS/AERA/blob/f19d1ce7371ded2efade87182f9e09a10f185452/r_exec/mdl_controller.cpp#L1771) (with a cmd on the LHS). But is it possible to have another reuse model that depends on the first reuse model:

    M7:(mdl [H: T: P0: C: T0: T1:] []
       (fact (imdl M6 [H: T: P0: T0_M6: T1_M6:] [T0_M0: T1_M0: DeltaP: P2: T1_RHS: T3:] : :) T0_cmd: T1_cmd: : :)
       (fact (mk.val C: position P3: :) T1_RHS: T3: : :)

This means that, under certain conditions established by another requirement model, if model M6 fires then there are even more consequences of executing the command on the LHS of the original M0. For this to work, when model M6 creates a simulated prediction from its RHS, then the controller should also inject a simulated imdl. However model M6 is not a "command model", so the controller does not currently inject the imdl. This pull request updates the model controller so that it also injects a simulated imdl for a reuse model like M6.