### PR TITLE
Fix bug in patch_input_code: Use input_code_index when recursing structures

### DIFF
--- a/r_exec/pgm_overlay.cpp
+++ b/r_exec/pgm_overlay.cpp
@@ -645,11 +645,11 @@ void PGMOverlay::patch_input_code(uint16 pgm_code_index, uint16 input_index, uin
       else
         code_[patch_index] = Atom::DInObjPointer(parent_index, input_code_index + j);
       patch_indices_.push_back(patch_index);
-      switch (dereference_in_ptr(head)->code(j).getDescriptor()) {
+      switch (dereference_in_ptr(head)->code(input_code_index + j).getDescriptor()) {
         // Caution: the pattern points to sub-structures using iptrs. However, the input object may have a rptr instead of an iptr: we have to disambiguate.
       case Atom::I_PTR:
         // Dereference and recurse.
-        patch_input_code(indirection, input_index, dereference_in_ptr(head)->code(j).asIndex(), parent_index);
+        patch_input_code(indirection, input_index, dereference_in_ptr(head)->code(input_code_index + j).asIndex(), parent_index);
         break;
       case Atom::R_PTR:
         // Do not dereference and recurse.


### PR DESCRIPTION
This pull request fixes the bug in issue #211.

Background: When an object is matched to the pattern in a program, the program controller [calls patch_input_code](https://github.com/IIIM-IS/AERA/blob/4356636b313858fce179c79bfbfd5b901ba73f77/r_exec/pgm_overlay.cpp#L758) which temporarily modifies the program code to place pointers to the input object which has the values that match variables in the pattern. This is a recursive process where `patch_input_code` [calls itself](https://github.com/IIIM-IS/AERA/blob/4356636b313858fce179c79bfbfd5b901ba73f77/r_exec/pgm_overlay.cpp#L652) when there is an `I_PTR` (internal pointer) which has more of the nested structure of the pattern. This requires keeping track of the offset of the substructure of the code being processed. For example, in [this line](https://github.com/IIIM-IS/AERA/blob/4356636b313858fce179c79bfbfd5b901ba73f77/r_exec/pgm_overlay.cpp#L652) the code of an `I_PTR` is replaced with a pointer to the particular value in the input object with the offset `input_code_index + j` that the `I_PTR` points to:

    code_[patch_index] = Atom::DInObjPointer(parent_index, input_code_index + j);

But the pattern being matched can have a deeper structure where a structure pointed to by an `I_PTR` itself has an `I_PTR`. Perhaps this use case was never tested during development, but there is a bug. When examining the "pointed to" `I_PTR`, it is necessary to use the same offset `input_code_index + j`. But the code simply uses `j` which is sufficient for cases without nested structures.

This pull request updates `patch_input_code` to use `input_code_index + j` to access the code in the substructure which may need recursion. With this fix, the use case in issue #211 works properly. (The value in the `mk.val` can be placed inside a nested list to any level needed.)
