### PR TITLE
If the LHS cause is an imdl, find_guard_builder can be used

### DIFF
--- a/r_exec/pattern_extractor.cpp
+++ b/r_exec/pattern_extractor.cpp
@@ -1067,7 +1067,49 @@ GuardBuilder *CTPX::find_guard_builder(_Fact *cause, _Fact *consequent, microsec
         }
       }
     }
-  } else if (opcode == Opcodes::MkVal) {
+  }
+
+  else if (opcode == Opcodes::IMdl) {
+    // Form 1
+    float32 q0 = target_->get_reference(0)->code(MK_VAL_VALUE).asFloat();
+    float32 q1 = consequent->get_reference(0)->code(MK_VAL_VALUE).asFloat();
+
+    // Form 1A
+    float32 searched_for = q1 - q0;
+    Code* imdl = cause->get_reference(0);
+    uint16 imdl_exposed_args_index = imdl->code(I_HLP_EXPOSED_ARGS).asIndex();
+    uint16 imdl_exposed_args_count = imdl->code(imdl_exposed_args_index).getAtomCount();
+
+    for (uint16 i = 1; i <= imdl_exposed_args_count; ++i) {
+
+      Atom s = imdl->code(imdl_exposed_args_index + i);
+      if (!s.isFloat())
+        continue;
+      float32 _s = s.asFloat();
+      if (Utils::Equal(_s, searched_for)) {
+        auto offset = duration_cast<microseconds>(Utils::GetTimestamp<Code>(cause, FACT_AFTER) - Utils::GetTimestamp<Code>(target_, FACT_AFTER));
+        return new ACGuardBuilder(period, period - offset, imdl_exposed_args_index + i);
+      }
+    }
+
+    if (q0 != 0) {
+      // Form 1B
+      searched_for = q1 / q0;
+      for (uint16 i = imdl_exposed_args_index + 1; i <= imdl_exposed_args_count; ++i) {
+
+        Atom s = imdl->code(i);
+        if (!s.isFloat())
+          continue;
+        float32 _s = s.asFloat();
+        if (Utils::Equal(_s, searched_for)) {
+          auto offset = duration_cast<microseconds>(Utils::GetTimestamp<Code>(cause, FACT_AFTER) - Utils::GetTimestamp<Code>(target_, FACT_AFTER));
+          return new MCGuardBuilder(period, period - offset, i);
+        }
+      }
+    }
+  }
+  
+  else if (opcode == Opcodes::MkVal) {
     // Forms 2 and 3
     Atom s = cause_payload->code(MK_VAL_VALUE);
     if (s.isFloat()) {


### PR DESCRIPTION
Currently, the method CTPX::get_default_guard_builder can generate reuse models with guards for calculating values for timing variables. A reuse model is a model with an imdl on its LHS. In complex examples, CTPX may need to build reuse models with guards for calculating values for timing variables and other types of variables.
This pull request extends CTPX by updating the CTPX::find_guard_builder method so that if the cause is an imdl, CTPX scans the exposed arguments of that, and checks if the observed value change equals any of the arguments. If so, it creates reuse models with guards for calculating values for timing variables and other types of variables.