### PR TITLE
Return NO_REQUIREMENT if only strong requirements but none match

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -607,7 +607,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(const HLPBindingMap *b
       }
 
       requirements_.CS_.leave();
-      return WEAK_REQUIREMENT_ENABLED;
+      return NO_REQUIREMENT;
     } else { // some strong req. and some weak req.: true if among the entries complying with timings and bindings, the youngest |f->imdl is weaker than the youngest f->imdl.
 
       r = WEAK_REQUIREMENT_DISABLED;
@@ -764,7 +764,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_bwd(HLPBindingMap *bm, Fac
       }
 
       requirements_.CS_.leave();
-      return WEAK_REQUIREMENT_ENABLED;
+      return NO_REQUIREMENT;
     } else { // some strong req. and some weak req.: true if among the entries complying with timings and bindings, the youngest |f->imdl is weaker than the youngest f->imdl.
 
       r = WEAK_REQUIREMENT_DISABLED;
@@ -923,7 +923,7 @@ ChainingStatus MDLController::retrieve_imdl_fwd(const HLPBindingMap *bm, Fact *f
 
     if (!wr_count) { // some strong req., no weak req.: true if there is no |f->imdl complying with timings and bindings.
 
-      r = WEAK_REQUIREMENT_ENABLED;
+      r = NO_REQUIREMENT;
       requirements_.CS_.enter();
       auto now = Now();
       r_code::list<RequirementEntry>::const_iterator e;
@@ -939,7 +939,7 @@ ChainingStatus MDLController::retrieve_imdl_fwd(const HLPBindingMap *bm, Fact *f
           HLPBindingMap _original(bm); // matching updates the binding map; always start afresh.
           if (_original.match_fwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE) { // tpl args will be valuated in bm.
 
-            if (r == WEAK_REQUIREMENT_ENABLED && (*e).chaining_was_allowed_) // first match.
+            if (r == NO_REQUIREMENT && (*e).chaining_was_allowed_) // first match.
               r = STRONG_REQUIREMENT_NO_WEAK_REQUIREMENT;
 
             r_p.strong_requirements_.controllers.insert((*e).controller_);
@@ -1131,7 +1131,7 @@ ChainingStatus MDLController::retrieve_imdl_bwd(HLPBindingMap *bm, Fact *f_imdl,
       }
 
       requirements_.CS_.leave();
-      return WEAK_REQUIREMENT_ENABLED;
+      return NO_REQUIREMENT;
     } else { // some strong req. and some weak req.: true if among the entries complying with timings and bindings, the youngest |f->imdl is weaker than the youngest f->imdl.
 
       r = WEAK_REQUIREMENT_DISABLED;

--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -2004,6 +2004,9 @@ void PrimaryMDLController::abduce(HLPBindingMap *bm, Fact *super_goal, bool oppo
       Fact *sim_ground;
       Fact *sim_strong_requirement_ground;
       ChainingStatus sim_c_s = retrieve_simulated_imdl_bwd(bm, f_imdl, sim, sim_ground, sim_strong_requirement_ground);
+      if (c_s == STRONG_REQUIREMENT_NO_WEAK_REQUIREMENT && sim_c_s == NO_REQUIREMENT)
+        // There is no simulated weak requirement to override the non-simulated strong requirement.
+        sim_c_s = STRONG_REQUIREMENT_NO_WEAK_REQUIREMENT;
       switch (sim_c_s) {
       case WEAK_REQUIREMENT_ENABLED:
         f_imdl->get_reference(0)->code(I_HLP_WEAK_REQUIREMENT_ENABLED) = Atom::Boolean(true);


### PR DESCRIPTION
Background: A model can have associated weak and strong requirement models. During forward or backward chaining, these can instantiate strong or weak requirements. If there is a matching weak requirement, then the model can be instantiated, but if there is also a matching strong requirement then this prevents it being instantiated. ("Being instantiated" means that if there is a matching LHS then the model can fire.) The method `retrieve_imdl_fwd` examines the weak and strong requirements which are attached to a model and returns the "chaining status" which can be [one of the following](https://github.com/IIIM-IS/AERA/blob/75db7506a489bd57727e5cbdfa820c6d99624d95/r_exec/hlp_controller.h#L90-L94):

    WEAK_REQUIREMENT_DISABLED
    STRONG_REQUIREMENT_NO_WEAK_REQUIREMENT
    STRONG_REQUIREMENT_DISABLED_WEAK_REQUIREMENT
    WEAK_REQUIREMENT_ENABLED
    NO_REQUIREMENT

These have ascending value for allowing the model to be instantiated. Only the last two (`WEAK_REQUIREMENT_ENABLED` and `NO_REQUIREMENT`) allow the model to be instantiated. The others give reasons why the model can't be instantiated. The "normal" case is `WEAK_REQUIREMENT_ENABLED` where a model only has an associated weak requirement model and there is a matching weak requirement so that the model can be instantiated. (If there is no matching weak requirement model then the status is `WEAK_REQUIREMENT_DISABLED` and the model is not instantiated). An interesting case is where there are no associated weak or strong requirement models (which is the case for most requirement models themselves). In this case the chaining status is `NO_REQUIREMENT` and the firing of the model only depends on a matching LHS.

Another interesting case is if the model only has associated strong requirement models but no weak requirement models. If there is a matching strong requirement, then obviously the model should not be instantiated and the chaining status is `STRONG_REQUIREMENT_NO_WEAK_REQUIREMENT`. But what if there are no matching strong requirements? In this case, the model should be instantiated and the chaining status is currently set to `WEAK_REQUIREMENT_ENABLED`. The problem is that there are no weak requirements. In this case it seems that the chaining status should be the same as the other case where there are no associated weak requirement models, which is `NO_REQUIREMENT`.

This pull request has two commits. The first commit updates `retrieve_imdl_fwd` (and the other related methods) to return a chaining status of `NO_REQUIREMENT` if the model only has associated strong requirement models but there are no matching strong requirements. As with the previously-used chaining status of `WEAK_REQUIREMENT_ENABLED`, this allows the model to be instantiated.

(Note: There is a technical question which must be addressed: An `imdl` has a parameter called `wr_enabled` for "weak requirement enabled". Some parts of the code set this based on the chaining status, [for example](https://github.com/IIIM-IS/AERA/blob/5715539d0337d2dd4944415f35f7f4c8f8c21dbc/r_exec/mdl_controller.cpp):

    case WEAK_REQUIREMENT_ENABLED:
      f_imdl->get_reference(0)->code(I_HLP_WEAK_REQUIREMENT_ENABLED) = Atom::Boolean(true);

What is `wr_enabled` and how is it used? [One comment](https://github.com/IIIM-IS/AERA/blob/5715539d0337d2dd4944415f35f7f4c8f8c21dbc/r_exec/mdl_controller.cpp#L860) from the original code says "wr_enabled: true if there is at least one weak requirement stronger than at least one strong requirement". Clearly, if there are no attached weak requirement models then `wr_enabled` doesn't need to be true. So it's OK for the chaining status to be `NO_REQUIREMENT` in this case.)

The second commit clarifies another case relating non-simulated and simulated requirements when there are only associated strong requirement models. In this case `retrieve_imdl_bwd` returns `STRONG_REQUIREMENT_NO_WEAK_REQUIREMENT` meaning that there is a matching strong requirement (and the model should not be instantiated). But the model controller continues to call `retrieve_simulated_imdl_bwd` to check for simulated strong requirements. When there are no matching simulated strong requirements this returns `NO_REQUIREMENT` as explained above. This alone would allow the model to be instantiated, but the matching strong requirement should prevent being instantiated. This commit updates the logic in this case so that the chaining status remains `STRONG_REQUIREMENT_NO_WEAK_REQUIREMENT` and the model is not instantiated.