### PR TITLE
In abduce_simulated_imdl, don't check for existing goal if sim->is_requirement_

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -2256,7 +2256,7 @@ _Fact* PrimaryMDLController::abduce_simulated_lhs(HLPBindingMap *bm, Fact *super
 
 void PrimaryMDLController::abduce_simulated_imdl(HLPBindingMap *bm, Fact *super_goal, Fact *f_imdl, bool opposite, float32 confidence, Sim *sim) { // goal is f->g->f->object or f->g->|f->object; called concurrently by redcue() and _GMonitor::update().
 
-  if (!sim->register_goal_target(f_imdl))
+  if (!sim->is_requirement_ && !sim->register_goal_target(f_imdl))
     // We are already simulating from this goal, so abort to avoid loops.
     return;
 


### PR DESCRIPTION
Background: During backward chaining, if the model controller determines that a model needs to be instantiated, it calls `abduce_simulated_imdl` which injects a new simulated "goal requirement" `(fact (goal (fact (imdl))))`. In this case, the controller [sets the is_requirement_ flag](https://github.com/IIIM-IS/AERA/blob/bec850dfd77f865fe67150d76c6c3feacbb0e555/r_exec/mdl_controller.cpp#L1964) of the simulation object to indicate that the simulation created a goal requirement. To avoid extra processing and possible loops, `abduce_simulated_imdl` [calls register_goal_target](https://github.com/IIIM-IS/AERA/blob/bec850dfd77f865fe67150d76c6c3feacbb0e555/r_exec/mdl_controller.cpp#L2259-L2261) which checks if a matching simulated goal has already been injected, and aborts if one has. If it does not abort for this reason, `abduce_simulated_imdl` injects the goal requirement and also [calls add_r_monitor](https://github.com/IIIM-IS/AERA/blob/bec850dfd77f865fe67150d76c6c3feacbb0e555/r_exec/mdl_controller.cpp#L2278) to store a goal requirement monitor. This is important because the goal requirement monitor is used during forward chaining to match a simulated requirement and to cause the model to fire.

Background continued: Independently, during backward chaining, a goal to instantiate a cst can produce a similar subgoal `(fact (goal (fact (imdl))))` if a member of the cst is an imdl. For example, the cst `S_speak_move` has a member which is the instantiation of the model `m_speak_after_two`:

    S_speak_move:(cst |[] []
       (fact (icst C0 |[] [H: hand A:] : :) T0: T1: : :)
       (fact (mk.val H: position P: :) T0: T1: : :)
       (fact (imdl m_speak_after_two [A: "put" "it" T0: T1:] ["there" : :] : :) T0: T1: : :))

During backward chaining, the composite state controller injects the subgoal (simplified) `(fact (goal (fact (imdl m_speak_after_two [interviewer "put" "it" : :] ["there" : :]))))`. It is a simulated goal so the composite state controller adds it to the list of simulated goals which is checked by `register_goal_target`. This type of goal imdl is not produced by the model controller and is not considered a "goal requirement", so there is no goal requirement monitor at this step in the process. However, the injected fact creates a job for it to be processed by the model controller for `m_speak_after_two`. The controller determines that the model should be instantiated, so (as described above) it sets the `is_requirement_` flag and calls `abduce_simulated_imdl`.

The problem: We would expect `abduce_simulated_imdl` to inject the goal requirement and add a goal requirement monitor. The problem is that when the composite state controller created the subgoal, it added it to the list of simulated goals. When `abduce_simulated_imdl` calls `register_goal_target`, it sees that the goal already exists and aborts. In this case, we need `abduce_simulated_imdl` to continue to add a goal requirement monitor so that the goal requirement can cause the model to fire during forward chaining.

This pull request updates `abduce_simulated_imdl` so that `register_goal_target` is only called to check for a matching goal if the goal was not created as a "goal requirement". This check is simple because (as explained above) the controller sets the `is_requirement_` flag in this case. So now the check looks like:

    if (!sim->is_requirement_ && !sim->register_goal_target(f_imdl))
      // We are already simulating from this goal, so abort to avoid loops.
      return;

With this change, since the goal is a "goal requirement" `register_goal_target` is not called, and `abduce_simulated_imdl` proceeds to inject an imdl subgoal as a goal requirement and add a goal requirement monitor which can be used to fire the model during forward chaining.

Clarification: The injected goal requirement creates another job for it to be processed again by the model controller for `m_speak_after_two`. Will this cause a loop? No, because the model controller [calls goal->is_requirement()](https://github.com/IIIM-IS/AERA/blob/bec850dfd77f865fe67150d76c6c3feacbb0e555/r_exec/mdl_controller.cpp#L1855) to check if the input fact already has the `is_requirement_` flag and stops processing in this case.