### PR TITLE
StructureValue: recursive copy of sub-structures

### DIFF
--- a/r_exec/binding_map.cpp
+++ b/r_exec/binding_map.cpp
@@ -248,6 +248,12 @@ void StructureValue::copy_structure(
   extent_index += (1 + atom_count);
   for (uint16 i = 0; i <= atom_count; ++i) {
     Atom a = source[source_index + i];
+    if (a.getDescriptor() == Atom::I_PTR) {
+      // Write an I_PTR and recurse to copy the the sub-structure.
+      destination->code(extent_start + i) = Atom::IPointer(extent_index);
+      copy_structure(destination, extent_index, source, a.asIndex());
+      continue;
+    }
     destination->code(extent_start + i) = a;
   }
 }


### PR DESCRIPTION
Background: A binding map stores values in subclasses of `BoundValue`. The `StructureValue` is used to store the bound value of a structured object such as `(vec3 1 2 3)`. The `copy_structure` method of `StructureValue` copies the code of a structure into and out of an AERA object such as `(mk.val h postition (vec3 1 2 3))` .

We want to support a bound value of a "nested" structure object such as `(vec [1 2 3])`, where the `(vec :)` is the top structure and the array `[1 2 3]` is the sub structure. This pull request updates `copy_structure` to check if part of the structure is an I_PTR which points to a sub structure. If so, then it calls itself recursively to copy the sub structure (and any further sub-structures). There is no change of behavior for existing AERA examples where no bound structured objects have sub-structures.