### PR TITLE
In reduce, copy f_imdl before calling predict

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -186,8 +186,10 @@ bool PrimaryMDLOverlay::reduce(_Fact *input, Fact *f_p_f_imdl, MDLController *re
           load_code();
         if (evaluate_fwd_guards()) { // may update bindings_ .
           // Valuate f_imdl from updated binding map.
-          f_imdl->set_reference(0, bindings_->bind_pattern(f_imdl->get_reference(0)));
-          ((PrimaryMDLController *)controller_)->predict(bindings_, input, f_imdl, chaining_allowed, r_p, bind_results[i].ground_);
+          P<Fact> f_imdl_copy = new Fact(
+            bindings_->bind_pattern(f_imdl->get_reference(0)), f_imdl->get_after(), f_imdl->get_before(),
+            f_imdl->get_cfd(), f_imdl->get_psln_thr());
+          ((PrimaryMDLController*)controller_)->predict(bindings_, input, f_imdl_copy, chaining_allowed, r_p, bind_results[i].ground_);
           match = true;
         }
       }


### PR DESCRIPTION
The pull request resolves issue #245. See that for background. As expected, the information of grabbing the cube (not the sphere) wasn't being carried through to PTPX. This information is created by the controller for the grab model which[ calls predict](https://github.com/IIIM-IS/AERA/blob/c2e737a87b45bf24cd37ad145781eb8bdd3253e4/r_exec/mdl_controller.cpp#L190) twice in a loop, to predict grabbing the cube on the first iteration and to predict grabbing the sphere on the second iteration. The problem is that the code [reuses one copy](https://github.com/IIIM-IS/AERA/blob/c2e737a87b45bf24cd37ad145781eb8bdd3253e4/r_exec/mdl_controller.cpp#L189) of `f_imdl`, so that on the second iteration the `imdl` with the information for the cube is replaced by the information for the sphere. The solution is to not reuse the `f_imdl`.

This pull request updates the loop to make a fresh copy of the `f_imdl` on each iteration so that the inner `imdl` is not replaced. (This is similar to what is [already done in check_simulated_imdl](https://github.com/IIIM-IS/AERA/blob/c2e737a87b45bf24cd37ad145781eb8bdd3253e4/r_exec/mdl_controller.cpp#L2395-L2397) to make a copy of the `f_imdl`.) Now, the second model made by PTPX predicts the failure of grabbing the cube, as desired:

    mdl_1441:(mdl [] []
       (fact (icst cst_1439 [] [Hand: Cube: P: Sphere:]) T0: T1:)
       (|fact (imdl mdl_252 [[] T0: T1:] [Hand: Cube: v7: v8:]) T0: T1:))
