### PR TITLE
Implement time interval (ti after before)

### DIFF
--- a/AERA/replicode_v1.2/std.replicode
+++ b/AERA/replicode_v1.2/std.replicode
@@ -44,6 +44,9 @@
 !def SIM_OPTIONAL 1
 !def SIM_MANDATORY 2
 
+; A time interval to use as a template parameter, etc. Matching two ti objects is flexible.
+!class (ti after:ts before:ts)
+
 ; mapping high-level objects -> r-code.
 !class (mk.val (_obj {obj: attr:ont val:}))
 !class (mk.act (_obj {actr:ent cmd:cmd}))

--- a/r_exec/binding_map.h
+++ b/r_exec/binding_map.h
@@ -400,7 +400,16 @@ private:
   void build_ihlp_structure(
     const r_code::Code* hlp, uint16 hlp_structure_index, r_code::Code* ihlp, uint16& extent_index) const;
 
-  void init_from_ihlp_args(const r_code::Code* ihlp);
+  /**
+   * Scan the structure in hlp at hlp_args_index and for each VL_PTR set the binding map to a subclass of
+   * BoundValue based on the value in ihlp at ihlp_args_index.
+   * \param hlp The HLP with the code to scan.
+   * \param hlp_args_index The index in hlp of the structure to scan.
+   * \param ihlp The ihlp to init the binding map from.
+   * \param ihlp_args_index The index in ihlp of the equivalent structure as in hlp.
+   */
+  void init_from_ihlp_args(
+    const r_code::Code* hlp, uint16 hlp_args_index, const r_code::Code* ihlp, uint16 ihlp_args_index);
 public:
   HLPBindingMap();
   HLPBindingMap(const HLPBindingMap *source);

--- a/r_exec/init.cpp
+++ b/r_exec/init.cpp
@@ -375,6 +375,8 @@ bool InitOpcodes(const r_comp::Metadata& metadata) {
   Opcodes::PgmView = _Opcodes.find("pgm_view")->second;
   Opcodes::GrpView = _Opcodes.find("grp_view")->second;
 
+  Opcodes::TI = _Opcodes.find("ti")->second;
+
   Opcodes::Ent = _Opcodes.find("ent")->second;
   Opcodes::Ont = _Opcodes.find("ont")->second;
   Opcodes::MkVal = _Opcodes.find("mk.val")->second;

--- a/r_exec/mdl_controller.h
+++ b/r_exec/mdl_controller.h
@@ -313,13 +313,14 @@ public:
    * \param imdl The imdl object.
    * \param after Set this to the after timestamp (if this returns true).
    * \param before Set this to the before timestamp (if this returns true).
+   * \param allow_ti If true, allow the last template value to be a (ti After: Before:). If omitted, use true.
    * \param (optional) after_ts_index If not NULL, set this to the index in imdl Code array of the after time stamp structure.
    * \param (optional)  before_ts_index If not NULL, set this to the index in imdl Code array of the before time stamp structure.
    * \return True for success, otherwise false if there are not enough template parameters,
    * or if the value is some type other than a timestamp (such as an unbound variable).
    */
   static bool get_imdl_template_timings(
-    r_code::Code* imdl, Timestamp& after, Timestamp& before, uint16* after_ts_index = NULL, uint16* before_ts_index = NULL);
+    r_code::Code* imdl, Timestamp& after, Timestamp& before, bool allow_ti = true, uint16* after_ts_index = NULL, uint16* before_ts_index = NULL);
 };
 
 class PMDLController :

--- a/r_exec/opcodes.cpp
+++ b/r_exec/opcodes.cpp
@@ -91,6 +91,8 @@ uint16 Opcodes::View;
 uint16 Opcodes::PgmView;
 uint16 Opcodes::GrpView;
 
+uint16 Opcodes::TI;
+
 uint16 Opcodes::Ent;
 uint16 Opcodes::Ont;
 uint16 Opcodes::MkVal;

--- a/r_exec/opcodes.h
+++ b/r_exec/opcodes.h
@@ -101,6 +101,8 @@ public:
   static uint16 PgmView;
   static uint16 GrpView;
 
+  static uint16 TI;
+
   static uint16 Ent;
   static uint16 Ont;
   static uint16 MkVal;


### PR DESCRIPTION
This pull request resolves #137 by adding support for time intervals as `(ti after before)` with "smart matching" for intersecting time intervals. It also resolves #251 because the "smart matching" updates ti value in the imdl which remains when the imdl is injected.

This pull request has six commits. The first commit changes `init_from_ihlp_args` which assigns variables in the binding map to template args from an ihlp (an imdl or icst). The current implementation gets the size of the template args and just assumes that the variables are in sequence starting from `v0`. For example `(imdl M2 [h s 100ms 200ms] ...)` has four template args for model `M2` which is:

    M2:(mdl [v0: v1: v2: v3:]
       ...

Therefore, the current implementation just assumes that the template args in the imdl should be assigned to variables `v0`, `v1`, `v2` and `v3` (without looking at the mdl). This commit changes `init_from_ihlp_args` to actually scan the template args of the mdl or cst to get the variable assignments. This commit doesn't change functionality, but scanning the mdl or cst will be useful later if it has structures like `(ti v2: v3:)`.

The second commit updates std.replicode to add the class `(ti after before)` as explained in issue #137. We also update the C++ code to get the assigned opcode so that it can recognize when a value is a time interval. This commit doesn't change functionality.

The third commit updates `BindingMap` methods to allow recursing into a structure like `(ti after before)` in template args when building an ihlp or assigning variables from one. For example this updates `init_from_ihlp_args` to support an imdl like `(imdl M2 [h s (ti 100ms 200ms)] ...)` so that `100ms` and `200ms` will be assigned to variables `v2` and `v3` which are found in the model:

    M2:(mdl [v0: v1: (ti v2: v3:)]
       ...

If existing code doesn't use structures in the template args, then this commit doesn't change functionality.

In the fourth commit, we update the utility methods `get_template_timings` and `get_imdl_template_timings` to check if the template args ends in a `(ti after before)` structure and to get the timings from it.

The fifth commit changes the model builder to use `ti` for the last two template args.

Finally, the sixth commit updates `build_ihlp_structure` so that, when building an imdl, from a model we leave the args of the `ti` as variables so that they can be narrowed during "smart match". And we update `match_structure` to recognize the `ti` and to do a "smart match" of the time intervals.

NOTE: When we update all seed models to use `ti`, we can remove the temporary fix introduced in pull request #136 (two years ago!). That added `TemplateTimingsUpdater` which forces two imdls to have the same template timing args so that `Match` will succeed. This is not needed anymore since `Match` does "smart matching" of template args in a `ti` value.