### PR TITLE
Allocation of the correct number of backward guards to reuse models in CmdGuardBuilder::_build

### DIFF
--- a/r_exec/guard_builder.h
+++ b/r_exec/guard_builder.h
@@ -158,11 +158,12 @@ class CmdGuardBuilder :
 protected:
   std::chrono::microseconds offset_;
   uint16 cmd_arg_index_;
+  bool add_imdl_template_timings_;
 
   void _build(r_code::Code *mdl, uint16 fwd_opcode, uint16 bwd_opcode, uint16 q0, uint16 t0, uint16 t1, uint16 &write_index) const;
   void _build(r_code::Code *mdl, uint16 fwd_opcode, uint16 bwd_opcode, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const;
 
-  CmdGuardBuilder(std::chrono::microseconds period, std::chrono::microseconds offset, uint16 cmd_arg_index);
+  CmdGuardBuilder(std::chrono::microseconds period, std::chrono::microseconds offset, uint16 cmd_arg_index, bool add_imdl_template_timings = false);
 public:
   virtual ~CmdGuardBuilder();
 };
@@ -185,7 +186,7 @@ class ACGuardBuilder :
 private:
 
 public:
-  ACGuardBuilder(std::chrono::microseconds period, std::chrono::microseconds offset, uint16 cmd_arg_index);
+  ACGuardBuilder(std::chrono::microseconds period, std::chrono::microseconds offset, uint16 cmd_arg_index, bool add_imdl_template_timings);
   ~ACGuardBuilder();
 
   void build(r_code::Code *mdl, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const override;

--- a/r_exec/pattern_extractor.cpp
+++ b/r_exec/pattern_extractor.cpp
@@ -1031,6 +1031,8 @@ GuardBuilder *CTPX::find_guard_builder(_Fact *cause, _Fact *consequent, microsec
 
   Code *cause_payload = cause->get_reference(0);
   uint16 opcode = cause_payload->code(0).asOpcode();
+  auto add_imdl_template_timings = false;
+  Timestamp after, before;
   if (opcode == Opcodes::Cmd) {
     // Form 1
     float32 q0 = target_->get_reference(0)->code(MK_VAL_VALUE).asFloat();
@@ -1048,7 +1050,7 @@ GuardBuilder *CTPX::find_guard_builder(_Fact *cause, _Fact *consequent, microsec
       float32 _s = s.asFloat();
       if (Utils::Equal(_s, searched_for)) {
         auto offset = duration_cast<microseconds>(Utils::GetTimestamp<Code>(cause, FACT_AFTER) - Utils::GetTimestamp<Code>(target_, FACT_AFTER));
-        return new ACGuardBuilder(period, period - offset, cmd_arg_set_index + i);
+        return new ACGuardBuilder(period, period - offset, cmd_arg_set_index + i, add_imdl_template_timings);
       }
     }
 
@@ -1069,7 +1071,7 @@ GuardBuilder *CTPX::find_guard_builder(_Fact *cause, _Fact *consequent, microsec
     }
   }
 
-  else if (opcode == Opcodes::IMdl) {
+  else if (opcode == Opcodes::IMdl && MDLController::get_imdl_template_timings(cause_payload, after, before)) {
     // Form 1
     float32 q0 = target_->get_reference(0)->code(MK_VAL_VALUE).asFloat();
     float32 q1 = consequent->get_reference(0)->code(MK_VAL_VALUE).asFloat();
@@ -1088,7 +1090,8 @@ GuardBuilder *CTPX::find_guard_builder(_Fact *cause, _Fact *consequent, microsec
       float32 _s = s.asFloat();
       if (Utils::Equal(_s, searched_for)) {
         auto offset = duration_cast<microseconds>(Utils::GetTimestamp<Code>(cause, FACT_AFTER) - Utils::GetTimestamp<Code>(target_, FACT_AFTER));
-        return new ACGuardBuilder(period, period - offset, imdl_exposed_args_index + i);
+        add_imdl_template_timings = true;
+        return new ACGuardBuilder(period, period - offset, imdl_exposed_args_index + i, add_imdl_template_timings);
       }
     }
 


### PR DESCRIPTION
Currently, when CTPX::find_guard_builder method creates a command model or a reuse model, it allocates 3 forward and 5 backward guards to the model. 5 backward guards are sufficient for backward chaining through command models but **not for reuse models**.  In fact, reuse models need two more timing guards which allocate different variables to the timings of imdl objects that exist on their LHS. (A "timing guard" is an assignment guard which computes a value for a variable containing a timestamp.)
Let us see what this means by an example. In the following example, command model M1 provides the prediction of a hand's position (Ph) after applying the move command, and reuse model M2 provides the prediction of a cube's position (Pc) after moving the cube by hand (i.e. after applying the move command to the hand). We can assume that the hand is pulling the cube by an intermediate object like a string and thus their position is not the same, (<> Pc Ph).

    ; Command model of the movement of hand H
    M1:(mdl [Ph0: T0: T1:] []
       (fact (cmd move [H: DeltaP:] :) T0_cmd: T1_cmd: : :)
       (fact (mk.val H: position Ph: :) T1_RHS: T3: : :)
    []
       T1_RHS:(add T0 100ms)
       T3:(add T1 100ms)
       Ph:(add Ph0 DeltaP)
    []
       T0:(sub T1_RHS 100ms)
       T1:(sub T3 100ms)
       T0_cmd:(sub T1_RHS 80ms)
       T1_cmd:(sub T3 100ms)
       DeltaP:(sub Ph Ph0)
    [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]

    ; Reuse of the movement of the hand model, this model predicts the cube's position (Pc), the cube is C.
    M2:(mdl [Pc0: T0: T1:] []
       (fact (imdl M1 [Ps: T0_M1: T1_M1:] [H: DeltaP: Ph: T1_RHS: T3:] : :) T0_cmd: T1_cmd: : :)
       (fact (mk.val C: position Pc: :) T1_RHS: T3: : :)
    []
       T1_RHS:(add T0 100ms)
       T3:(add T1 100ms)
       Pc:(add Pc0 DeltaP)
    []
       T0_M1:(sub T1_RHS 100ms) ; Added guard
       T1_M1:(sub T3 100ms)     ; Added guard
       T0:(sub T1_RHS 100ms)
       T1:(sub T3 100ms)
       T0_cmd:(sub T1_RHS 80ms)
       T1_cmd:(sub T3 100ms)
       DeltaP:(sub Pc Pc0)
    [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]

M2 shows the correct syntax for a reuse model, where 7 guards exist in the RHS, and 6 of them are timing guards. The two guards marked "Added guard" are not currently created by the CTPX, even though they are required for backward chaining since they supply values to additional timing variables in imdl on the LHS. This pull request fixes the above issue by modifying CmdGuardBuilder::_build method in guard_builder.cpp and CTPX::find_guard_builder such that CTPX decides to allocate the proper number of backward guards to models based on Opcodes. If the object is a command (Opcodes::Cmd) it writes 5 backward guards and if the object is an imdl (Opcodes::IMdl) it will write two more timing guards that specify the timings of the imdl object.
  