### PR TITLE
Fix bug in unpack_hlp: Shift code from unpacked_hlp

### DIFF
--- a/r_exec/mem.cpp
+++ b/r_exec/mem.cpp
@@ -1057,7 +1057,7 @@ void _Mem::unpack_hlp(Code *hlp) { // produces a new object (featuring a set of 
   uint16 invalid_zone_length = valid_point - invalid_point;
   for (uint16 i = valid_point; i < hlp->code_size(); ++i) { // shift the valid code upward; adjust i-ptrs.
 
-    Atom h_atom = hlp->code(i);
+    Atom h_atom = unpacked_hlp->code(i);
     switch (h_atom.getDescriptor()) {
     case Atom::I_PTR:
       unpacked_hlp->code(i - invalid_zone_length) = Atom::IPointer(h_atom.asIndex() - invalid_zone_length);


### PR DESCRIPTION
Background: As the method comment says, `unpack_hlp` produces a new model featuring a set of pattern objects instead of a set of embedded pattern expressions. This is used when [comparing two models](https://github.com/IIIM-IS/AERA/blob/d191299a1087c852a00e6686f4193a685ebde422/r_exec/model_base.cpp#L184-L186) to check if they are equal, for example to check if a new proposed model is the same as one which has already been produced by the pattern matcher. It is necessary to compare the unpacked versions of each.

`unpack_hlp` makes a new buffer `unpacked_hlp` and initially [copies the code](https://github.com/IIIM-IS/AERA/blob/864ea755c7bf903a6284c811ae3950e88cbbb7c5/r_exec/mem.cpp#L1035-L1036) from the packed model into it. It fixes some of the references in this new buffer. The unpacked code is smaller than the packed code (in which patterns are expanded), so the next step is to shift the code in this buffer to replace the expanded patterns, as mentioned in [this comment](https://github.com/IIIM-IS/AERA/blob/864ea755c7bf903a6284c811ae3950e88cbbb7c5/r_exec/mem.cpp#L1058).

But there is a small bug. The code is copied from the original packed model, not from the code in `unpacked_hlp` where the references have already been fixed. If the fixed references are not used, then the code comparison can fail. In this case, the pattern matcher can inject a model which is actually a copy of an existing model.

This pull request makes a simple fix: change to copy from `unpacked_hlp`. Now the pattern matcher correctly determines when it produces a model which is the same as an existing one. Why didn't we see this bug until now? This bug does not show up when the pattern matcher compares a new model to one it produced earlier, because the behavior of `unpack_hlp` is the same in both cases. But this bug appears when the pattern matcher compares a new model to one that was unpacked from the seed code. We didn't have this use case before.