### PR TITLE
Changed vcpkg configuration to use correct dlls in debug

### DIFF
--- a/AERA/AERA.vcxproj
+++ b/AERA/AERA.vcxproj
@@ -69,6 +69,9 @@
     <IntDir>$(Configuration)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <VcpkgConfiguration>Debug</VcpkgConfiguration>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>


### PR DESCRIPTION
Finally found the setting to change the vcpkg configuration to use debug dlls instead of release. It works on my machine after "Clean Solution" and "Rebuild Solution". Can you confirm this?