### PR TITLE
Monitor goals even if a prediction was made

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1875,8 +1875,15 @@ void PrimaryMDLController::reduce(r_exec::View *input) { // no lock.
 
     PrimaryMDLOverlay o(this, bindings_);
     bool match = o.reduce((_Fact *)input->object_, NULL, NULL);
-    if (!match && !monitor_predictions((_Fact *)input->object_) && !monitor_goals((_Fact *)input->object_))
+    bool matched_p_monitor = false;
+    bool matched_g_monitor = false;
+    if (!match)
+      matched_p_monitor = monitor_predictions((_Fact*)input->object_);
+    if (!match && !matched_p_monitor)
+      matched_g_monitor = monitor_goals((_Fact*)input->object_);
+    if (!match && !matched_p_monitor && !matched_g_monitor)
       assume((_Fact *)input->object_);
+
     check_last_match_time(match);
   }
 }

--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1879,7 +1879,8 @@ void PrimaryMDLController::reduce(r_exec::View *input) { // no lock.
     bool matched_g_monitor = false;
     if (!match)
       matched_p_monitor = monitor_predictions((_Fact*)input->object_);
-    if (!match && !matched_p_monitor)
+    if (!matched_p_monitor)
+      // Monitor goals even if PrimaryMDLOverlay reduce sets match true, but not if a PMonitor matches.
       matched_g_monitor = monitor_goals((_Fact*)input->object_);
     if (!match && !matched_p_monitor && !matched_g_monitor)
       assume((_Fact *)input->object_);


### PR DESCRIPTION
Background: `PrimaryMDLController::reduce` processes an input for a model controller. If the input is not a goal, it[ calls PrimaryMDLOverlay::reduce](https://github.com/IIIM-IS/AERA/blob/dev/r_exec/mdl_controller.cpp#L1877) to check if the model should make a prediction from the input, and if it does to return true. If it returns false (because no prediction was made), then the model controller [calls monitor_predictions](https://github.com/IIIM-IS/AERA/blob/dev/r_exec/mdl_controller.cpp#L1878) to check if the input matches a previous prediction. It makes sense that we only check the input against previous predictions if we didn't use it to make a new prediction. The model controller also calls `monitor_goals` to check if the input matches a previous goal. Finally, if there are no matches, then it [calls assume](https://github.com/IIIM-IS/AERA/blob/dev/r_exec/mdl_controller.cpp#L1879) to make an assumption from the input.

Note that if the controller makes a prediction from the input, then `monitor_goals` is not called. This is a problem because there may be a goal to execute a command, and the input may be the evidence that the command was executed. In this case it matches the model's LHS and it makes a prediction. We want to call `monitor_goals` so that it can record that the goal to execute the command was achieved.

This pull request has two commits. The first commit only refactors [the logic](`monitor_goals`) for checking the result of trying to make a prediction, calling `monitor_predictions` and `monitor_goals` and maybe calling `assume`. We spell out the logic in multiple steps, but the functionality is the same.

The second commit changes to call `monitor_goals` even if a prediction was made from the input. Therefore, we can check if the input matches a goal.