### PR TITLE
PrimaryMDLController: Inject mk.new for new model

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1526,6 +1526,7 @@ void TopLevelMDLController::register_req_outcome(Fact *f_pred, bool success, boo
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 PrimaryMDLController::PrimaryMDLController(_View *view) : PMDLController(view) {
+  inject_notification_into_out_groups(get_host(), new MkNew(_Mem::Get(), get_core_object()));
 }
 
 void PrimaryMDLController::set_secondary(SecondaryMDLController *secondary) {


### PR DESCRIPTION
AERA already injects a `mk.new` event when the auto-focus controller injects a new object into a group. But this currently isn't done for models created by PTPX, etc. We want a program to be able to run when a new model is created. This pull request updates the PrimaryMDLController constructor to inject a `mk.new` event for a new model. For example:

    (mk.new mdl_183 0)