### PR TITLE
Added support of sending entities to AERA

### DIFF
--- a/AERA/IODevices/TCP/Proto/tcp_data_message.pb.cc
+++ b/AERA/IODevices/TCP/Proto/tcp_data_message.pb.cc
@@ -332,19 +332,19 @@ const char descriptor_table_protodef_tcp_5fdata_5fmessage_2eproto[] PROTOBUF_SEC
   "\0227\n\013description\030\001 \001(\0132\".tcp_io_device.Va"
   "riableDescription\022\014\n\004name\030\002 \001(\t\"P\n\013DataM"
   "essage\022/\n\tvariables\030\001 \003(\0132\034.tcp_io_devic"
-  "e.ProtoVariable\022\020\n\010timeSpan\030\002 \001(\004\"\312\001\n\023Va"
+  "e.ProtoVariable\022\020\n\010timeSpan\030\002 \001(\004\"\340\001\n\023Va"
   "riableDescription\022\020\n\010entityID\030\001 \001(\005\022\n\n\002I"
   "D\030\002 \001(\005\022=\n\010dataType\030\003 \001(\0162+.tcp_io_devic"
   "e.VariableDescription.DataType\022\022\n\ndimens"
-  "ions\030\004 \003(\004\"B\n\010DataType\022\n\n\006DOUBLE\020\000\022\t\n\005IN"
-  "T64\020\003\022\010\n\004BOOL\020\014\022\n\n\006STRING\020\r\022\t\n\005BYTES\020\016\"S"
-  "\n\rProtoVariable\0224\n\010metaData\030\001 \001(\0132\".tcp_"
-  "io_device.VariableDescription\022\014\n\004data\030\002 "
-  "\001(\014b\006proto3"
+  "ions\030\004 \003(\004\"X\n\010DataType\022\n\n\006DOUBLE\020\000\022\t\n\005IN"
+  "T64\020\003\022\010\n\004BOOL\020\014\022\n\n\006STRING\020\r\022\t\n\005BYTES\020\016\022\024"
+  "\n\020COMMUNICATION_ID\020\017\"S\n\rProtoVariable\0224\n"
+  "\010metaData\030\001 \001(\0132\".tcp_io_device.Variable"
+  "Description\022\014\n\004data\030\002 \001(\014b\006proto3"
   ;
 static ::_pbi::once_flag descriptor_table_tcp_5fdata_5fmessage_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_tcp_5fdata_5fmessage_2eproto = {
-    false, false, 1331, descriptor_table_protodef_tcp_5fdata_5fmessage_2eproto,
+    false, false, 1353, descriptor_table_protodef_tcp_5fdata_5fmessage_2eproto,
     "tcp_data_message.proto",
     &descriptor_table_tcp_5fdata_5fmessage_2eproto_once, nullptr, 0, 11,
     schemas, file_default_instances, TableStruct_tcp_5fdata_5fmessage_2eproto::offsets,
@@ -394,6 +394,7 @@ bool VariableDescription_DataType_IsValid(int value) {
     case 12:
     case 13:
     case 14:
+    case 15:
       return true;
     default:
       return false;
@@ -406,6 +407,7 @@ constexpr VariableDescription_DataType VariableDescription::INT64;
 constexpr VariableDescription_DataType VariableDescription::BOOL;
 constexpr VariableDescription_DataType VariableDescription::STRING;
 constexpr VariableDescription_DataType VariableDescription::BYTES;
+constexpr VariableDescription_DataType VariableDescription::COMMUNICATION_ID;
 constexpr VariableDescription_DataType VariableDescription::DataType_MIN;
 constexpr VariableDescription_DataType VariableDescription::DataType_MAX;
 constexpr int VariableDescription::DataType_ARRAYSIZE;

--- a/AERA/IODevices/TCP/Proto/tcp_data_message.pb.h
+++ b/AERA/IODevices/TCP/Proto/tcp_data_message.pb.h
@@ -132,12 +132,13 @@ enum VariableDescription_DataType : int {
   VariableDescription_DataType_BOOL = 12,
   VariableDescription_DataType_STRING = 13,
   VariableDescription_DataType_BYTES = 14,
+  VariableDescription_DataType_COMMUNICATION_ID = 15,
   VariableDescription_DataType_VariableDescription_DataType_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::min(),
   VariableDescription_DataType_VariableDescription_DataType_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::max()
 };
 bool VariableDescription_DataType_IsValid(int value);
 constexpr VariableDescription_DataType VariableDescription_DataType_DataType_MIN = VariableDescription_DataType_DOUBLE;
-constexpr VariableDescription_DataType VariableDescription_DataType_DataType_MAX = VariableDescription_DataType_BYTES;
+constexpr VariableDescription_DataType VariableDescription_DataType_DataType_MAX = VariableDescription_DataType_COMMUNICATION_ID;
 constexpr int VariableDescription_DataType_DataType_ARRAYSIZE = VariableDescription_DataType_DataType_MAX + 1;
 
 const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* VariableDescription_DataType_descriptor();
@@ -1495,6 +1496,8 @@ class VariableDescription final :
     VariableDescription_DataType_STRING;
   static constexpr DataType BYTES =
     VariableDescription_DataType_BYTES;
+  static constexpr DataType COMMUNICATION_ID =
+    VariableDescription_DataType_COMMUNICATION_ID;
   static inline bool DataType_IsValid(int value) {
     return VariableDescription_DataType_IsValid(value);
   }

--- a/AERA/IODevices/TCP/Proto/tcp_data_message.proto
+++ b/AERA/IODevices/TCP/Proto/tcp_data_message.proto
@@ -63,6 +63,7 @@ message VariableDescription {
         BOOL = 12;
         STRING = 13;
         BYTES = 14;
+        COMMUNICATION_ID = 15; // Handled the same as a INT64, but provides information that the sent int is an ID (e.g. to send "holding s").
     }
 
     int32 entityID = 1;

--- a/AERA/IODevices/TCP/Proto/utils.h
+++ b/AERA/IODevices/TCP/Proto/utils.h
@@ -193,6 +193,7 @@ namespace tcp_io_device {
       return meta_data_;
     }
 
+    std::string _data() { return data_; }
 
     /**
     * Casts the data from the byte representation stored as a string to the template type.
@@ -200,9 +201,9 @@ namespace tcp_io_device {
     template <typename T> std::vector<T> getData() {
       T a;
       std::vector<T> values;
-      for (int i = 0; i < meta_data_.data_size_; i += meta_data_.type_size_) {
+      for (int i = 0; i < meta_data_.data_size_; i += sizeof(T)) {
         char* pos = &data_[i];
-        memcpy(&a, pos, meta_data_.type_size_);
+        memcpy(&a, pos, sizeof(T));
         values.push_back(a);
       }
       return values;

--- a/AERA/IODevices/TCP/Proto/utils.h
+++ b/AERA/IODevices/TCP/Proto/utils.h
@@ -142,6 +142,9 @@ namespace tcp_io_device {
       case 3:
         type_size_ = 8;
         break;
+      case 15:
+        type_size_ = 8;
+        break;
       default:
         type_size_ = 1;
         break;

--- a/AERA/IODevices/TCP/tcp_io_device.cpp
+++ b/AERA/IODevices/TCP/tcp_io_device.cpp
@@ -324,8 +324,11 @@ namespace tcp_io_device {
     }
     case VariableDescription_DataType_STRING:
     {
-      // TODO: Using the .asIndex() function this can be done
+      // TODO: Using the .asIndex() function this can be done (See the Utils::GetString())
       cout << "> WARNING: String type not implemented, yet" << endl;
+      break;
+      // std::string data = cmd->code(args_set_index + 2).String(0);
+      // var->set_data(data);
     }
     }
     return msg;

--- a/AERA/IODevices/TCP/tcp_io_device.cpp
+++ b/AERA/IODevices/TCP/tcp_io_device.cpp
@@ -436,7 +436,35 @@ namespace tcp_io_device {
 
       auto entity = entities_[id_mapping_[var.getMetaData().getEntityID()]];
       auto obj = objects_[id_mapping_[var.getMetaData().getID()]];
-      Atom val = Atom::Float(var.getData<double>()[0]);
+      
+      Atom val = Atom();
+      if (var.getMetaData().getType() == VariableDescription_DataType_DOUBLE)
+      {
+        val = Atom::Float(var.getData<double>()[0]);
+      }
+      else if (var.getMetaData().getType() == VariableDescription_DataType_INT64){
+        val = Atom::Float(var.getData<int64_t>()[0]);
+      }
+      else if (var.getMetaData().getType() == VariableDescription_DataType_COMMUNICATION_ID) {
+        int64_t val = var.getData<int64_t>()[0];
+        std::vector<r_code::Code*> value;
+        if (val != -1) {
+          if (id_mapping_.find(val) == id_mapping_.end())
+          {
+            std::cout << "WARNING: Received message with unknown Communication ID" << std::endl;
+            continue;
+          }
+          std::string object_entity = id_mapping_[val];
+          if (entities_.find(object_entity) == entities_.end())
+          {
+            std::cout << "WARNING: Received message with uninitalized entity, this should never happen!" << std::endl;
+            continue;
+          }
+          value.push_back(entities_[object_entity]);
+        }
+        inject_marker_value_from_io_device(entity, obj, value, now, now + get_sampling_period(), r_exec::View::SYNC_PERIODIC, get_stdin());
+        continue;
+      }
       if (id_mapping_[var.getMetaData().getID()] == "velocity_y") {
         inject_marker_value_from_io_device(entity, obj, val, now, now + get_sampling_period(), r_exec::View::SYNC_HOLD, get_stdin());
       }


### PR DESCRIPTION
Added a COMMUNICATION_ID message type to the protobuf messages and a handler that injects entities with the sent communication id into AERA accordingly.

Tested by sending "h holding ..." to AERA with cube, sphere, and "nothing". The casting of bitstreams to the according communication id and transforming to AERA internal OIDs works in the given cases.