### PR TITLE
BindingMap: Fix bug in abstract_f_ihlp template args

### DIFF
--- a/r_exec/binding_map.cpp
+++ b/r_exec/binding_map.cpp
@@ -365,7 +365,7 @@ bool ObjectValue::contains(const Code *o) const {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-_Fact *BindingMap::abstract_f_ihlp(const _Fact *f_ihlp) const { // bindings are set already (coming from a mk.rdx caught by auto-focus).
+_Fact *BindingMap::abstract_f_ihlp(const _Fact *f_ihlp) { // bindings are set already (coming from a mk.rdx caught by auto-focus).
 
   uint16 opcode;
   Code *ihlp = f_ihlp->get_reference(0);
@@ -392,7 +392,7 @@ _Fact *BindingMap::abstract_f_ihlp(const _Fact *f_ihlp) const { // bindings are 
   _ihlp->code(extent_index) = Atom::Set(tpl_arg_count);
   for (uint16 i = 1; i <= tpl_arg_count; ++i)
     _ihlp->code(extent_index + i) = Atom::VLPointer(map_index++);
-  extent_index += tpl_arg_count;
+  extent_index += 1 + tpl_arg_count;
 
   uint16 arg_set_index = ihlp->code(I_HLP_EXPOSED_ARGS).asIndex();
   uint16 arg_count = ihlp->code(arg_set_index).getAtomCount();
@@ -401,6 +401,7 @@ _Fact *BindingMap::abstract_f_ihlp(const _Fact *f_ihlp) const { // bindings are 
   for (uint16 i = 1; i <= arg_count; ++i)
     _ihlp->code(extent_index + i) = Atom::VLPointer(map_index++);
 
+  _ihlp->code(I_HLP_WEAK_REQUIREMENT_ENABLED) = ihlp->code(I_HLP_WEAK_REQUIREMENT_ENABLED);
   _ihlp->code(I_HLP_ARITY) = ihlp->code(I_HLP_ARITY);
 
   _ihlp->add_reference(ihlp->get_reference(ihlp->code(I_HLP_OBJ).asIndex()));

--- a/r_exec/binding_map.h
+++ b/r_exec/binding_map.h
@@ -288,7 +288,7 @@ public:
 
   void init(const r_code::Code *object, uint16 index);
 
-  _Fact *abstract_f_ihlp(const _Fact *fact) const; // for icst and imdl.
+  static _Fact *abstract_f_ihlp(const _Fact *fact); // for icst and imdl.
 
   /**
    * Fill in the fresh fact object as an abstract copy of the original fact, creating new bindings as needed.


### PR DESCRIPTION
Background: `BindingMap::abstract_f_ihlp` is used to convert an icst or imdl into an abstract version by replacing each reference to a variable. For example, with the following "non-abstract" input:

    (icst cst_147 [] [h s] false 1)

`abstract_f_ihlp` makes this abstract result:

    (icst cst_147 [v0: v1:] [v0: v1:] undefined 1)

The exposed args list `[h s]` is correctly abstracted to `[v0: v1:]` . But this is incorrectly used to overwrite the template args which should be `[]` as in the original. This is due to a bug. After writing the template args structure we need to increment extent_index by `1 + tpl_arg_count` , not just by `tpl_arg_count` . 

There is another error. In the original, weak requirement enabled is `false` , but this is not copied through. We fix this similar to the other copy operations:

     _ihlp->code(I_HLP_WEAK_REQUIREMENT_ENABLED) = ihlp->code(I_HLP_WEAK_REQUIREMENT_ENABLED);

With these fixes, `abstract_f_ihlp` now makes the correct abstract result:

    (icst cst_147 [] [v0: v1:] false 1)

Finally, `abstract_f_ihlp` is a utility method which does not use the binding map, so we make it static.

