### PR TITLE
Fix bug in CounterEvidence call to MatchStructure

### DIFF
--- a/r_exec/factory.cpp
+++ b/r_exec/factory.cpp
@@ -417,7 +417,7 @@ bool _Fact::CounterEvidence(const Code *lhs, const Code *rhs) {
       case Atom::R_PTR:
         return !MatchObject(lhs->get_reference(lhs->code(MK_VAL_VALUE).asIndex()), rhs->get_reference(rhs->code(MK_VAL_VALUE).asIndex()));
       case Atom::I_PTR:
-        return !MatchStructure(lhs, MK_VAL_VALUE, lhs_atom.asIndex(), rhs, rhs_atom.asIndex(), false);
+        return !MatchStructure(lhs, lhs_atom.asIndex(), 0, rhs, rhs_atom.asIndex(), false);
       default:
         return !MatchAtom(lhs_atom, rhs_atom);
       }


### PR DESCRIPTION
Background: The method [`MatchStructure`](https://github.com/IIIM-IS/AERA/blob/c8935633a635a740844b12cfe42652b8fb0f4193/r_exec/factory.cpp#L349) has a parameter `lhs_base_index` which is passed on to the [call to `Match`](https://github.com/IIIM-IS/AERA/blob/c8935633a635a740844b12cfe42652b8fb0f4193/r_exec/factory.cpp#L361) which scans the structure by incrementing `lhs_index`. If `Match` comes across an I_PTR, then it recursively [calls `MatchStructure`](https://github.com/IIIM-IS/AERA/blob/c8935633a635a740844b12cfe42652b8fb0f4193/r_exec/factory.cpp#L294) where the `lhs_base_index` is the position of the new structure, and where 0 is again passed for `lhs_index`.

`MatchStructure` is also [called from `CounterEvidence`](https://github.com/IIIM-IS/AERA/blob/c8935633a635a740844b12cfe42652b8fb0f4193/r_exec/factory.cpp#L420), but it is called incorrectly. It correctly uses `lhs_atom.asIndex()` as the position of the structure, but it should not pass `MK_VAL_VALUE` because `MatchStructure` adds the two together to get the wrong code position. This is a bug that can cause an out-of-bounds error which we have seen sometimes. (It doesn't occur often because it only happens when comparing mk.val where the value is a structure, like `(mk.val h holding [s])` . If the value is a float then this part of the code isn't used.)

This pull request fixes `CounterEvidence` to call `MatchStructure` in the same way that `Match` does, as described above. This fixes the out-of-bounds error.