### PR TITLE
Compiler: Treat [] as an empty set if it is not at the end of a line

### DIFF
--- a/AERA/replicode_v1.2/hand-grab-sphere.replicode
+++ b/AERA/replicode_v1.2/hand-grab-sphere.replicode
@@ -26,24 +26,22 @@ s_is_a_hand:(mk.val s essence hand 1) |[]
 e1:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 emulator_state:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
 ; Inject the emulator state into the emulator group.
-emulator:(std_grp 2 0 0 0 |[]) [[SYNC_ONCE now 0 forever root nil COV_OFF 0]]
+emulator:(std_grp 2 0 0 0 []) [[SYNC_ONCE now 0 forever root nil COV_OFF 0]]
 
 ; This program runs in the primary group to re-inject any (fact (goal (fact (cmd ::)))) into emulator.
-pgm_inject_in_emulator_group:(pgm |[]
-[]
-   (ptn f_G:(fact G:(goal (fact (cmd ::) ::) ::) ::) |[])
+pgm_inject_in_emulator_group:(pgm [] []
+   (ptn f_G:(fact G:(goal (fact (cmd ::) ::) ::) ::) [])
 []
    ; Only re-inject non-simulation goals.
    (= (is_sim G) false)
 []
    (inj [f_G [SYNC_ONCE (now) 1 1 emulator nil]])
 1) |[]
-(ipgm pgm_inject_in_emulator_group |[] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+(ipgm pgm_inject_in_emulator_group [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever primary nil 1]
 
 ; Hand H has position P.
-S0:(cst |[]
-[]
+S0:(cst [] []
    (fact (mk.val H: essence hand :) T0: T1: : :); Changed X to hand.
    (fact (mk.val H: position P: :) T0: T1: : :)
 |[]
@@ -69,17 +67,15 @@ M0:(mdl [H: P0: T0: T1:]
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; If we observe state S0 (hand H has position P0), then if M0 predicts something (position P1) it will be right.
-M1:(mdl |[]
-[]
-   (fact (icst S0 |[] [H: P0:] : :) T0: T1: : :)
+M1:(mdl [] []
+   (fact (icst S0 [] [H: P0:] : :) T0: T1: : :)
    (fact (imdl M0 [H: P0: T0: T1:] [DeltaP: P1: T1_RHS: T3:] : :) T0: T1: : :); T2: is not exposed from M0. T1_RHS is also exposed.
 |[]
 |[]
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; A thing C of kind X occupies position P. (Modified to exclude when C is a hand.)
-S3:(cst |[]
-[]
+S3:(cst [] []
    (fact (mk.val C: essence X: :) T0: T1: : :)
    (fact (mk.val C: position P: :) T0: T1: : :)
    (|fact (mk.val C: essence hand :) T0: T1: : :); Don't duplicate S0, which is for hands.
@@ -88,11 +84,10 @@ S3:(cst |[]
 [stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; One hand H is at a position P and another thing C is at the same position and the hand is not holding anything.
-S1:(cst |[]
-[]
-   (fact (icst S0 |[] [H: P:] : :) T0: T1: : :)
-   (fact (icst S3 |[] [C: X: P:] : :) T0: T1: : :); X is also exposed from S3.
-   (fact (mk.val H: holding |[] :) T0: T1: : :); Change anti-fact to fact of holding |[].
+S1:(cst [] []
+   (fact (icst S0 [] [H: P:] : :) T0: T1: : :)
+   (fact (icst S3 [] [C: X: P:] : :) T0: T1: : :); X is also exposed from S3.
+   (fact (mk.val H: holding [] :) T0: T1: : :); Change anti-fact to fact of holding [].
 |[]
 |[]
 [stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
@@ -113,19 +108,17 @@ M2:(mdl [H: C: T0: T1:]
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; M2 will work (hand H will be holding something) if it is at the same position as hand H and H is not already holding anything.
-M3:(mdl |[]
-[]
-   (fact (icst S1 |[] [H: P: C: X:] : :) T0: T1: : :); X is also exposed from S1.
+M3:(mdl [] []
+   (fact (icst S1 [] [H: P: C: X:] : :) T0: T1: : :); X is also exposed from S1.
    (fact (imdl M2 [H: C: T0: T1:] [T1_RHS: T3:] : :) T0: T1: : :); T2 is not exposed from M2. T1_RHS is also exposed.
 |[]
 |[]
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; Hand H and object C are at the same position P and H is already holding C.
-S2:(cst |[]
-[]
-   (fact (icst S0 |[] [H: P:] : :) T0: T1: : :)
-   (fact (icst S3 |[] [C: X: P:] : :) T0: T1: : :); X is also exposed from S3.
+S2:(cst [] []
+   (fact (icst S0 [] [H: P:] : :) T0: T1: : :)
+   (fact (icst S3 [] [C: X: P:] : :) T0: T1: : :); X is also exposed from S3.
    (fact (mk.val H: holding [C:] :) T0: T1: : :)
 []
    (<> C nil); Make sure the object C is not nil.
@@ -137,7 +130,7 @@ S2:(cst |[]
 M4:(mdl [H: C: T0: T1:]
 []
    (fact (cmd release [H:] :) T2: T1_cmd: : :); Change T1 to T1_cmd.
-   (fact (mk.val H: holding |[] :) T1_RHS: T3: : :); Change T1 to T1_RHS. Change anti-fact to fact of holding |[].
+   (fact (mk.val H: holding [] :) T1_RHS: T3: : :); Change T1 to T1_RHS. Change anti-fact to fact of holding [].
 []
    T1_RHS:(+ T0 100ms); Copy from M0.
    T3:(+ T1 100ms);     Copy from M0.
@@ -149,9 +142,8 @@ M4:(mdl [H: C: T0: T1:]
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; M4 will work (hand H will not be holding some C) if it is at the same position as hand H and H is already holding it.
-M5:(mdl |[]
-[]
-   (fact (icst S2 |[] [H: P: C: X:] : :) T0: T1: : :); X is also exposed from S2.
+M5:(mdl [] []
+   (fact (icst S2 [] [H: P: C: X:] : :) T0: T1: : :); X is also exposed from S2.
    (fact (imdl M4 [H: C: T0: T1:] [T1_RHS: T3:] : :) T0: T1: : :); T2 is not exposed from M4. T1_RHS is also exposed.
 |[]
 |[]
@@ -175,9 +167,8 @@ M6:(mdl [H: C: P0: T0: T1:]
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; When hand H is holding some C and the hand moves to position P1, then C will also be at P1.
-M7:(mdl |[]
-[]
-   (fact (icst S2 |[] [H: P: C: X:] : :) T0: T1: : :); X is also exposed from S2.
+M7:(mdl [] []
+   (fact (icst S2 [] [H: P: C: X:] : :) T0: T1: : :); X is also exposed from S2.
    (fact (imdl M6 [H: C: P: T0: T1:] [T0_M0: T1_M0: DeltaP: P1: T1_RHS: T3:] : :) T0: T1: : :); M6 template needs P. T0_M0 T1_M0, DeltaP, P1 and T1_RHS are exposed. T2 is not exposed from M6.
 |[]
 |[]
@@ -190,19 +181,16 @@ M7:(mdl |[]
 !def DRIVE_START 300ms
 
 ; Initial conditions.
-start:(pgm |[] |[] |[] []
-   (inj []
-      State:(mk.val e1 emulator_state [c pH0 pH0 pS0] 1)
-      |[]
-   )
+start:(pgm [] [] [] []
+   (inj [State:(mk.val e1 emulator_state [c pH0 pH0 pS0] 1) []])
    (inj []
       (fact State After:(now) (+ After sampling_period) 1 1)
       [SYNC_PERIODIC now 1 1 emulator nil]
    )
 1) |[]
-(ipgm start |[] RUN_ONCE sampling_period VOLATILE NOTIFY 1) [[SYNC_ONCE now 0 forever stdin nil 1]]
+(ipgm start [] RUN_ONCE sampling_period VOLATILE NOTIFY 1) [[SYNC_ONCE now 0 forever stdin nil 1]]
 
-m_drive:(mdl |[] []
+m_drive:(mdl [] []
    ; The goal target timings are the same as the drive timings.
    (fact (mk.val s position pS1 1) T0: T1: 1 1)
    (fact run T0: T1: ::)
@@ -210,56 +198,44 @@ m_drive:(mdl |[] []
 |[]
 [stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
-pgm_inject_drive:(pgm |[]
-[]
+pgm_inject_drive:(pgm [] []
    ; This fact repeats periodically. We use it as a "heartbeat".
-   (ptn (fact (mk.val h essence hand :) After: Before: ::) |[])
+   (ptn (fact (mk.val h essence hand :) After: Before: ::) [])
 []
    (>= After (+ this.vw.ijt DRIVE_START))
 []
-   (inj []
-      ; The end of the time interval will be used in m_drive as the end of the goal interval.
-      f_run:(fact run After (+ Before 500ms) 1 1)
-      |[]
-   )
-   (inj []
-      G:(goal f_run self nil 1)
-      |[]
-   )
+   ; The end of the time interval will be used in m_drive as the end of the goal interval.
+   (inj [f_run:(fact run After (+ Before 500ms) 1 1) []])
+   (inj [G:(goal f_run self nil 1) []])
    (inj []
       ; Delay a little to allow predictions for this sampling period before injecting the drive.
       (fact G T0:(+ After 10ms) T0 1 1)
       [SYNC_ONCE T0 1 forever primary nil]
    )
-   (prb [1 "print" "injected drive" |[]])
+   (prb [1 "print" "injected drive" []])
 1) |[]
-(ipgm pgm_inject_drive |[] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+(ipgm pgm_inject_drive [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever primary nil 1]
 
 ; Before DRIVE_START, just re-inject the same values.
-pgm_before_drive:(pgm |[]
-[]
-   (ptn (fact (mk.val e1 emulator_state [Holding_obj: Pos_h: Pos_c: Pos_s:] :) After: Before: ::) |[])
+pgm_before_drive:(pgm [] []
+   (ptn (fact (mk.val e1 emulator_state [Holding_obj: Pos_h: Pos_c: Pos_s:] :) After: Before: ::) [])
 []
    (< After (+ this.vw.ijt DRIVE_START))
 []
    ; All state variables keep the same value.
-   (inj []
-      Next_state:(mk.val e1 emulator_state [Holding_obj Pos_h Pos_c Pos_s] 1)
-      |[]
-   )
+   (inj [Next_state:(mk.val e1 emulator_state [Holding_obj Pos_h Pos_c Pos_s] 1) []])
    (inj []
       (fact Next_state (+ After sampling_period) (+ Before sampling_period) 1 1)
       [SYNC_PERIODIC (+ After sampling_period) 1 1 emulator nil]
    )
 1) |[]
-(ipgm pgm_before_drive |[] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+(ipgm pgm_before_drive [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever emulator nil 1]
 
-pgm_cmd_move_h_holding_c:(pgm |[]
-[]
-   (ptn (fact G:(goal (fact (cmd move [h DeltaP_in:] ::) Cmd_after: Cmd_before: ::) ::) ::) |[])
-   (ptn (fact (mk.val e1 emulator_state [Holding_obj: Pos_h: Pos_c: Pos_s:] :) After: Before: ::) |[])
+pgm_cmd_move_h_holding_c:(pgm [] []
+   (ptn (fact G:(goal (fact (cmd move [h DeltaP_in:] ::) Cmd_after: Cmd_before: ::) ::) ::) [])
+   (ptn (fact (mk.val e1 emulator_state [Holding_obj: Pos_h: Pos_c: Pos_s:] :) After: Before: ::) [])
 []
    (= Holding_obj c)
    (= (is_sim G) false)
@@ -267,32 +243,25 @@ pgm_cmd_move_h_holding_c:(pgm |[]
    (> Cmd_before After)
 []
    ; Limit DeltaP to +/- 20. Inject the fact that the command was executed.
-   (inj []
-      Command:(cmd move [h DeltaP:(min (max DeltaP_in -20) 20)] 1)
-      |[]
-   )
+   (inj [Command:(cmd move [h DeltaP:(min (max DeltaP_in -20) 20)] 1) []])
    (inj []
       (fact Command (+ After 20ms) Before 1 1)
       [SYNC_ONCE After 1 1 stdin nil]
    )
    ; Move h by DeltaP. c moves with h.
-   (inj []
-      Next_state:(mk.val e1 emulator_state [Holding_obj Next_pos_h:(+ Pos_h DeltaP) Next_pos_h Pos_s] 1)
-      |[]
-   )
+   (inj [Next_state:(mk.val e1 emulator_state [Holding_obj Next_pos_h:(+ Pos_h DeltaP) Next_pos_h Pos_s] 1) []])
    (inj []
       (fact Next_state (+ After sampling_period) (+ Before sampling_period) 1 1)
       [SYNC_PERIODIC (+ After sampling_period) 1 1 emulator nil]
    )
    (prb [1 "print" "pgm_cmd_move_h_holding_c from command:" [Command]])
 1) |[]
-(ipgm pgm_cmd_move_h_holding_c |[] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+(ipgm pgm_cmd_move_h_holding_c [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever emulator nil 1]
 
-pgm_cmd_move_h_holding_s:(pgm |[]
-[]
-   (ptn (fact G:(goal (fact (cmd move [h DeltaP_in:] ::) Cmd_after: Cmd_before: ::) ::) ::) |[])
-   (ptn (fact (mk.val e1 emulator_state [Holding_obj: Pos_h: Pos_c: Pos_s:] :) After: Before: ::) |[])
+pgm_cmd_move_h_holding_s:(pgm [] []
+   (ptn (fact G:(goal (fact (cmd move [h DeltaP_in:] ::) Cmd_after: Cmd_before: ::) ::) ::) [])
+   (ptn (fact (mk.val e1 emulator_state [Holding_obj: Pos_h: Pos_c: Pos_s:] :) After: Before: ::) [])
 []
    (= Holding_obj s)
    (= (is_sim G) false)
@@ -300,19 +269,13 @@ pgm_cmd_move_h_holding_s:(pgm |[]
    (> Cmd_before After)
 []
    ; Limit DeltaP to +/- 20. Inject the fact that the command was executed.
-   (inj []
-      Command:(cmd move [h DeltaP:(min (max DeltaP_in -20) 20)] 1)
-      |[]
-   )
+   (inj [Command:(cmd move [h DeltaP:(min (max DeltaP_in -20) 20)] 1) []])
    (inj []
       (fact Command (+ After 20ms) Before 1 1)
       [SYNC_ONCE After 1 1 stdin nil]
    )
    ; Move h by DeltaP. s moves with h.
-   (inj []
-      Next_state:(mk.val e1 emulator_state [Holding_obj Next_pos_h:(+ Pos_h DeltaP) Pos_c Next_pos_h] 1)
-      |[]
-   )
+   (inj [Next_state:(mk.val e1 emulator_state [Holding_obj Next_pos_h:(+ Pos_h DeltaP) Pos_c Next_pos_h] 1) []])
    (inj []
       (fact Next_state (+ After sampling_period) (+ Before sampling_period) 1 1)
       [SYNC_PERIODIC (+ After sampling_period) 1 1 emulator nil]
@@ -320,45 +283,37 @@ pgm_cmd_move_h_holding_s:(pgm |[]
    (prb [1 "print" "pgm_cmd_move_h_holding_s from command:" [Command]])
    (prb [1 "print" "pgm_cmd_move_h_holding_s new s position:" [Next_state]])
 1) |[]
-(ipgm pgm_cmd_move_h_holding_s |[] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+(ipgm pgm_cmd_move_h_holding_s [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever emulator nil 1]
 
-pgm_cmd_move_h_not_holding:(pgm |[]
-[]
-   (ptn (fact G:(goal (fact (cmd move [h DeltaP_in:] ::) Cmd_after: Cmd_before: ::) ::) ::) |[])
-   (ptn (fact (mk.val e1 emulator_state [nil Pos_h: Pos_c: Pos_s:] :) After: Before: ::) |[])
+pgm_cmd_move_h_not_holding:(pgm [] []
+   (ptn (fact G:(goal (fact (cmd move [h DeltaP_in:] ::) Cmd_after: Cmd_before: ::) ::) ::) [])
+   (ptn (fact (mk.val e1 emulator_state [nil Pos_h: Pos_c: Pos_s:] :) After: Before: ::) [])
 []
    (= (is_sim G) false)
    (< Cmd_after Before)
    (> Cmd_before After)
 []
    ; Limit DeltaP to +/- 20. Inject the fact that the command was executed.
-   (inj []
-      Command:(cmd move [h DeltaP:(min (max DeltaP_in -20) 20)] 1)
-      |[]
-   )
+   (inj [Command:(cmd move [h DeltaP:(min (max DeltaP_in -20) 20)] 1) []])
    (inj []
       (fact Command (+ After 20ms) Before 1 1)
       [SYNC_ONCE After 1 1 stdin nil]
    )
    ; Move h by DeltaP.
-   (inj []
-      Next_state:(mk.val e1 emulator_state [nil (+ Pos_h DeltaP) Pos_c Pos_s] 1)
-      |[]
-   )
+   (inj [Next_state:(mk.val e1 emulator_state [nil (+ Pos_h DeltaP) Pos_c Pos_s] 1) []])
    (inj []
       (fact Next_state (+ After sampling_period) (+ Before sampling_period) 1 1)
       [SYNC_PERIODIC (+ After sampling_period) 1 1 emulator nil]
    )
    (prb [1 "print" "pgm_cmd_move_h_not_holding from command:" [Command]])
 1) |[]
-(ipgm pgm_cmd_move_h_not_holding |[] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+(ipgm pgm_cmd_move_h_not_holding [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever emulator nil 1]
 
-pgm_cmd_release_h:(pgm |[]
-[]
-   (ptn (fact G:(goal (fact Command:(cmd release [h] ::) Cmd_after: Cmd_before: ::) ::) ::) |[])
-   (ptn (fact (mk.val e1 emulator_state [Holding_obj: Pos_h: Pos_c: Pos_s:] :) After: Before: ::) |[])
+pgm_cmd_release_h:(pgm [] []
+   (ptn (fact G:(goal (fact Command:(cmd release [h] ::) Cmd_after: Cmd_before: ::) ::) ::) [])
+   (ptn (fact (mk.val e1 emulator_state [Holding_obj: Pos_h: Pos_c: Pos_s:] :) After: Before: ::) [])
 []
    (= (is_sim G) false)
    (<> Holding_obj nil)
@@ -371,23 +326,19 @@ pgm_cmd_release_h:(pgm |[]
       [SYNC_ONCE After 1 1 stdin nil]
    )
    ; h is now not holding.
-   (inj []
-      Next_state:(mk.val e1 emulator_state [nil Pos_h Pos_c Pos_s] 1)
-      |[]
-   )
+   (inj [Next_state:(mk.val e1 emulator_state [nil Pos_h Pos_c Pos_s] 1) []])
    (inj []
       (fact Next_state (+ After sampling_period) (+ Before sampling_period) 1 1)
       [SYNC_PERIODIC (+ After sampling_period) 1 1 emulator nil]
    )
    (prb [1 "print" "pgm_cmd_release_h from command:" [Command]])
 1) |[]
-(ipgm pgm_cmd_release_h |[] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+(ipgm pgm_cmd_release_h [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever emulator nil 1]
 
-pgm_cmd_grab_h:(pgm |[]
-[]
-   (ptn (fact G:(goal (fact Command:(cmd grab [h] ::) Cmd_after: Cmd_before: ::) ::) ::) |[])
-   (ptn (fact (mk.val e1 emulator_state [nil Pos_h: Pos_c: Pos_s:] :) After: Before: ::) |[])
+pgm_cmd_grab_h:(pgm [] []
+   (ptn (fact G:(goal (fact Command:(cmd grab [h] ::) Cmd_after: Cmd_before: ::) ::) ::) [])
+   (ptn (fact (mk.val e1 emulator_state [nil Pos_h: Pos_c: Pos_s:] :) After: Before: ::) [])
 []
    (= Pos_h Pos_s); For h to grab s, they must be at the same position.
    (= (is_sim G) false)
@@ -400,101 +351,72 @@ pgm_cmd_grab_h:(pgm |[]
       [SYNC_ONCE After 1 1 stdin nil]
    )
    ; We already checked that s is at the hand's position. TODO: What if c is also there? 
-   (inj []
-      Next_state:(mk.val e1 emulator_state [s Pos_h Pos_c Pos_s] 1)
-      |[]
-   )
+   (inj [Next_state:(mk.val e1 emulator_state [s Pos_h Pos_c Pos_s] 1) []])
    (inj []
       (fact Next_state (+ After sampling_period) (+ Before sampling_period) 1 1)
       [SYNC_PERIODIC (+ After sampling_period) 1 1 emulator nil]
    )
    (prb [1 "print" "pgm_cmd_grab_h from command:" [Command]])
 1) |[]
-(ipgm pgm_cmd_grab_h |[] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+(ipgm pgm_cmd_grab_h [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever emulator nil 1]
 
 ; Match the emulator state and inject individual mk.val at the same time for each of
 ; the state variables as needed.
-pgm_inject_mk_vals_holding:(pgm |[]
-[]
-   (ptn (fact (mk.val e1 emulator_state [Holding_obj: Pos_h: Pos_c: Pos_s:] :) After: Before: ::) |[])
+pgm_inject_mk_vals_holding:(pgm [] []
+   (ptn (fact (mk.val e1 emulator_state [Holding_obj: Pos_h: Pos_c: Pos_s:] :) After: Before: ::) [])
 []
    (<> Holding_obj nil)
 []
-   (inj []
-      Val_holding:(mk.val h holding [Holding_obj] 1)
-      |[]
-   )
+   (inj [Val_holding:(mk.val h holding [Holding_obj] 1) []])
    (inj []
       (fact Val_holding After Before 1 1)
       [SYNC_PERIODIC After 1 1 stdin nil]
    )
-   (inj []
-      Val_pos_h:(mk.val h position Pos_h 1)
-      |[]
-   )
+   (inj [Val_pos_h:(mk.val h position Pos_h 1) []])
    (inj []
       (fact Val_pos_h After Before 1 1)
       [SYNC_PERIODIC After 1 1 stdin nil]
    )
-   (inj []
-      Val_pos_c:(mk.val c position Pos_c 1)
-      |[]
-   )
+   (inj [Val_pos_c:(mk.val c position Pos_c 1) []])
    (inj []
       (fact Val_pos_c After Before 1 1)
       [SYNC_PERIODIC After 1 1 stdin nil]
    )
-   (inj []
-      Val_pos_s:(mk.val s position Pos_s 1)
-      |[]
-   )
+   (inj [Val_pos_s:(mk.val s position Pos_s 1) []])
    (inj []
       (fact Val_pos_s After Before 1 1)
       [SYNC_PERIODIC After 1 1 stdin nil]
    )
 1) |[]
-(ipgm pgm_inject_mk_vals_holding |[] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+(ipgm pgm_inject_mk_vals_holding [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever emulator nil 1]
 
 ; The same as pgm_inject_mk_vals_holding for the case when not holding.
-pgm_inject_mk_vals_not_holding:(pgm |[]
-[]
-   (ptn (fact (mk.val e1 emulator_state [nil Pos_h: Pos_c: Pos_s:] :) After: Before: ::) |[])
+pgm_inject_mk_vals_not_holding:(pgm [] []
+   (ptn (fact (mk.val e1 emulator_state [nil Pos_h: Pos_c: Pos_s:] :) After: Before: ::) [])
 |[]
 []
-   (inj []
-      Val_holding:(mk.val h holding |[] 1)
-      |[]
-   )
+   (inj [Val_holding:(mk.val h holding [] 1) []])
    (inj []
       (fact Val_holding After Before 1 1)
       [SYNC_PERIODIC After 1 1 stdin nil]
    )
-   (inj []
-      Val_pos_h:(mk.val h position Pos_h 1)
-      |[]
-   )
+   (inj [Val_pos_h:(mk.val h position Pos_h 1) []])
    (inj []
       (fact Val_pos_h After Before 1 1)
       [SYNC_PERIODIC After 1 1 stdin nil]
    )
-   (inj []
-      Val_pos_c:(mk.val c position Pos_c 1)
-      |[]
-   )
+   (inj [Val_pos_c:(mk.val c position Pos_c 1) []])
    (inj []
       (fact Val_pos_c After Before 1 1)
       [SYNC_PERIODIC After 1 1 stdin nil]
    )
-   (inj []
-      Val_pos_s:(mk.val s position Pos_s 1)
-      |[]
-   )
+   (inj [Val_pos_s:(mk.val s position Pos_s 1) []])
    (inj []
       (fact Val_pos_s After Before 1 1)
       [SYNC_PERIODIC After 1 1 stdin nil]
    )
 1) |[]
-(ipgm pgm_inject_mk_vals_not_holding |[] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+(ipgm pgm_inject_mk_vals_not_holding [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever emulator nil 1]

--- a/r_comp/compiler.cpp
+++ b/r_comp/compiler.cpp
@@ -2412,7 +2412,9 @@ bool Compiler::read_nil(uint16 write_index, uint16 &extent_index, bool write) {
 bool Compiler::read_nil_set(uint16 write_index, uint16 &extent_index, bool write) {
 
   std::streampos i = in_stream_->tellg();
-  if (match_symbol("|[]", false)) {
+  if (match_symbol("|[]", false) ||
+      // Treat [] as an empty set if it is not at the end of a line.
+      (match_symbol("[]", false) && in_stream_->peek() >= 32)) {
 
     if (write) {
 

--- a/r_comp/decompiler.cpp
+++ b/r_comp/decompiler.cpp
@@ -867,7 +867,8 @@ void Decompiler::write_any(uint16 read_index, bool &after_tail_wildcard, uint16 
     case Atom::SET:
     case Atom::S_SET:
       if (atom.readsAsNil())
-        out_stream_->push("|[]", read_index);
+        // In a horizontal set (where characters follow), we can write an empty set as [] .
+        out_stream_->push(horizontal_set_ ? "[]" : "|[]", read_index);
       else
         write_set(index, write_as_view_index);
       break;


### PR DESCRIPTION
Background: In the Replicode syntax, `[]` is not an empty set. Rather it marks the beginning of set members which are indented on the following lines. To write an empty set, you have to use `|[]`. For example, here is an icst where the template set is empty:

    (icst S0 |[] [h 25])

This syntax is unusual, confusing to others during presentations, and a gotcha for new AERA users. If possible, we want to use `[]` .

This pull requests has two commits. The first commit updates the Compiler to allow `[]` as an empty set if it is not at the end of a line. (We also update the Decompiler to write `[]` in the same place.) This is the majority of cases. Now the icst looks as expected:

    (icst S0 [] [h 25])

The Compiler still allows `|[]`, so this change is backwards compatible with existing Replicode code. Issue #22 proposes wider changes which are not backwards compatible, and so need to be enabled by a compiler directive like `!easy`. But the change in this pull request does not require a special directive.

As a demonstration, the second commit updates the hand-grab-sphere example to use `[]` where possible.