### PR TITLE
Don't fail evaluation if assignment guard is already bound

### DIFF
--- a/r_exec/hlp_context.cpp
+++ b/r_exec/hlp_context.cpp
@@ -155,6 +155,9 @@ bool HLPContext::evaluate_no_dereference() const {
 
       ((HLPOverlay *)overlay_)->bindings_->bind_variable(code_, code_[index_].asAssignmentIndex(), code_[index_].asIndex(), &overlay_->values_[0]);
       return true;
+    } else if (((HLPOverlay*)overlay_)->bindings_->scan_variable(code_[index_].asAssignmentIndex())) {
+      // The assignment expression could not be evaluated, but the assignment variable is already bound.
+      return true;
     } else
       return false;
   }case Atom::OPERATOR: {

--- a/r_exec/hlp_overlay.cpp
+++ b/r_exec/hlp_overlay.cpp
@@ -237,7 +237,8 @@ bool HLPOverlay::scan_bwd_guards() const {
         return false;
       break;
     case Atom::ASSIGN_PTR:
-      if (!scan_location(a.asIndex()))
+      // If scan_location fails, then succeed if the assignment variable is already bound.
+      if (!scan_location(a.asIndex()) && !bindings_->scan_variable(a.asAssignmentIndex()))
         return false;
       break;
     }


### PR DESCRIPTION
Background: During backward chaining, the backward assignment guards are evaluated. For example the move model evaluates `DeltaP:(- P1 P0)` . In this case the variable `P0` is bound to the current position and `P1` is bound to the goal position which was determined during backward chaining. Therefore `DeltaP` can be computed. In general it is expected that the variables in the expression are all bound to a value, and that the assignment variable doesn't have a value yet. (This has been the case in all the examples we have worked with so far.)

But now we have a case that comes from reuse models where, during backward chaining, the value of the assignment variable such as `DeltaP` is known, but some of the variable in the expression are unknown. Currently, the code to evaluate backward guards will fail because the expression cannot be evaluated. But it seems that this shouldn't matter since the value of the assignment variable is already known.

This pull request updates `HLPContext::evaluate_no_dereference` so that, if the evaluation of the expression fails, it checks if the assignment variable already has a binding. If yes then it keeps the binding and succeeds. Also, there is a method `HLPOverlay::scan_bwd_guards` which simply does a quick check to see if it is possible to backward chain through the model. We do a similar check so that it will still succeed if the assignment variable already has a value.