### PR TITLE
INSTALL: Update SDK options and add Win32

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,6 +17,10 @@ To install Visual Studio, download and install Visual Studio Community Edition 2
 https://visualstudio.microsoft.com/vs/older-downloads .
 In the installer, under "Desktop development with C++", check "Windows 10 SDK (10.0.17134.0)" and
   "MSVC v141 - VS 2017 C++ build tools".
+  
+In case you have Visual Studio Community Edition 2022 installed, "Windows 10 SDK (10.0.17134.0)" will
+  not be listed as an option in the installer.
+Instead, you can download  "Windows 10 SDK (10.0.17134.12)" from https://developer.microsoft.com/windows/downloads/sdk-archive/ .
 
 To install Git, download and install GitHub for Desktop from https://desktop.github.com .
 
@@ -41,6 +45,9 @@ the line is:
 ## Compile
 
 In the Solution Configurations drop-down, make sure you select Release (unless you plan to debug AERA).
+
+In the Solution Options drop-down, make sure you select Win32.
+
 On the Build menu, click Build Solution. (Don't worry about all the compiler warnings.)
 
 Run


### PR DESCRIPTION
INSTALL.md does not specify that AERA is 32 bit, which might cause an issue if the build solution is set to 64 bit automatically.

Building AERA also works on newer versions (up to 2022) of VS community, but the required Windows SDK version isn't listed in the installer anymore. Instead you can download it from the Microsoft archive.