### PR TITLE
Multiple matches in retrieve_imdl_fwd

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -135,20 +135,20 @@ bool PrimaryMDLOverlay::reduce(_Fact *input, Fact *f_p_f_imdl, MDLController *re
     bool match = false;
     Fact *f_imdl = ((MDLController *)controller_)->get_f_ihlp(bm, false);
     RequirementsPair r_p;
-    Fact *ground = NULL;
+    vector<BindingResult> bind_results;
     bool wr_enabled = false;
-    ChainingStatus c_s = ((MDLController *)controller_)->retrieve_imdl_fwd(bm, f_imdl, r_p, ground, req_controller, wr_enabled);
+    ChainingStatus c_s = ((MDLController *)controller_)->retrieve_imdl_fwd(bm, f_imdl, r_p, bind_results, req_controller, wr_enabled);
     f_imdl->get_reference(0)->code(I_HLP_WEAK_REQUIREMENT_ENABLED) = Atom::Boolean(wr_enabled);
 
     bool chaining_allowed = (c_s >= WEAK_REQUIREMENT_ENABLED);
     bool did_check_simulated_chaining = false;
     bool check_simulated_chaining_result;
-    vector<BindingResult> bind_results;
     switch (c_s) {
     case WEAK_REQUIREMENT_DISABLED:
     case STRONG_REQUIREMENT_NO_WEAK_REQUIREMENT: // silent monitoring of a prediction that will not be injected.
       if (is_simulation) { // if there is simulated imdl for the root of one sim in prediction, allow forward chaining.
 
+        bind_results.clear();
         check_simulated_chaining_result = check_simulated_chaining(bm, f_imdl, prediction, bind_results);
         did_check_simulated_chaining = true;
         if (check_simulated_chaining_result)
@@ -165,6 +165,7 @@ bool PrimaryMDLOverlay::reduce(_Fact *input, Fact *f_p_f_imdl, MDLController *re
       if (is_simulation) { // if there is simulated imdl for the root of one sim in prediction, allow forward chaining.
 
         if (!did_check_simulated_chaining) {
+          bind_results.clear();
           check_simulated_chaining_result = check_simulated_chaining(bm, f_imdl, prediction, bind_results);
           did_check_simulated_chaining = true;
         }
@@ -175,8 +176,8 @@ bool PrimaryMDLOverlay::reduce(_Fact *input, Fact *f_p_f_imdl, MDLController *re
       }
     case WEAK_REQUIREMENT_ENABLED:
       if (bind_results.size() == 0)
-        // check_simulated_chaining did not create any new bindings, so use the bm that we have been updating.
-        bind_results.push_back(BindingResult(bm, ground));
+        // retrieve_imdl_fwd doesn't add a result for status such as NO_REQUIREMENT, so use the bm that we created above.
+        bind_results.push_back(BindingResult(bm, NULL));
       for (size_t i = 0; i < bind_results.size(); ++i) {
         // evaluate_fwd_guards() uses bindings_, so set it to the binding map.
         bindings_ = bind_results[i].map_;
@@ -242,9 +243,9 @@ bool SecondaryMDLOverlay::reduce(_Fact *input, Fact *f_p_f_imdl, MDLController *
     bool match = false;
     Fact *f_imdl = ((MDLController *)controller_)->get_f_ihlp(bm, false);
     RequirementsPair r_p;
-    Fact *ground = f_p_f_imdl;
+    vector<BindingResult> bind_results;
     bool wr_enabled = false;
-    ChainingStatus c_s = ((MDLController *)controller_)->retrieve_imdl_fwd(bm, f_imdl, r_p, ground, req_controller, wr_enabled);
+    ChainingStatus c_s = ((MDLController *)controller_)->retrieve_imdl_fwd(bm, f_imdl, r_p, bind_results, req_controller, wr_enabled);
     f_imdl->get_reference(0)->code(I_HLP_WEAK_REQUIREMENT_ENABLED) = Atom::Boolean(wr_enabled);
     bool chaining_allowed = (c_s >= NO_REQUIREMENT);
     switch (c_s) {
@@ -257,10 +258,20 @@ bool SecondaryMDLOverlay::reduce(_Fact *input, Fact *f_p_f_imdl, MDLController *
         f_imdl->get_reference(0)->code(I_HLP_WEAK_REQUIREMENT_ENABLED) = Atom::Boolean(false);
     case STRONG_REQUIREMENT_DISABLED_WEAK_REQUIREMENT:
     case WEAK_REQUIREMENT_ENABLED:
-      if (evaluate_fwd_guards()) { // may update bindings.
-        f_imdl->set_reference(0, bm->bind_pattern(f_imdl->get_reference(0))); // valuate f_imdl from updated bm.
-        ((SecondaryMDLController *)controller_)->predict(bindings_, input, NULL, true, r_p, ground);
-        match = true;
+      if (bind_results.size() == 0)
+        // retrieve_imdl_fwd doesn't add a result for status such as NO_REQUIREMENT, so use the bm that we created above.
+        bind_results.push_back(BindingResult(bm, NULL));
+      for (size_t i = 0; i < bind_results.size(); ++i) {
+        // evaluate_fwd_guards() uses bindings_, so set it to the binding map.
+        bindings_ = bind_results[i].map_;
+        if (i > 0)
+          // During the previous iteration, evaluate_fwd_guards patched code_ in place, so restore.
+          load_code();
+        if (evaluate_fwd_guards()) { // may update bindings_ .
+          f_imdl->set_reference(0, bindings_->bind_pattern(f_imdl->get_reference(0))); // valuate f_imdl from updated binding map.
+          ((SecondaryMDLController*)controller_)->predict(bindings_, input, NULL, true, r_p, bind_results[i].ground_);
+          match = true;
+        }
       }
       break;
     }
@@ -846,12 +857,11 @@ ChainingStatus MDLController::retrieve_simulated_imdl_bwd(HLPBindingMap *bm, Fac
   }
 }
 
-ChainingStatus MDLController::retrieve_imdl_fwd(HLPBindingMap *bm, Fact *f_imdl, RequirementsPair &r_p, Fact *&ground, MDLController *req_controller, bool &wr_enabled) { // wr_enabled: true if there is at least one wr stronger than at least one sr.
+ChainingStatus MDLController::retrieve_imdl_fwd(const HLPBindingMap *bm, Fact *f_imdl, RequirementsPair &r_p, std::vector<BindingResult>& results, MDLController *req_controller, bool &wr_enabled) { // wr_enabled: true if there is at least one wr stronger than at least one sr.
 
   uint32 wr_count;
   uint32 sr_count;
   uint32 r_count = get_requirement_count(wr_count, sr_count);
-  ground = NULL;
   if (!r_count)
     return NO_REQUIREMENT;
   ChainingStatus r;
@@ -894,8 +904,7 @@ ChainingStatus MDLController::retrieve_imdl_fwd(HLPBindingMap *bm, Fact *f_imdl,
           if (r == WEAK_REQUIREMENT_DISABLED && (*e).chaining_was_allowed_) { // first match.
 
             r = WEAK_REQUIREMENT_ENABLED;
-            bm->load(&_original);
-            ground = (*e).evidence_;
+            results.push_back(BindingResult(new HLPBindingMap(_original), (*e).evidence_));
           }
 
           r_p.weak_requirements_.controllers.insert((*e).controller_);
@@ -1016,7 +1025,7 @@ ChainingStatus MDLController::retrieve_imdl_fwd(HLPBindingMap *bm, Fact *f_imdl,
               if (!strong_matches_weak || (*e).confidence_ > negative_cfd) {
 
                 r = WEAK_REQUIREMENT_ENABLED;
-                ground = (*e).evidence_;
+                results.push_back(BindingResult(new HLPBindingMap(_original), (*e).evidence_));
                 wr_enabled = strong_matches_weak;
               } else {
 

--- a/r_exec/mdl_controller.h
+++ b/r_exec/mdl_controller.h
@@ -288,7 +288,7 @@ public:
    * If f_p_f_imdl->get_pred()->is_simulation(), then this is for a simulation.
    */
   virtual void store_requirement(_Fact *f_p_f_imdl, MDLController *controller, bool chaining_was_allowed) = 0;
-  ChainingStatus retrieve_imdl_fwd(HLPBindingMap *bm, Fact *f_imdl, RequirementsPair &r_p, Fact *&ground, MDLController *req_controller, bool &wr_enabled); // checks the requirement instances during fwd; r_p: all wrs in first, all srs in second.
+  ChainingStatus retrieve_imdl_fwd(const HLPBindingMap *bm, Fact *f_imdl, RequirementsPair &r_p, std::vector<BindingResult>& results, MDLController *req_controller, bool &wr_enabled); // checks the requirement instances during fwd; r_p: all wrs in first, all srs in second.
   ChainingStatus retrieve_imdl_bwd(HLPBindingMap *bm, Fact *f_imdl, Fact *&ground, Fact *&strong_requirement_ground); // checks the requirement instances during bwd; ground is set to the best weak requirement if chaining allowed, NULL otherwise.
   ChainingStatus retrieve_simulated_imdl_fwd(const HLPBindingMap *bm, Fact *f_imdl, Sim* sim, std::vector<BindingResult>& results);
   ChainingStatus retrieve_simulated_imdl_bwd(HLPBindingMap *bm, Fact *f_imdl, Sim* prediction_sim, Fact *&ground, Fact *&strong_requirement_ground);


### PR DESCRIPTION
Pull request #186 updated `retrieve_simulated_imdl_fwd` to return multiple matches if there are multiple matching requirements. This allows `PrimaryMDLOverlay::reduce` to call `predict` once for each match. The reason we need this is explained in that pull request (in short, because there can be multiple ways to instantiate a model which make different valid predictions from the RHS). Similar arguments apply to the method `retrieve_imdl_fwd`, but at the time we didn't have a use case where there were multiple matching non-simulated requirements. Now we have a use case, so that we can implement the change to `retrieve_imdl_fwd` and test it (for instance, if there are two non-simulated requirements which allow grabbing a sphere or a cube, the grab model should predict both).

Similar to that pull request, this pull request has two commits. The first commit updates `retrieve_imdl_fwd` to return a list of matches using the helper class `BindingResult` which was already created for the first pull request. `PrimaryMDLOverlay::reduce` already loops through list of matches returned by `retrieve_simulated_imdl_fwd`, so we update the code to make sure it uses the same list for `retrieve_imdl_fwd`. In this commit, the functionality is the same.

The second commit updates `retrieve_imdl_fwd` to follow the same logic as `retrieve_simulated_imdl_fwd` to allow adding multiple matches (of weak requirements) to the returned results, by continuing to examine the entire list of requirements. In case there is a strong requirement, we make sure that the returned chaining status is `WEAK_REQUIREMENT_ENABLED` if one or more weak requirements have a higher confidence than the strong requirement.