### PR TITLE
Support model shared template variables

### DIFF
--- a/AERA/replicode_v1.2/hand-grab-sphere.replicode
+++ b/AERA/replicode_v1.2/hand-grab-sphere.replicode
@@ -148,7 +148,7 @@ M5:(mdl [] []
 
 ; When model M0 fires the prediction of the next position P1 of hand H, something C will also be at the same position P1.
 M6:(mdl [H: C: P0: T0: T1:] []
-   (fact (imdl M0 [H: P0: T0_M0: T1_M0:] [DeltaP: P1: T1_RHS: T3:] : :) T0_cmd: T1_cmd: : :); Change timings from T1 T3 to T0_cmd T1_cmd. T2 is not exposed from M0. T1_RHS is also exposed. Distinguish T0_M0 and T1_M0.
+   (fact (imdl M0 [H: P0: T0: T1:] [DeltaP: P1: T1_RHS: T3:] : :) T0_cmd: T1_cmd: : :); Change timings from T1 T3 to T0_cmd T1_cmd. T2 is not exposed from M0. T1_RHS is also exposed.
    (fact (mk.val C: position P1: :) T1_RHS: T3: : :); Fix bug as explained: Change C to P1. Change T1 to T1_RHS.
 []
    T1_RHS:(+ T0 100ms); Repeat from M0.
@@ -158,14 +158,12 @@ M6:(mdl [H: C: P0: T0: T1:] []
    T1_cmd:(- T3 100ms);     Copy from M0.
    T0:(- T1_RHS 100ms);     Copy from M0.
    T1:(- T3 100ms);         Copy from M0.
-   T0_M0:(- T1_RHS 100ms);  Duplicate T0.
-   T1_M0:(- T3 100ms);      Duplicate T1.
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; When hand H is holding some C and the hand moves to position P1, then C will also be at P1.
 M7:(mdl [] []
    (fact (icst S2 [] [H: P: C: X:] : :) T0: T1: : :); X is also exposed from S2.
-   (fact (imdl M6 [H: C: P: T0: T1:] [T0_M0: T1_M0: DeltaP: P1: T1_RHS: T3:] : :) T0: T1: : :); M6 template needs P. T0_M0 T1_M0, DeltaP, P1 and T1_RHS are exposed. T2 is not exposed from M6.
+   (fact (imdl M6 [H: C: P: T0: T1:] [DeltaP: P1: T1_RHS: T3:] : :) T0: T1: : :); M6 template needs P. T0_M0 T1_M0, DeltaP, P1 and T1_RHS are exposed. T2 is not exposed from M6.
 |[]
 |[]
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]

--- a/r_exec/binding_map.cpp
+++ b/r_exec/binding_map.cpp
@@ -469,7 +469,8 @@ Code *BindingMap::abstract_object(Code *object, bool force_sync, int timing_vars
     uint16 extent_index = I_HLP_ARITY + 1;
     abstracted_object = _Mem::Get()->build_object(object->code(0));
     abstract_member(object, I_HLP_OBJ, abstracted_object, I_HLP_OBJ, extent_index);
-    abstract_member(object, I_HLP_TPL_ARGS, abstracted_object, I_HLP_TPL_ARGS, extent_index, timing_vars_first_search_index);
+    // Set first_search_index to allow search to match with the model template args.
+    abstract_member(object, I_HLP_TPL_ARGS, abstracted_object, I_HLP_TPL_ARGS, extent_index, 0);
     // Set first_search_index to not search because exposed args are "output values" which can't be assume to be the same as other values.
     abstract_member(object, I_HLP_EXPOSED_ARGS, abstracted_object, I_HLP_EXPOSED_ARGS, extent_index, -1);
     abstracted_object->code(I_HLP_WEAK_REQUIREMENT_ENABLED) = Atom::Wildcard();

--- a/r_exec/guard_builder.cpp
+++ b/r_exec/guard_builder.cpp
@@ -253,9 +253,8 @@ void SGuardBuilder::build(Code *mdl, _Fact *premise_pattern, _Fact *cause_patter
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-NoArgCmdGuardBuilder::NoArgCmdGuardBuilder(microseconds period, microseconds offset, microseconds cmd_duration,
-  bool add_imdl_template_timings)
-: TimingGuardBuilder(period), offset_(offset), cmd_duration_(cmd_duration), add_imdl_template_timings_(add_imdl_template_timings) {
+NoArgCmdGuardBuilder::NoArgCmdGuardBuilder(microseconds period, microseconds offset, microseconds cmd_duration)
+: TimingGuardBuilder(period), offset_(offset), cmd_duration_(cmd_duration) {
 }
 
 NoArgCmdGuardBuilder::~NoArgCmdGuardBuilder() {
@@ -282,23 +281,8 @@ void NoArgCmdGuardBuilder::_build(Code *mdl, uint16 q0, uint16 t0, uint16 t1, ui
   write_index = extent_index;
   mdl->code(MDL_BWD_GUARDS) = Atom::IPointer(++write_index);
 
-  if (add_imdl_template_timings_) {
-    // We have already made sure the timings exist using MDLController::get_imdl_template_timings.
-    auto imdl = lhs->get_reference(0);
-    auto template_set_index = imdl->code(I_HLP_TPL_ARGS).asIndex();
-    auto template_set_count = imdl->code(template_set_index).getAtomCount();
-    uint16 template_t0 = imdl->code(template_set_index + (template_set_count - 1)).asIndex();
-    uint16 template_t1 = imdl->code(template_set_index + template_set_count).asIndex();
-
-    mdl->code(write_index) = Atom::Set(6);
-    extent_index = write_index + 6;
-    write_guard(mdl, template_t0, t2, Opcodes::Sub, period_, write_index, extent_index);
-    write_guard(mdl, template_t1, t3, Opcodes::Sub, period_, write_index, extent_index);
-  }
-  else {
-    mdl->code(write_index) = Atom::Set(4);
-    extent_index = write_index + 4;
-  }
+  mdl->code(write_index) = Atom::Set(4);
+  extent_index = write_index + 4;
 
   write_guard(mdl, t0, t2, Opcodes::Sub, period_, write_index, extent_index);
   write_guard(mdl, t1, t3, Opcodes::Sub, period_, write_index, extent_index);

--- a/r_exec/guard_builder.h
+++ b/r_exec/guard_builder.h
@@ -136,7 +136,6 @@ class NoArgCmdGuardBuilder :
 protected:
   std::chrono::microseconds offset_;
   std::chrono::microseconds cmd_duration_;
-  bool add_imdl_template_timings_;
 
   void _build(r_code::Code *mdl, uint16 q0, uint16 t0, uint16 t1, uint16 &write_index) const;
 public:
@@ -145,8 +144,7 @@ public:
    * backward guards similar to those added for t0 and t1, but assign the imdl template timings.
    * If ommitted, use false.
    */
-  NoArgCmdGuardBuilder(std::chrono::microseconds period, std::chrono::microseconds offset, std::chrono::microseconds cmd_duration,
-    bool add_imdl_template_timings = false);
+  NoArgCmdGuardBuilder(std::chrono::microseconds period, std::chrono::microseconds offset, std::chrono::microseconds cmd_duration);
   ~NoArgCmdGuardBuilder();
 
   void build(r_code::Code *mdl, _Fact *premise_pattern, _Fact *cause_pattern, uint16 &write_index) const override;

--- a/r_exec/pattern_extractor.cpp
+++ b/r_exec/pattern_extractor.cpp
@@ -1010,12 +1010,7 @@ GuardBuilder *CTPX::get_default_guard_builder(_Fact *cause, _Fact *consequent, m
 
     auto offset = duration_cast<microseconds>(consequent->get_after() - cause->get_after());
     auto cmd_duration = duration_cast<microseconds>(cause->get_before() - cause->get_after());
-    auto add_imdl_template_timings = false;
-    Timestamp after, before;
-    if (opcode == Opcodes::IMdl && MDLController::get_imdl_template_timings(cause_payload, after, before))
-      // The imdl has template timings, so we want the backward guards to assign them.
-      add_imdl_template_timings = true;
-    return new NoArgCmdGuardBuilder(period, offset, cmd_duration, add_imdl_template_timings);
+    return new NoArgCmdGuardBuilder(period, offset, cmd_duration);
   }
 
   return new TimingGuardBuilder(period);


### PR DESCRIPTION
Background: In the hand-grab-sphere example, the reuse model `M6` currently is:

    M6:(mdl [H: C: P0: T0: T1:] []
       (fact (imdl M0 [H: P0: T0_M0: T1_M0:] [DeltaP: P1: T2: T3:] : :) T0_cmd: T1_cmd: : :)
       (fact (mk.val C: position P1: :) T2: T3: : :)
    []
       T2:(+ T0 100ms)
       T3:(+ T1 100ms)
    []
       T0_cmd:(- T1_RHS 80ms)
       T1_cmd:(- T3 100ms)
       T0:(- T2 100ms)
       T1:(- T3 100ms)
       T0_M0:(- T2 100ms); Duplicate T0.
       T1_M0:(- T3 100ms);     Duplicate T1.

In forward chaining, a goal requirement makes the imdl `(imdl M0 [h 0 0s:200ms:0us 0s:800ms:0us] [: : : :] :)`. This matches the LHS of model `M6` and binds `T0_M0` and `T1_M0` to the timing values 0s:200ms:0us 0s:800ms:0us. Also, the requirement model has stored the requirement `(imdl M6 [h s 0 0s:600ms:0us 0s:700ms:0us] [: : : : : :])`. This matches and the template arguments `T0` and `T1` are bound to the timing values 0s:600ms:0us 0s:700ms:0us . These are used by the forward guards to correctly compute the RHS timing variables `T2` and `T3` as 0s:700ms:0us 0s:800ms:0us. Forward chaining proceeds and the example works because `T0_M0` and `T1_M0` are separate variables from `T0` and `T1` (explained below).

The backward guards must compute  values for `T0_M0` and `T1_M0`. But notice that the formulas are the same as for `T0` and `T1`. We would prefer to simplify by eliminating the extra variables `T0_M0` and `T1_M0` as follows:

    M6:(mdl [H: C: P0: T0: T1:] []
       (fact (imdl M0 [H: P0: T0: T1:] [DeltaP: P1: T2: T3:] : :) T0_cmd: T1_cmd: : :)
       (fact (mk.val C: position P1: :) T2: T3: : :)
    []
       T2:(+ T0 100ms)
       T3:(+ T1 100ms)
    []
       T0_cmd:(- T1_RHS 80ms)
       T1_cmd:(- T3 100ms)
       T0:(- T2 100ms)
       T1:(- T3 100ms)

But there is a problem. As before, during forward chaining a goal requirement makes the imdl `(imdl M0 [h 0 0s:200ms:0us 0s:800ms:0us] [: : : :] :)`. This matches the LHS of model `M6`, but this time it binds `T0` and `T1` to the timing values 0s:200ms:0us 0s:800ms:0us . When the stored requirement is matched, these values for `T0` and `T1` are retained so that the forward guards compute the RHS timing variables `T2` and `T3` as 0s:300ms:0us 0s:900ms:0us . This is not correct, and the example fails. The correct values 0s:600ms:0us 0s:700ms:0us for `T0` and `T1` are available from the requirement. During matching, these should be used to "narrow" the goal time interval of 0s:300ms:0us 0s:900ms:0us and the "narrowed" match should replace the values for template variables `T0` and `T1`. (The method `match_timings` is already used to match fact timing variables such as `T0_cmd` and `T1_cmd`, and updates the timing variables by "narrowing" during match.)

This pull request has four commits. The first commit updates the class `TemplateTimingsUpdater` which is used by `retrieve_simulated_imdl_fwd` to match a requirement. The purpose of `TemplateTimingsUpdater` is to temporarily make the template timings of two imdls the same so that matching can succeed (since the low-level matching algorithm doesn't take into account the semantics of template time intervals and narrowing). We add a method `narrow_timings` which is called after a successful match. This calls `match_timings` which updates the template timing variables. In the example above, the variables `T0` and `T1` are changed to the correct values 0s:600ms:0us 0s:700ms:0us when matching to the template values in the requirement. We update `retrieve_simulated_imdl_fwd` (and related methods) to call `narrow_timings` after a successful match.

The previous commit is enough to solve the problem for hand-coded models in the seed. But we want to support shared template timings in learned models too. The second commit updates the `BindingMap` method `abstract_object` which is used when creating a model from patterns to make an abstract LHS which only has variables (to be used in the general model). When assigning variables based on pattern values, `abstract_object` searches for existing variables which have the same value and re-uses the variable if the same. We update `abstract_object` to allow template variables in an imdl to match an existing variable. (This was previously avoided for the reasons explained above.)

Now that a reuse model does not have separate template timing variables like `T0_M0` and `T1_M0`, we don't need backward guards to compute their values. The third commit updates `NoArgCmdGuardBuilder` which is used to make the guards in a new learned model. We remove support for `add_imdl_template_timings` which is not needed.

Finally, the fourth commit updates the hand-grab-sphere example as shown above so that the hand-coded model `M6` removes variables `T0_M0` and `T1_M0` and the backward guards to compute their values.