### PR TITLE
Added method for multi-dimensional marker values

### DIFF
--- a/r_exec/mem.cpp
+++ b/r_exec/mem.cpp
@@ -837,6 +837,33 @@ View* _Mem::inject_marker_value_from_io_device(
 }
 
 View* _Mem::inject_marker_value_from_io_device(
+  Code* obj, Code* prop, std::vector<Atom> val, Timestamp after, Timestamp before,
+  View::SyncMode sync_mode, Code* group)
+{
+  if (!obj || !prop)
+    // We don't expect this, but sanity check.
+    return NULL;
+
+  Code* object = new LObject(this);
+  uint16 extent_index = 4;
+  object->code(0) = Atom::Marker(GetOpcode("mk.val"), 4); // Caveat: arity does not include the opcode.
+  object->code(1) = Atom::RPointer(0); // obj
+  object->code(2) = Atom::RPointer(1); // prop
+  object->code(3) = Atom::IPointer(++extent_index);
+  object->code(4) = Atom::Float(1); // psln_thr.
+
+
+  object->set_reference(0, obj);
+  object->set_reference(1, prop);
+  object->code(extent_index) = Atom::Set(val.size());
+  for (uint16 i = 0; i < val.size(); ++i) {
+    object->code(++extent_index) = val[i];
+  }
+
+  return inject_fact_from_io_device(object, after, before, sync_mode, group);
+}
+
+View* _Mem::inject_marker_value_from_io_device(
   Code* obj, Code* prop, Code* val, Timestamp after, Timestamp before,
   View::SyncMode sync_mode, Code* group)
 {

--- a/r_exec/mem.h
+++ b/r_exec/mem.h
@@ -335,6 +335,25 @@ public:
 
   /**
    * Inject (fact (mk.val obj prop val 1) after before 1 1)
+   * [sync_mode after 1 1 group nil]
+   * where val is a set of Atoms.
+   * This is called from the I/O device to call the normal inject(view), then
+   * log the injection event.
+   * \param obj The object for the mk.val.
+   * \param prop The property for the mk.val.
+   * \param val The Atom value for the mk.val, such as Atom::Float(1).
+   * \param after The start of the fact time interval.
+   * \param before The end of the fact time interval.
+   * \param sync_mode The view sync mode, such as View::SYNC_PERIODIC.
+   * \param group The group of the view, such as get_stdin().
+   * \return The created View.
+   */
+  View* _Mem::inject_marker_value_from_io_device(
+    Code* obj, Code* prop, std::vector<Atom> val, Timestamp after, Timestamp before,
+    View::SyncMode sync_mode, Code* group);
+
+  /**
+   * Inject (fact (mk.val obj prop val 1) after before 1 1)
    * [sync_mode after 1 1 stdin nil]
    * where val is a simple Atom.
    * This is called from the I/O device to call the normal inject(view), then


### PR DESCRIPTION
Added a new inject_marker_value_from_io_device method that takes a vector of Atoms and injects them as a single marker value into AERA. Attempts to solve issue #254 