### PR TITLE
HLPBindingMap: In init_from_hlp, add packed_hlp and use it to get vars

### DIFF
--- a/r_exec/binding_map.cpp
+++ b/r_exec/binding_map.cpp
@@ -1015,10 +1015,12 @@ void HLPBindingMap::init_from_hlp(const Code* hlp, const Code* packed_hlp) { // 
   if (obj_count >= 2)
     init_timing_indexes(hlp->get_reference(hlp->code(obj_set_index + 2).asIndex()),
       bwd_after_index_, bwd_before_index_);
-  for (uint16 i = 1; i <= obj_count; ++i) {
 
-    _Fact *pattern = (_Fact *)hlp->get_reference(hlp->code(obj_set_index + i).asIndex());
-    init_from_pattern(pattern);
+  // Use the packed hlp without recursion which has exactly the vars we need for the binding map.
+  for (uint16 i = 1; i < packed_hlp->code_size(); ++i) {
+    Atom s = packed_hlp->code(i);
+    if (s.getDescriptor() == Atom::VL_PTR)
+      add_unbound_value(s.asIndex());
   }
 }
 

--- a/r_exec/binding_map.cpp
+++ b/r_exec/binding_map.cpp
@@ -975,19 +975,6 @@ void HLPBindingMap::load(const HLPBindingMap *source) {
   *this = *source;
 }
 
-void HLPBindingMap::init_from_pattern(const Code *source) { // source is abstracted.
-
-  for (uint16 i = 1; i < source->code_size(); ++i) {
-
-    Atom s = source->code(i);
-    if (s.getDescriptor() == Atom::VL_PTR)
-      add_unbound_value(s.asIndex());
-  }
-
-  for (uint16 i = 0; i < source->references_size(); ++i)
-    init_from_pattern(source->get_reference(i));
-}
-
 void HLPBindingMap::add_unbound_values(const Code* hlp, uint16 structure_index) {
   uint16 arg_count = hlp->code(structure_index).getAtomCount();
   for (uint16 i = 1; i <= arg_count; ++i) {

--- a/r_exec/binding_map.h
+++ b/r_exec/binding_map.h
@@ -412,8 +412,6 @@ private:
       before_index = source->code(FACT_BEFORE).asIndex();
   }
 
-  void init_from_pattern(const r_code::Code *source);
-
   /**
    * Scan the structure in hlp at structure_index and call add_unbound_value for each VL_PTR.
    * \param hlp The HLP with the code.


### PR DESCRIPTION
Background: When a new cst or model is injected, a controller is created for it. The controller has a "binding map template" which is simply a binding map with the same number of variables as the cst or model. The controller's binding map template is set up by `HLPBindingMap::init_from_hlp` which scans the code of the cst or model looking for variables. Consider this cst (simplified):

    (cst [] []
       (fact (mk.val v0: holding []) v1: v2:)
       (fact (icst cst_same_pos [] [v0: v3: v4: sphere]) v1: v2:))

It has variables `v0` through `v4` so the binding map template should have these five variables.

More background: A cst or mdl has a "packed" and "unpacked" version. The packed version has all the code in one array similar to the example shown above. There can be external references such as `cst_same_pos`, but the relevant code is all together. This is used for evaluating guards, etc. The unpacked version is much smaller and has external references to each of the components, such as the two facts in the example above. This is used, for example, to match with an input fact during forward or backward chaining.

Currently, `HLPBindingMap::init_from_hlp` scans the unpacked version. This means that it uses `init_from_pattern` to [recurse into every reference](https://github.com/IIIM-IS/AERA/blob/63387fc52b02e421d518dd666ef9feffdb8648a5/r_exec/binding_map.cpp#L984C1-L985), scanning for variables. Normally, this works OK but in this case it recurses into `cst_same_pos` which has variables `v0` through `v5` . (This happens because the constant `sphere` is used instead of a variable `v5`.) Therefore, the controller's binding map template is set up incorrectly.

This pull request updates `HLPBindingMap::init_from_hlp` to take the parameter `packed_hlp` and use the packed version to scan for variables. In this case, it does not need to recurse into referenced objects so we can remove the unused recursive method `init_from_pattern`. Since the packed version has exactly the needed variables, the controller's binding map template is correct.