### PR TITLE
PTPX: In reduce, use the template timings for the RHS. Revert PR #166.

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -139,12 +139,6 @@ bool PrimaryMDLOverlay::reduce(_Fact *input, Fact *f_p_f_imdl, MDLController *re
     bool wr_enabled = false;
     ChainingStatus c_s = ((MDLController *)controller_)->retrieve_imdl_fwd(bm, f_imdl, r_p, ground, req_controller, wr_enabled);
     f_imdl->get_reference(0)->code(I_HLP_WEAK_REQUIREMENT_ENABLED) = Atom::Boolean(wr_enabled);
-    // Use the timestamps in the template parameters that came from the prerequisite model.
-    Timestamp f_imdl_after, f_imdl_before;
-    if (((PrimaryMDLController *)controller_)->get_template_timings(bm, f_imdl_after, f_imdl_before)) {
-      Utils::SetTimestamp<Code>(f_imdl, FACT_AFTER, f_imdl_after);
-      Utils::SetTimestamp<Code>(f_imdl, FACT_BEFORE, f_imdl_before);
-    }
 
     bool chaining_allowed = (c_s >= WEAK_REQUIREMENT_ENABLED);
     bool did_check_simulated_chaining = false;

--- a/r_exec/pattern_extractor.cpp
+++ b/r_exec/pattern_extractor.cpp
@@ -86,6 +86,7 @@
 #include "reduction_job.h"
 #include "mem.h"
 #include "model_base.h"
+#include "mdl_controller.h"
 
 using namespace std;
 using namespace std::chrono;
@@ -703,7 +704,13 @@ void PTPX::reduce(r_exec::View *input) {
   auto analysis_starting_time = Now();
 
   // input->object is the prediction failure: ignore and consider |f->imdl instead.
-  _Fact *consequent = new Fact((Fact *)f_imdl_);
+  Fact* f_imdl = (Fact *)f_imdl_;
+  Timestamp f_imdl_after = f_imdl->get_after();
+  Timestamp f_imdl_before = f_imdl->get_before();
+  // Use the timestamps in the template parameters, similar to PrimaryMDLController::abduce_imdl.
+  // This is to make it symmetric with the timestamp in the forward chaining requirement.
+  MDLController::get_imdl_template_timings(f_imdl->get_reference(0), f_imdl_after, f_imdl_before);
+  P<_Fact> consequent = new Fact(f_imdl->get_reference(0), f_imdl_after, f_imdl_before, f_imdl->get_cfd(), f_imdl->get_psln_thr());
   consequent->set_opposite();
 
   P<BindingMap> end_bm = new BindingMap();


### PR DESCRIPTION
The prediction targeted pattern extractor (PTPX) is invoked when a prediction fails. It makes a new model where the RHS is an anti-fact of the imdl which produced the prediction, and the LHS is an icst which explains the conditions of the failure. The purpose of pull request #166 was to make the timings of the RHS imdl match those of the LHS icst so that the resulting "anti-requirement" model does not need guards to adjust the timings:

    (mdl |[] []
      (fact (icst cst_ball_and_wall_same_position |[] [v0: v1: v2: v3:]) v4: v5:)
      (|fact (imdl mdl_ball_position [v0: v1: v3: v4: v5:] [v6: v7: v8:]) v4: v5:)
    |[]
    |[])

We still want the "anti-requirement" model to look like this, but PR #166 achieved this by altering the timings of the original imdl _at the moment when it was produced_. Normally, when the model fires, the imdl has the timings of the command on the model's LHS which is typically delayed by 20ms. It makes sense for the imdl to have the same timings, because it "fires" when the LHS cmd is executed. Therefore, we want to revert PR #166 and allow the imdl to use the timings of the LHS command. But we still want the "anti-requirement" model to look like the example above where the timings of the RHS anti-fact of the imdl match those of the LHS. We can accomplish this by updating the PTPX code.

This pull request updates `PTPX::reduce` so that, when it is creating the RHS anti-fact of the imdl, it uses the "template timings" in the imdl (similar to what PR #166 did when altering the imdl at the moment it was produced). We also revert PR #166. Now the "anti-requirement" model still looks like the example above, but the original imdl has the timings of the cmd which fired it, as desired.