### PR TITLE
Custom defined classes with operators can now be retrieved from Metadata

### DIFF
--- a/AERA/IODevices/TCP/tcp_io_device.cpp
+++ b/AERA/IODevices/TCP/tcp_io_device.cpp
@@ -532,21 +532,6 @@ namespace tcp_io_device {
           continue;
         }
       }
-      
-      std::vector<Atom> val;
-      if (var.getMetaData().getType() == VariableDescription_DataType_DOUBLE)
-      {
-        std::vector<double> values = var.getData<double>();
-        for (auto it = values.begin(); it != values.end(); ++it) {
-          val.push_back(Atom::Float(*it));
-        }
-      }
-      else if (var.getMetaData().getType() == VariableDescription_DataType_INT64){
-        std::vector<int64_t> values = var.getData<int64_t>();
-        for (auto it = values.begin(); it != values.end(); ++it) {
-          val.push_back(Atom::Float(*it));
-        }
-      }
       else if (var.getMetaData().getType() == VariableDescription_DataType_COMMUNICATION_ID) {
         int64_t val = var.getData<int64_t>()[0];
         std::vector<r_code::Code*> value;
@@ -568,11 +553,11 @@ namespace tcp_io_device {
         inject_marker_value_from_io_device(entity, obj, value, now, now + get_sampling_period(), r_exec::View::SYNC_PERIODIC, get_stdin());
         continue;
       }
-      if (id_mapping_[var.getMetaData().getID()] == "velocity_y") {
-        //inject_marker_value_from_io_device(entity, obj, val, now, now + get_sampling_period(), r_exec::View::SYNC_HOLD, get_stdin());
-      }
-      else {
-        //inject_marker_value_from_io_device(entity, obj, val, now, now + get_sampling_period(), r_exec::View::SYNC_PERIODIC, get_stdin());
+      else if (var.getMetaData().getType() == VariableDescription_DataType_STRING) {
+        /** @todo multidimensionality not working, yet*/
+        std::string val = var.getData<std::string>()[0];
+        inject_marker_value_from_io_device(entity, obj, val, now, now + get_sampling_period(), r_exec::View::SYNC_PERIODIC, get_stdin());
+        
       }
     }
   }

--- a/AERA/IODevices/TCP/tcp_io_device.cpp
+++ b/AERA/IODevices/TCP/tcp_io_device.cpp
@@ -279,13 +279,21 @@ namespace tcp_io_device {
     if (stored_meta_data.getOpCodeHandle() != "" ||
       (stored_meta_data.getDimensions() != std::vector<uint64_t>({ 1 }) && stored_meta_data.getDimensions() != std::vector<uint64_t>({ 1, 1 }))) {
       if (cmd->code(args_set_index + 2).getDescriptor() != Atom::I_PTR) {
-        std::cout << "ERROR: Ejected command with OpCodeHandle " << stored_meta_data.getOpCodeHandle() << " with dimensionality > 1 and r_code object without the necessary nesting." << std::endl;
+        std::cout << "ERROR: Ejected command with OpCodeHandle \"" << stored_meta_data.getOpCodeHandle() << "\" with dimensionality > 1 and r_code object without the necessary nesting." << std::endl;
         return tcp_io_device::MsgData::invalidMsgData();
       }
       int set_index = cmd->code(args_set_index + 2).asIndex();
       // @todo Check whether dimensionality of stored_meta_data fits the atom count of the set of the r_code Object.
       start = set_index + 1;
       end = start + cmd->code(set_index).getAtomCount();
+#if 1
+      if (cmd->code(set_index).asOpcode() == GetOpcode("quat")) {
+        double _1 = cmd->code(start) < 0 ? -1 : 1;
+        for (int i = start; i < end; ++i) {
+          cmd->code(i) = Atom::Float(cmd->code(i).asFloat() * _1);
+        }
+      }
+#endif
     }
 
     std::cout << "Eject cmd: " << cmd_identifier << ", entity: " << entity << ", Value(s): "; // << cmd->code(args_set_index + 2).asFloat() << std::endl;

--- a/AERA/IODevices/TCP/tcp_io_device.cpp
+++ b/AERA/IODevices/TCP/tcp_io_device.cpp
@@ -238,12 +238,12 @@ namespace tcp_io_device {
         if (it->second != obj) {
           continue;
         }
-        std::unique_ptr<TCPMessage> msg = std::move(constructMessageFromCommand(cmd->first, it->first, command));
-        if (!msg) {
+        tcp_io_device::MsgData msg = constructMessageFromCommand(cmd->first, it->first, command);
+        if (!msg.isValid()) {
           cout << "Could not create message from ejected command" << endl;
           return NULL;
         }
-        sendMessage(std::move(msg));
+        sendDataMessage(msg);
         break;
       }
       return command;
@@ -253,85 +253,124 @@ namespace tcp_io_device {
   }
 
   template<class O, class S>
-  std::unique_ptr< TCPMessage> TcpIoDevice<O, S>::constructMessageFromCommand(string cmd_identifier, string entity, r_code::Code* cmd)
+  tcp_io_device::MsgData TcpIoDevice<O, S>::constructMessageFromCommand(string cmd_identifier, string entity, r_code::Code* cmd)
   {
     // Get the stored meta data received by the SetupMessage during establishConnection with the correct identifier.
-    std::map<string, MetaData>::iterator stored_meta_data = meta_data_map_.find(cmd_identifier);
-    if (stored_meta_data == meta_data_map_.end()) {
+    std::map<string, MetaData>::iterator meta_data_it = meta_data_map_.find(cmd_identifier);
+    if (meta_data_it == meta_data_map_.end()) {
       cout << "> WARNING: Could not find cmd identifier " << cmd_identifier << " in the MetaData of available commands!" << endl;
-      return NULL;
+      return tcp_io_device::MsgData::invalidMsgData();
     }
 
-    // Create a new message to send later
-    std::unique_ptr<TCPMessage> msg = std::make_unique<TCPMessage>();
-    msg->set_messagetype(TCPMessage::DATA);
-
-    DataMessage* data_msg = msg->mutable_datamessage();
-
-    ProtoVariable* var = data_msg->add_variables();
-
-    VariableDescription* meta_data = var->mutable_metadata();
-    meta_data->set_datatype(stored_meta_data->second.getType());
-
-    for (auto it = id_mapping_.begin(); it != id_mapping_.end(); ++it) {
-      if (it->second.compare(entity) == 0) {
-        meta_data->set_entityid(it->first);
-      }
-      if (it->second.compare(cmd_identifier) == 0) {
-        meta_data->set_id(it->first);
-      }
-    }
-
-    auto dim = meta_data->mutable_dimensions();
-    for (uint64_t i = 0; i < stored_meta_data->second.getDimensions().size(); i++) {
-      dim->Add(stored_meta_data->second.getDimensions()[i]);
-    }
-
+    MetaData stored_meta_data = meta_data_it->second;
     uint16 args_set_index = cmd->code(CMD_ARGS).asIndex();
 
-    std::cout << "Eject cmd: " << cmd_identifier << ", entity: " << entity << ", Value: " << cmd->code(args_set_index + 2).asFloat() << std::endl;
+    tcp_io_device::MsgData msg_data = tcp_io_device::MsgData::invalidMsgData();
+    // Default values for OpCodeHandle == "" and dimensionality of 1.
+    int start = args_set_index + 2;
+    int end = args_set_index + 3;
 
+    // Otherwise retrieve the start and end indices by de-constructing the r_code::Code object.
+    if (stored_meta_data.getOpCodeHandle() != "" ||
+      (stored_meta_data.getDimensions() != std::vector<uint64_t>({ 1 }) && stored_meta_data.getDimensions() != std::vector<uint64_t>({ 1, 1 }))) {
+      if (cmd->code(args_set_index + 2).getDescriptor() != Atom::I_PTR) {
+        std::cout << "ERROR: Ejected command with OpCodeHandle " << stored_meta_data.getOpCodeHandle() << " with dimensionality > 1 and r_code object without the necessary nesting." << std::endl;
+        return tcp_io_device::MsgData::invalidMsgData();
+      }
+      int set_index = cmd->code(args_set_index + 2).asIndex();
+      // @todo Check whether dimensionality of stored_meta_data fits the atom count of the set of the r_code Object.
+      start = set_index + 1;
+      end = start + cmd->code(set_index).getAtomCount();
+    }
 
-    // @todo: Only a single value implemented. For multiple values (dim != [1]) this needs to be extended.
-    switch (stored_meta_data->second.getType()) {
+    std::cout << "Eject cmd: " << cmd_identifier << ", entity: " << entity << ", Value(s): "; // << cmd->code(args_set_index + 2).asFloat() << std::endl;
+    for (int i = start; i < end; ++i) {
+      std::cout << cmd->code(i).asFloat() << " ";
+    }
+    std::cout << std::endl;
+
+    switch (auto t = stored_meta_data.getType()) {
+      case VariableDescription_DataType_BOOL:
+      {
+        std::vector<bool> data = getDataVec<bool>(cmd, start, end, t);
+        msg_data = tcp_io_device::MsgData::createNewMsgData(stored_meta_data, data);
+        break;
+      }
+      case VariableDescription_DataType_INT64:
+      {
+        std::vector<int64_t> data = getDataVec<int64_t>(cmd, start, end, t);
+        msg_data = tcp_io_device::MsgData::createNewMsgData(stored_meta_data, data);
+        break;
+      }
+      case VariableDescription_DataType_DOUBLE:
+      {
+        std::vector<double> data = getDataVec<double>(cmd, start, end, t);
+        msg_data = tcp_io_device::MsgData::createNewMsgData(stored_meta_data, data);
+        break;
+      }
+      case VariableDescription_DataType_COMMUNICATION_ID:
+      {
+        std::vector<communication_id_t> data = getDataVec<communication_id_t>(cmd, start, end, t);
+        msg_data = tcp_io_device::MsgData::createNewMsgData(stored_meta_data, data);
+        break;
+      }
+      case VariableDescription_DataType_STRING:
+      {
+        // std::vector<bool> data = getDataVec<bool>(cmd, start, end, t);
+        // msg_data.push_back(tcp_io_device::MsgData::createNewMsgData(stored_meta_data, data));
+        // TODO: Using the .asIndex() function this can be done (See the Utils::GetString())
+        cout << "> WARNING: String type not implemented, yet" << endl;
+        return tcp_io_device::MsgData::invalidMsgData();
+        break;
+      }
+    }
+    return msg_data;
+  }
+
+  template<class O, class S>
+  template<class T>
+  std::vector<T> TcpIoDevice<O, S>::getDataVec(r_code::Code* cmd, int start_index, int end_index, tcp_io_device::VariableDescription_DataType type) {
+    std::vector<T> data;
+    switch (type) {
     case VariableDescription_DataType_BOOL:
-    {
-      char d = (char)cmd->code(args_set_index + 2).asBoolean();
-      var->set_data(std::string(&d));
+      for (int i = start_index; i < end_index; ++i) {
+        data.push_back(cmd->code(i).asBoolean());
+      }
       break;
-    }
     case VariableDescription_DataType_INT64:
-    {
-      // No direct representation as integer, only float32 in AERA
-      int val = (int)cmd->code(args_set_index + 2).asFloat();
-      char d[8];
-      for (int i = 0; i < 8; i++) {
-        d[i] = val >> (8 - 1 - i) * 8;
+      for (int i = start_index; i < end_index; ++i) {
+        data.push_back((int)cmd->code(i).asFloat());
       }
-      var->set_data(std::string(d));
       break;
-    }
     case VariableDescription_DataType_DOUBLE:
-    {
-      double val = (double)cmd->code(args_set_index + 2).asFloat();
-      std::string data;
-      char const* d = reinterpret_cast<char const*>(&val);
-      for (size_t i = 0; i < sizeof(double); ++i) {
-        data += d[i];
+      for (int i = start_index; i < end_index; ++i) {
+        data.push_back(cmd->code(i).asFloat());
       }
-      var->set_data(data);
       break;
-    }
+    case VariableDescription_DataType_COMMUNICATION_ID:
+      for (int i = start_index; i < end_index; ++i) {
+        if (cmd->code(i).getDescriptor() != Atom::R_PTR) {
+          // @todo This isn't an R_PTR whysoever...
+          std::cout << "WARNING: Got command which should include a communicaiton id which points to another object without R_PTR. Ignoring it." << std::endl;;
+          continue;
+        }
+        r_code::Code* reference = cmd->get_reference(cmd->code(i).asIndex());
+        for (auto it = entities_.begin(); it != entities_.end(); ++it) {
+          if (it->second != reference) {
+            continue;
+          }
+          // @todo Need to implement this once the proper object is found earlier.
+        }
+        data.push_back(cmd->code(i).asFloat());
+      }
+      break;
     case VariableDescription_DataType_STRING:
-    {
-      // TODO: Using the .asIndex() function this can be done (See the Utils::GetString())
-      cout << "> WARNING: String type not implemented, yet" << endl;
+      // for (int i = start_index; i < end_index; ++i) {
+      //   data.push_back(cmd->code(i).asBoolean());
+      // }
       break;
-      // std::string data = cmd->code(args_set_index + 2).String(0);
-      // var->set_data(data);
     }
-    }
-    return msg;
+    return data;
   }
 
   template<class O, class S>
@@ -405,6 +444,17 @@ namespace tcp_io_device {
     thread_ret_val(0);
   }
 
+
+  template<class O, class S>
+  void TcpIoDevice<O, S>::sendDataMessage(tcp_io_device::MsgData msg_data) {
+    std::unique_ptr<tcp_io_device::TCPMessage> msg = std::make_unique<tcp_io_device::TCPMessage>();
+    msg->set_messagetype(tcp_io_device::TCPMessage::DATA);
+    tcp_io_device::DataMessage* data_msg = msg->mutable_datamessage();
+    tcp_io_device::ProtoVariable* var = data_msg->add_variables();
+    msg_data.toMutableProtoVariable(var);
+    sendMessage(std::move(msg));
+  }
+
   template<class O, class S>
   void TcpIoDevice<O, S>::sendMessage(std::unique_ptr<TCPMessage> msg) {
     // Simply enqueue the message to send and let the TCPConnection do the actual sending.
@@ -434,21 +484,60 @@ namespace tcp_io_device {
     // @todo: Need to change it to actual receive time
     auto now = r_exec::Now();
     auto data = data_msg->release_datamessage();
+    std::cout << "Received data message. Injecting received data:" << std::endl;
     for (int i = 0; i < data->variables_size(); ++i) {
-      ProtoVariable v = data->variables(i);
-      MsgData var(&v);
-      std::string d = v.data();
-
+      MsgData var(&(data->variables(i)));
       auto entity = entities_[id_mapping_[var.getMetaData().getEntityID()]];
       auto obj = objects_[id_mapping_[var.getMetaData().getID()]];
-      
-      Atom val = Atom();
+      std::cout << "Variable " << i << ":" << std::endl;
+      std::cout << "Entity: " << id_mapping_[var.getMetaData().getEntityID()] << std::endl;
+      std::cout << "Property: " << id_mapping_[var.getMetaData().getID()] << std::endl;
+      std::cout << "Value(s):" << std::endl;
+
       if (var.getMetaData().getType() == VariableDescription_DataType_DOUBLE)
       {
-        val = Atom::Float(var.getData<double>()[0]);
+        if (var.getMetaData().getOpCodeHandle() == "") {
+          injectDefault<double>(entity, obj, var.getData<double>(), now);
+          continue;
+        }
+        else if (var.getMetaData().getOpCodeHandle() == "set") {
+          injectSet<double>(entity, obj, var.getData<double>(), now);
+          continue;
+        }
+        else {
+          injectOpCode<double>(entity, obj, var.getData<double>(), now, var.getMetaData().getOpCodeHandle());
+          continue;
+        }
+      }
+      else if (var.getMetaData().getType() == VariableDescription_DataType_INT64)
+      {
+        if (var.getMetaData().getOpCodeHandle() == "") {
+          injectDefault<int64_t>(entity, obj, var.getData<int64_t>(), now);
+          continue;
+        }
+        else if (var.getMetaData().getOpCodeHandle() == "set") {
+          injectSet<int64_t>(entity, obj, var.getData<int64_t>(), now);
+          continue;
+        }
+        else {
+          injectOpCode<int64_t>(entity, obj, var.getData<int64_t>(), now, var.getMetaData().getOpCodeHandle());
+          continue;
+        }
+      }
+      
+      std::vector<Atom> val;
+      if (var.getMetaData().getType() == VariableDescription_DataType_DOUBLE)
+      {
+        std::vector<double> values = var.getData<double>();
+        for (auto it = values.begin(); it != values.end(); ++it) {
+          val.push_back(Atom::Float(*it));
+        }
       }
       else if (var.getMetaData().getType() == VariableDescription_DataType_INT64){
-        val = Atom::Float(var.getData<int64_t>()[0]);
+        std::vector<int64_t> values = var.getData<int64_t>();
+        for (auto it = values.begin(); it != values.end(); ++it) {
+          val.push_back(Atom::Float(*it));
+        }
       }
       else if (var.getMetaData().getType() == VariableDescription_DataType_COMMUNICATION_ID) {
         int64_t val = var.getData<int64_t>()[0];
@@ -460,6 +549,7 @@ namespace tcp_io_device {
             continue;
           }
           std::string object_entity = id_mapping_[val];
+          std::cout << object_entity << std::endl;
           if (entities_.find(object_entity) == entities_.end())
           {
             std::cout << "WARNING: Received message with uninitalized entity, this should never happen!" << std::endl;
@@ -471,12 +561,73 @@ namespace tcp_io_device {
         continue;
       }
       if (id_mapping_[var.getMetaData().getID()] == "velocity_y") {
-        inject_marker_value_from_io_device(entity, obj, val, now, now + get_sampling_period(), r_exec::View::SYNC_HOLD, get_stdin());
+        //inject_marker_value_from_io_device(entity, obj, val, now, now + get_sampling_period(), r_exec::View::SYNC_HOLD, get_stdin());
       }
       else {
-        inject_marker_value_from_io_device(entity, obj, val, now, now + get_sampling_period(), r_exec::View::SYNC_PERIODIC, get_stdin());
+        //inject_marker_value_from_io_device(entity, obj, val, now, now + get_sampling_period(), r_exec::View::SYNC_PERIODIC, get_stdin());
       }
     }
+  }
+
+  template<class O, class S>
+  template<class V>
+  void TcpIoDevice<O, S>::injectDefault(r_code::Code* entity, r_code::Code* object, std::vector<V> vals, core::Timestamp time) {
+    if (vals.size() == 0) {
+      std::cout << "[]" << std::endl;
+      inject_marker_value_from_io_device(entity, object, std::vector<r_code::Code*>(), time, time + get_sampling_period(), r_exec::View::SYNC_PERIODIC, get_stdin());
+      return;
+    }
+    if (vals.size() == 1) {
+      std::cout << vals[0] << std::endl;
+      inject_marker_value_from_io_device(entity, object, Atom::Float(vals[0]), time, time + get_sampling_period(), r_exec::View::SYNC_PERIODIC, get_stdin());
+      return;
+    }
+    injectSet<V>(entity, object, vals, time);
+  }
+
+  template<class O, class S>
+  void TcpIoDevice<O, S>::injectDefault(r_code::Code* entity, r_code::Code* object, std::vector<r_code::Code*> vals, core::Timestamp time) {
+    if (vals.size() == 0) {
+      inject_marker_value_from_io_device(entity, object, std::vector<r_code::Code*>(), time, time + get_sampling_period(), r_exec::View::SYNC_PERIODIC, get_stdin());
+      return;
+    }
+    if (vals.size() == 1) {
+      inject_marker_value_from_io_device(entity, object, vals[0], time, time + get_sampling_period(), r_exec::View::SYNC_PERIODIC, get_stdin());
+      return;
+    }
+    injectSet(entity, object, vals, time);
+  }
+
+  template<class O, class S>
+  template<class V>
+  void TcpIoDevice<O, S>::injectSet(r_code::Code* entity, r_code::Code* object, std::vector<V> vals, core::Timestamp time) {
+    std::vector<Atom> atom_vals;
+    for (auto it = vals.begin(); it != vals.end(); ++it) {
+      std::cout << *it << std::endl;
+      atom_vals.push_back(Atom::Float(*it));
+    }
+    inject_marker_value_from_io_device(entity, object, atom_vals, time, time + get_sampling_period(), r_exec::View::SYNC_PERIODIC, get_stdin());
+  }
+
+  template<class O, class S>
+  void TcpIoDevice<O, S>::injectSet(r_code::Code* entity, r_code::Code* object, std::vector<r_code::Code*> vals, core::Timestamp time) {
+    inject_marker_value_from_io_device(entity, object, vals, time, time + get_sampling_period(), r_exec::View::SYNC_PERIODIC, get_stdin());
+  }
+
+  template<class O, class S>
+  template<class V>
+  void TcpIoDevice<O, S>::injectOpCode(r_code::Code* entity, r_code::Code* object, std::vector<V> vals, core::Timestamp time, std::string opcode_handle) {
+    core::uint16 op_code = r_exec::GetOpcode(opcode_handle.c_str());
+    if (op_code == 0xFFFF) {
+      std::cout << "ERROR: Received message with unknown opcode handle! Handle: " << opcode_handle << std::endl;
+      return;
+    }
+    std::vector<Atom> atom_vals;
+    for (auto it = vals.begin(); it != vals.end(); ++it) {
+      std::cout << *it << std::endl;
+      atom_vals.push_back(Atom::Float(*it));
+    }
+    inject_marker_value_from_io_device(entity, object, op_code, atom_vals, time, time);
   }
 
   template<class O, class S>

--- a/AERA/IODevices/TCP/tcp_io_device.cpp
+++ b/AERA/IODevices/TCP/tcp_io_device.cpp
@@ -265,6 +265,11 @@ namespace tcp_io_device {
     MetaData stored_meta_data = meta_data_it->second;
     uint16 args_set_index = cmd->code(CMD_ARGS).asIndex();
 
+    if (cmd->code(args_set_index).getAtomCount() == 1) {
+      // std::cout << "Cmd without values ejected." << std::endl;
+      return tcp_io_device::MsgData::createNewMsgData(stored_meta_data);
+    }
+
     tcp_io_device::MsgData msg_data = tcp_io_device::MsgData::invalidMsgData();
     // Default values for OpCodeHandle == "" and dimensionality of 1.
     int start = args_set_index + 2;
@@ -345,10 +350,13 @@ namespace tcp_io_device {
     case VariableDescription_DataType_DOUBLE:
       for (int i = start_index; i < end_index; ++i) {
         data.push_back(cmd->code(i).asFloat());
+        // std::cout << "Debug DataType Double trace:" << cmd->trace_string() << std::endl;
       }
       break;
     case VariableDescription_DataType_COMMUNICATION_ID:
       for (int i = start_index; i < end_index; ++i) {
+        // std::cout << "Start: " << start_index << " End:" << end_index << std::endl;
+        // std::cout << "Debug test of Communication_id. 1) cmd trace " << cmd->trace_string() << std::endl;
         if (cmd->code(i).getDescriptor() != Atom::R_PTR) {
           // @todo This isn't an R_PTR whysoever...
           std::cout << "WARNING: Got command which should include a communicaiton id which points to another object without R_PTR. Ignoring it." << std::endl;;
@@ -394,7 +402,7 @@ namespace tcp_io_device {
         return;
       }
     }
-    std::cout << "Received message of type " << msg->messagetype();
+    std::cout << "Received message of type " << msg->messagetype() << std::endl;
 
     handleMessage(std::move(msg));
     lastInjectTime_ = now;
@@ -484,15 +492,15 @@ namespace tcp_io_device {
     // @todo: Need to change it to actual receive time
     auto now = r_exec::Now();
     auto data = data_msg->release_datamessage();
-    std::cout << "Received data message. Injecting received data:" << std::endl;
+    // std::cout << "Received data message. Injecting received data:" << std::endl;
     for (int i = 0; i < data->variables_size(); ++i) {
       MsgData var(&(data->variables(i)));
       auto entity = entities_[id_mapping_[var.getMetaData().getEntityID()]];
       auto obj = objects_[id_mapping_[var.getMetaData().getID()]];
-      std::cout << "Variable " << i << ":" << std::endl;
-      std::cout << "Entity: " << id_mapping_[var.getMetaData().getEntityID()] << std::endl;
-      std::cout << "Property: " << id_mapping_[var.getMetaData().getID()] << std::endl;
-      std::cout << "Value(s):" << std::endl;
+      // std::cout << "Variable " << i << ":" << std::endl;
+      // std::cout << "Entity: " << id_mapping_[var.getMetaData().getEntityID()] << std::endl;
+      // std::cout << "Property: " << id_mapping_[var.getMetaData().getID()] << std::endl;
+      // std::cout << "Value(s):" << std::endl;
 
       if (var.getMetaData().getType() == VariableDescription_DataType_DOUBLE)
       {
@@ -549,7 +557,7 @@ namespace tcp_io_device {
             continue;
           }
           std::string object_entity = id_mapping_[val];
-          std::cout << object_entity << std::endl;
+          // std::cout << object_entity << std::endl;
           if (entities_.find(object_entity) == entities_.end())
           {
             std::cout << "WARNING: Received message with uninitalized entity, this should never happen!" << std::endl;
@@ -573,12 +581,12 @@ namespace tcp_io_device {
   template<class V>
   void TcpIoDevice<O, S>::injectDefault(r_code::Code* entity, r_code::Code* object, std::vector<V> vals, core::Timestamp time) {
     if (vals.size() == 0) {
-      std::cout << "[]" << std::endl;
+      // std::cout << "[]" << std::endl;
       inject_marker_value_from_io_device(entity, object, std::vector<r_code::Code*>(), time, time + get_sampling_period(), r_exec::View::SYNC_PERIODIC, get_stdin());
       return;
     }
     if (vals.size() == 1) {
-      std::cout << vals[0] << std::endl;
+      // std::cout << vals[0] << std::endl;
       inject_marker_value_from_io_device(entity, object, Atom::Float(vals[0]), time, time + get_sampling_period(), r_exec::View::SYNC_PERIODIC, get_stdin());
       return;
     }
@@ -603,7 +611,7 @@ namespace tcp_io_device {
   void TcpIoDevice<O, S>::injectSet(r_code::Code* entity, r_code::Code* object, std::vector<V> vals, core::Timestamp time) {
     std::vector<Atom> atom_vals;
     for (auto it = vals.begin(); it != vals.end(); ++it) {
-      std::cout << *it << std::endl;
+      // std::cout << *it << std::endl;
       atom_vals.push_back(Atom::Float(*it));
     }
     inject_marker_value_from_io_device(entity, object, atom_vals, time, time + get_sampling_period(), r_exec::View::SYNC_PERIODIC, get_stdin());
@@ -624,7 +632,7 @@ namespace tcp_io_device {
     }
     std::vector<Atom> atom_vals;
     for (auto it = vals.begin(); it != vals.end(); ++it) {
-      std::cout << *it << std::endl;
+      // std::cout << *it << std::endl;
       atom_vals.push_back(Atom::Float(*it));
     }
     inject_marker_value_from_io_device(entity, object, op_code, atom_vals, time, time);

--- a/AERA/IODevices/TCP/tcp_io_device.h
+++ b/AERA/IODevices/TCP/tcp_io_device.h
@@ -218,9 +218,12 @@ namespace tcp_io_device {
     * \param cmd_identifier The identifier of the ejected command.
     * \param entity The name of the entity for which the command was ejected.
     * \param cmd the ejected r_code::Code*.
-    * \return The constructed TCPMessage which can be sent to the environment simulation.
+    * \return The constructed MsgData which can be sent to the environment simulation.
     */
-    std::unique_ptr< TCPMessage> constructMessageFromCommand(std::string cmd_identifier, std::string entity, r_code::Code* cmd);
+    tcp_io_device::MsgData constructMessageFromCommand(std::string cmd_identifier, std::string entity, r_code::Code* cmd);
+
+    template<class T>
+    std::vector<T> getDataVec(r_code::Code* cmd, int start_index, int end_index, tcp_io_device::VariableDescription_DataType type);
 
     /**
     * Message handler for incoming messages. Passes them on to specific handlers by the given TCPMessage_Type
@@ -235,11 +238,42 @@ namespace tcp_io_device {
     void handleDataMessage(std::unique_ptr<TCPMessage> data_msg);
 
     /**
+    * Injects numeric (i.e., int and double) variables without specified opcode_handle (i.e., empty string). Single dimensional variables are injected as is, empty and multi dimensional variables are injected as sets.
+    * \param var MsgData object to be injected.
+    */
+    template<class V>
+    void injectDefault(r_code::Code* entity, r_code::Code* object, std::vector<V> vals, core::Timestamp time);
+
+    void injectDefault(r_code::Code* entity, r_code::Code* object, std::vector<r_code::Code*> vals, core::Timestamp time);
+
+    /**
+    * Injects numeric (i.e., int and double) variables with either specified opcode_handle "set" (i.e. for single dimensional variables that are to be injected as sets), or multi dimensional variables injected through injectDefault().
+    * \param var MsgData object to be injected.
+    */
+    template<class V>
+    void injectSet(r_code::Code* entity, r_code::Code* object, std::vector<V> vals, core::Timestamp time);
+
+    void injectSet(r_code::Code* entity, r_code::Code* object, std::vector<r_code::Code*> vals, core::Timestamp time);
+
+    /**
+    * Injects numeric (i.e., int and double) variables with specified opcode_handle.
+    * \param var MsgData object to be injected.
+    */
+    template<class V>
+    void injectOpCode(r_code::Code* entity, r_code::Code* object, std::vector<V> vals, core::Timestamp time, std::string opcode_handle);
+
+    /**
     * Message handler for incoming setup messages. Fills the available entities_, objects_, and commands_ maps as well as
     * a mapping of id to string for fast access when receiving messages from the environment simulation.
     * \param setup_msg The incoming message.
     */
     void handleSetupMessage(std::unique_ptr<TCPMessage> setup_msg);
+
+    /**
+    * Handler to send messages. Transforms the MsgData object to a TCPMessage with type Data.
+    * \param msg_data MsgData object to send.
+    */
+    void sendDataMessage(tcp_io_device::MsgData msg_data);
 
     /**
     * Enqueues messages to the SafeQueues to pass them thread-safe to the TCPConnection which handles the actual sending of the message.

--- a/AERA/replicode_v1.2/hand-grab-sphere-learn.external.ur.replicode
+++ b/AERA/replicode_v1.2/hand-grab-sphere-learn.external.ur.replicode
@@ -1,0 +1,613 @@
+; AGI-13 Summer School - AERA 6. Example by Eric Nivel.
+; https://www.youtube.com/watch?v=LDbOHxUtVlU&t=5561
+; A robotic arm is holding a cube and needs to put a sphere somewhere.
+; It has only one hand; effectors: move, grab, release.
+; ontology: essence ("is a"), position, holding.
+; inputs: position, holding, efferent copies of commands.
+
+h:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+h_is_a_hand:(mk.val h essence hand 1) |[]
+(fact h_is_a_hand 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+b_0:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+b_0_is_a_cube:(mk.val b_0 essence cube 1) |[]
+(fact b_0_is_a_cube 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+b_0_is_a_hand:(mk.val b_0 essence hand 1) |[]
+; This is needed for S3.
+(|fact b_0_is_a_hand 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+b_1:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+b_1_is_a_cube:(mk.val b_1 essence cube 1) |[]
+(fact b_1_is_a_cube 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+b_1_is_a_hand:(mk.val b_1 essence hand 1) |[]
+; This is needed for S3.
+(|fact b_1_is_a_hand 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+b_2:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+b_2_is_a_cube:(mk.val b_2 essence cube 1) |[]
+(fact b_2_is_a_cube 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+b_2_is_a_hand:(mk.val b_2 essence hand 1) |[]
+; This is needed for S3.
+(|fact b_2_is_a_hand 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+; Hand H has position P.
+S0:(cst [] []
+   (fact (mk.val H: essence hand :) T0: T1: : :); Changed X to hand.
+   (fact (mk.val H: position P: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; A thing C of kind X occupies position P. (Modified to exclude when C is a hand.)
+S3:(cst [] []
+   (fact (mk.val C: essence X: :) T0: T1: : :)
+   (fact (mk.val C: position P: :) T0: T1: : :)
+   (|fact (mk.val C: essence hand :) T0: T1: : :); Don't duplicate S0, which is for hands.
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+!def p_zero (vec3 0 0 0)
+!def pH0 (vec3 25 0 0)
+!def pS0 p_zero
+!def pS1 (vec3 15 0 0)
+
+; Execute babble pass A commands.
+!def DRIVE_PASS1_START 1400ms
+!def DRIVE_PASS1_END (+ DRIVE_PASS1_START 400ms)
+; Execute experimenting pass A commands.
+!def DRIVE_PASS2_START (+ DRIVE_PASS1_END 1100ms)
+
+start:(pgm [] [] [] []
+   (cmd ready ["hand-grab-sphere"] 1)
+1) |[]
+(ipgm start [] RUN_ONCE 0s VOLATILE NOTIFY 1) [[SYNC_ONCE now 0 forever stdin nil 1]]
+
+m_drive:(mdl [] []
+   ; The goal target timings are the same as the drive timings.
+   (fact (mk.val b_1 position pS1 1) T0: T1: 1 1)
+   (fact run T0: T1: ::)
+|[]
+|[]
+[stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+pgm_babbleA_1:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt 100ms))
+[]
+   ; Move where initial and final positions have no objects so that they are not correlated.
+   (inj [Command:(cmd move [h (vec3 -2.2 0 0.2)] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd move [h (vec3 -2.2 0 0.2)])" []])
+1) |[]
+(ipgm pgm_babbleA_1 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_2:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt 200ms))
+[]
+   ; Now move to the sphere.
+   (inj [Command:(cmd move [h (vec3 1 0.5 0)] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd move [h (vec3 1 0.5 0)])" []])
+1) |[]
+(ipgm pgm_babbleA_2 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_3:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt 300ms))
+[]
+   ; Grab the sphere.
+   (inj [Command:(cmd grab [h] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd grab [h])" []])
+1) |[]
+(ipgm pgm_babbleA_3 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_4:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt 400ms))
+[]
+   ; Release the sphere to learn the release model and the "holding" cst.
+   (inj [Command:(cmd release [h] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd release [h])" []])
+1) |[]
+(ipgm pgm_babbleA_4 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_5:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt 500ms))
+[]
+   ; Grab the sphere again so we can move while holding it.
+   (inj [Command:(cmd grab [h] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd grab [h])" []])
+1) |[]
+(ipgm pgm_babbleA_5 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_6:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt 600ms))
+[]
+   ; Move while holding the sphere to learn the re-use model.
+   (inj [Command:(cmd move [h (vec3 0.5 -0.2 0)] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd move [h (vec3 0.5 -0.2 0)])" []])
+1) |[]
+(ipgm pgm_babbleA_6 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_7:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt 700ms))
+[]
+   ; Move while holding the sphere to learn the re-use model.
+   (inj [Command:(cmd move [h (vec3 -0.9 -1.5 0)] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd move [h (vec3 -0.9 -1.5 0)])" []])
+1) |[]
+(ipgm pgm_babbleA_7 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_8:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt 800ms))
+[]
+   ; Release the sphere in the initial position for the task.
+   (inj [Command:(cmd release [h] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd release [h])" []])
+1) |[]
+(ipgm pgm_babbleA_8 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_9:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt 900ms))
+[]
+   ; Move to the cube.
+   (inj [Command:(cmd move [h (vec3 -0.5 0 0)] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd move [h (vec3 -0.5 0 0)])" []])
+1) |[]
+(ipgm pgm_babbleA_9 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_10:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt 1000ms))
+[]
+   ; Grab the cube.
+   (inj [Command:(cmd grab [h] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd grab [h])" []])
+1) |[]
+(ipgm pgm_babbleA_10 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_11:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt 1100ms))
+[]
+   ; Release the cube.
+   (inj [Command:(cmd release [h] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd release [h])" []])
+1) |[]
+(ipgm pgm_babbleA_11 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_12:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt 1200ms))
+[]
+   ; Grab the cube again so we can move it.
+   (inj [Command:(cmd grab [h] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd grab [h])" []])
+1) |[]
+(ipgm pgm_babbleA_12 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_13:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt 1300ms))
+[]
+   ; Move while holding the cube to the initial position for the task and to learn the re-use model.
+   (inj [Command:(cmd move [h (vec3 20 0 0)] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd move [h (vec3 20 0 0)])" []])
+1) |[]
+(ipgm pgm_babbleA_13 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_inject_drive_pass1:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt DRIVE_PASS1_START))
+   (< After (+ this.vw.ijt DRIVE_PASS1_END))
+[]
+   ; The end of the time interval will be used in m_drive as the end of the goal interval.
+   (inj [F_run:(fact run After (+ Before 500ms) 1 1) []])
+   (inj [G:(goal F_run self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before injecting the drive.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected drive" []])
+1) |[]
+(ipgm pgm_inject_drive_pass1 [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_inject_drive_pass2:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt DRIVE_PASS2_START))
+[]
+   ; The end of the time interval will be used in m_drive as the end of the goal interval.
+   (inj [F_run:(fact run After (+ Before 500ms) 1 1) []])
+   (inj [G:(goal F_run self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before injecting the drive.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected drive" []])
+1) |[]
+(ipgm pgm_inject_drive_pass2 [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_experimentingA_0:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 0us)))
+[]
+   (inj [Command:(cmd release [h] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd release [h])" []])
+1) |[]
+(ipgm pgm_experimentingA_0 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_experimentingA_1:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 100us)))
+[]
+   (inj [Command:(cmd move [h (vec3 -15 0 0)] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd move [h (vec3 -15 0 0)])" []])
+1) |[]
+(ipgm pgm_experimentingA_1 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_experimentingA_2:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 200ms)))
+[]
+   (inj [Command:(cmd grab [h] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd grab [h])" []])
+1) |[]
+(ipgm pgm_experimentingA_2 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_experimentingA_3:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 300ms)))
+[]
+   (inj [Command:(cmd release [h] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd release [h])" []])
+1) |[]
+(ipgm pgm_experimentingA_3 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_experimentingA_4:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 400ms)))
+[]
+   (inj [Command:(cmd grab [h] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd grab [h]" []])
+1) |[]
+(ipgm pgm_experimentingA_4 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_experimentingA_5:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 500ms)))
+[]
+   (inj [Command:(cmd release [h] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd release [h])" []])
+1) |[]
+(ipgm pgm_experimentingA_5 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_experimentingA_6:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 600ms)))
+[]
+   (inj [Command:(cmd move [h (vec3 5 0 0)] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd move [h (vec3 5 0 0)])" []])
+1) |[]
+(ipgm pgm_experimentingA_6 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_experimentingA_7:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 700ms)))
+[]
+   (inj [Command:(cmd grab [h] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd grab [h])" []])
+1) |[]
+(ipgm pgm_experimentingA_7 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_experimentingA_8:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 800ms)))
+[]
+   (inj [Command:(cmd release [h] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd release [h])" []])
+1) |[]
+(ipgm pgm_experimentingA_8 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_experimentingA_9:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 900ms)))
+[]
+   (inj [Command:(cmd grab [h] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd grab [h])" []])
+1) |[]
+(ipgm pgm_experimentingA_9 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_experimentingA_10:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 1000ms)))
+[]
+   (inj [Command:(cmd move [h (vec3 20 0 0)] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd move [h (vec3 20 0 0)])" []])
+1) |[]
+(ipgm pgm_experimentingA_10 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_eject_cmd_move:(pgm [] []
+   (ptn (fact G:(goal (fact (cmd move [H: D:] :) ::) ::) ::) [])
+[]
+   ; Only eject non-simulation goals.
+   (= (is_sim G) false)
+[]
+   (cmd move [H D] 1)
+1) |[]
+(ipgm pgm_eject_cmd_move [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_eject_cmd_grab:(pgm [] []
+   (ptn (fact G:(goal (fact (cmd grab [H:] :) ::) ::) ::) [])
+[]
+   ; Only eject non-simulation goals.
+   (= (is_sim G) false)
+[]
+   (cmd grab [H] 1)
+1) |[]
+(ipgm pgm_eject_cmd_grab [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_eject_cmd_release:(pgm [] []
+   (ptn (fact G:(goal (fact (cmd release [H:] :) ::) ::) ::) [])
+[]
+   ; Only eject non-simulation goals.
+   (= (is_sim G) false)
+[]
+   (cmd release [H] 1)
+1) |[]
+(ipgm pgm_eject_cmd_release [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]

--- a/AERA/replicode_v1.2/hand-grab-sphere-learn.external.ur.replicode
+++ b/AERA/replicode_v1.2/hand-grab-sphere-learn.external.ur.replicode
@@ -47,16 +47,13 @@ S3:(cst [] []
 |[]
 [stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
-!def p_zero (vec3 0 0 0)
-!def pH0 (vec3 25 0 0)
-!def pS0 p_zero
 !def pS1 (vec3 -0.5 0.5 0)
 
 ; Execute babble pass A commands.
 !def DRIVE_PASS1_START 1400ms
 !def DRIVE_PASS1_END (+ DRIVE_PASS1_START 200ms)
 ; Execute experimenting pass A commands.
-!def DRIVE_PASS2_START (+ DRIVE_PASS1_END 1200ms)
+!def DRIVE_PASS2_START (+ DRIVE_PASS1_END 600ms)
 
 start:(pgm [] [] [] []
    (cmd ready ["hand-grab-sphere"] 1)
@@ -370,13 +367,13 @@ pgm_inject_drive_pass2:(pgm [] []
 (ipgm pgm_inject_drive_pass2 [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever primary nil 1]
 
-pgm_experimentingA_00:(pgm [] []
+pgm_experimentingA_0:(pgm [] []
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h position : :) After: Before: ::) [])
 []
    (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 0us)))
 []
-   (inj [Command:(cmd move [h (vec3 -0.5 -1 0)] 1) []])
+   (inj [Command:(cmd move [h (vec3 -0.5 0 0)] 1) []])
    (inj [F_Command:(fact Command After Before 1 1) []])
    (inj [G:(goal F_Command self nil 1) []])
    (inj []
@@ -384,12 +381,12 @@ pgm_experimentingA_00:(pgm [] []
       (fact G T0:(+ After 10ms) T0 1 1)
       [SYNC_ONCE T0 1 forever primary nil]
    )
-   (prb [1 "print" "injected (cmd move [h (vec3 -0.5 -1 0)])" []])
+   (prb [1 "print" "injected (cmd move [h (vec3 -0.5 0 0)])" []])
 1) |[]
-(ipgm pgm_experimentingA_00 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+(ipgm pgm_experimentingA_0 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever primary nil 1]
 
-pgm_experimentingA_0:(pgm [] []
+pgm_experimentingA_1:(pgm [] []
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h position : :) After: Before: ::) [])
 []
@@ -405,25 +402,6 @@ pgm_experimentingA_0:(pgm [] []
    )
    (prb [1 "print" "injected (cmd release [h])" []])
 1) |[]
-(ipgm pgm_experimentingA_0 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
-   [SYNC_ONCE now 0 forever primary nil 1]
-
-pgm_experimentingA_1:(pgm [] []
-   ; This fact repeats periodically. We use it as a "heartbeat".
-   (ptn (fact (mk.val h position : :) After: Before: ::) [])
-[]
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 200us)))
-[]
-   (inj [Command:(cmd move [h (vec3 0.5 1 0)] 1) []])
-   (inj [F_Command:(fact Command After Before 1 1) []])
-   (inj [G:(goal F_Command self nil 1) []])
-   (inj []
-      ; Delay a little to allow predictions for this sampling period before processing.
-      (fact G T0:(+ After 10ms) T0 1 1)
-      [SYNC_ONCE T0 1 forever primary nil]
-   )
-   (prb [1 "print" "injected (cmd move [h (vec3 0.5 1 0)])" []])
-1) |[]
 (ipgm pgm_experimentingA_1 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever primary nil 1]
 
@@ -431,7 +409,7 @@ pgm_experimentingA_2:(pgm [] []
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h position : :) After: Before: ::) [])
 []
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 300ms)))
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 200ms)))
 []
    (inj [Command:(cmd grab [h] 1) []])
    (inj [F_Command:(fact Command After Before 1 1) []])
@@ -441,7 +419,7 @@ pgm_experimentingA_2:(pgm [] []
       (fact G T0:(+ After 10ms) T0 1 1)
       [SYNC_ONCE T0 1 forever primary nil]
    )
-   (prb [1 "print" "injected (cmd grab [h])" []])
+   (prb [1 "print" "injected (cmd grab [h]" []])
 1) |[]
 (ipgm pgm_experimentingA_2 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever primary nil 1]
@@ -450,7 +428,7 @@ pgm_experimentingA_3:(pgm [] []
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h position : :) After: Before: ::) [])
 []
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 400ms)))
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 300ms)))
 []
    (inj [Command:(cmd release [h] 1) []])
    (inj [F_Command:(fact Command After Before 1 1) []])
@@ -469,7 +447,7 @@ pgm_experimentingA_4:(pgm [] []
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h position : :) After: Before: ::) [])
 []
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 500ms)))
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 400ms)))
 []
    (inj [Command:(cmd grab [h] 1) []])
    (inj [F_Command:(fact Command After Before 1 1) []])
@@ -488,9 +466,9 @@ pgm_experimentingA_5:(pgm [] []
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h position : :) After: Before: ::) [])
 []
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 600ms)))
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 500ms)))
 []
-   (inj [Command:(cmd release [h] 1) []])
+   (inj [Command:(cmd move [h (vec3 0 -1 0)] 1) []])
    (inj [F_Command:(fact Command After Before 1 1) []])
    (inj [G:(goal F_Command self nil 1) []])
    (inj []
@@ -498,104 +476,9 @@ pgm_experimentingA_5:(pgm [] []
       (fact G T0:(+ After 10ms) T0 1 1)
       [SYNC_ONCE T0 1 forever primary nil]
    )
-   (prb [1 "print" "injected (cmd release [h])" []])
+   (prb [1 "print" "injected (cmd move [h (vec3 0 -1 0)])" []])
 1) |[]
 (ipgm pgm_experimentingA_5 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
-   [SYNC_ONCE now 0 forever primary nil 1]
-
-pgm_experimentingA_6:(pgm [] []
-   ; This fact repeats periodically. We use it as a "heartbeat".
-   (ptn (fact (mk.val h position : :) After: Before: ::) [])
-[]
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 700ms)))
-[]
-   (inj [Command:(cmd move [h (vec3 -0.5 -1 0)] 1) []])
-   (inj [F_Command:(fact Command After Before 1 1) []])
-   (inj [G:(goal F_Command self nil 1) []])
-   (inj []
-      ; Delay a little to allow predictions for this sampling period before processing.
-      (fact G T0:(+ After 10ms) T0 1 1)
-      [SYNC_ONCE T0 1 forever primary nil]
-   )
-   (prb [1 "print" "injected (cmd move [h (vec3 5 0 0)])" []])
-1) |[]
-(ipgm pgm_experimentingA_6 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
-   [SYNC_ONCE now 0 forever primary nil 1]
-
-pgm_experimentingA_7:(pgm [] []
-   ; This fact repeats periodically. We use it as a "heartbeat".
-   (ptn (fact (mk.val h position : :) After: Before: ::) [])
-[]
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 800ms)))
-[]
-   (inj [Command:(cmd grab [h] 1) []])
-   (inj [F_Command:(fact Command After Before 1 1) []])
-   (inj [G:(goal F_Command self nil 1) []])
-   (inj []
-      ; Delay a little to allow predictions for this sampling period before processing.
-      (fact G T0:(+ After 10ms) T0 1 1)
-      [SYNC_ONCE T0 1 forever primary nil]
-   )
-   (prb [1 "print" "injected (cmd grab [h])" []])
-1) |[]
-(ipgm pgm_experimentingA_7 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
-   [SYNC_ONCE now 0 forever primary nil 1]
-
-pgm_experimentingA_8:(pgm [] []
-   ; This fact repeats periodically. We use it as a "heartbeat".
-   (ptn (fact (mk.val h position : :) After: Before: ::) [])
-[]
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 900ms)))
-[]
-   (inj [Command:(cmd release [h] 1) []])
-   (inj [F_Command:(fact Command After Before 1 1) []])
-   (inj [G:(goal F_Command self nil 1) []])
-   (inj []
-      ; Delay a little to allow predictions for this sampling period before processing.
-      (fact G T0:(+ After 10ms) T0 1 1)
-      [SYNC_ONCE T0 1 forever primary nil]
-   )
-   (prb [1 "print" "injected (cmd release [h])" []])
-1) |[]
-(ipgm pgm_experimentingA_8 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
-   [SYNC_ONCE now 0 forever primary nil 1]
-
-pgm_experimentingA_9:(pgm [] []
-   ; This fact repeats periodically. We use it as a "heartbeat".
-   (ptn (fact (mk.val h position : :) After: Before: ::) [])
-[]
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 1000ms)))
-[]
-   (inj [Command:(cmd grab [h] 1) []])
-   (inj [F_Command:(fact Command After Before 1 1) []])
-   (inj [G:(goal F_Command self nil 1) []])
-   (inj []
-      ; Delay a little to allow predictions for this sampling period before processing.
-      (fact G T0:(+ After 10ms) T0 1 1)
-      [SYNC_ONCE T0 1 forever primary nil]
-   )
-   (prb [1 "print" "injected (cmd grab [h])" []])
-1) |[]
-(ipgm pgm_experimentingA_9 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
-   [SYNC_ONCE now 0 forever primary nil 1]
-
-pgm_experimentingA_10:(pgm [] []
-   ; This fact repeats periodically. We use it as a "heartbeat".
-   (ptn (fact (mk.val h position : :) After: Before: ::) [])
-[]
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 1100ms)))
-[]
-   (inj [Command:(cmd move [h (vec3 0 0.5 0)] 1) []])
-   (inj [F_Command:(fact Command After Before 1 1) []])
-   (inj [G:(goal F_Command self nil 1) []])
-   (inj []
-      ; Delay a little to allow predictions for this sampling period before processing.
-      (fact G T0:(+ After 10ms) T0 1 1)
-      [SYNC_ONCE T0 1 forever primary nil]
-   )
-   (prb [1 "print" "injected (cmd move [h (vec3 20 0 0)])" []])
-1) |[]
-(ipgm pgm_experimentingA_10 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever primary nil 1]
 
 pgm_eject_cmd_move:(pgm [] []

--- a/AERA/replicode_v1.2/hand-grab-sphere-learn.external.ur.replicode
+++ b/AERA/replicode_v1.2/hand-grab-sphere-learn.external.ur.replicode
@@ -17,8 +17,8 @@ b_0_is_a_hand:(mk.val b_0 essence hand 1) |[]
 (|fact b_0_is_a_hand 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 
 b_1:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
-b_1_is_a_cube:(mk.val b_1 essence cube 1) |[]
-(fact b_1_is_a_cube 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+b_1_is_a_sphere:(mk.val b_1 essence sphere 1) |[]
+(fact b_1_is_a_sphere 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 b_1_is_a_hand:(mk.val b_1 essence hand 1) |[]
 ; This is needed for S3.
 (|fact b_1_is_a_hand 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
@@ -50,13 +50,13 @@ S3:(cst [] []
 !def p_zero (vec3 0 0 0)
 !def pH0 (vec3 25 0 0)
 !def pS0 p_zero
-!def pS1 (vec3 15 0 0)
+!def pS1 (vec3 -0.5 0.5 0)
 
 ; Execute babble pass A commands.
 !def DRIVE_PASS1_START 1400ms
-!def DRIVE_PASS1_END (+ DRIVE_PASS1_START 400ms)
+!def DRIVE_PASS1_END (+ DRIVE_PASS1_START 200ms)
 ; Execute experimenting pass A commands.
-!def DRIVE_PASS2_START (+ DRIVE_PASS1_END 1100ms)
+!def DRIVE_PASS2_START (+ DRIVE_PASS1_END 1200ms)
 
 start:(pgm [] [] [] []
    (cmd ready ["hand-grab-sphere"] 1)
@@ -78,7 +78,7 @@ pgm_babbleA_1:(pgm [] []
    (>= After (+ this.vw.ijt 100ms))
 []
    ; Move where initial and final positions have no objects so that they are not correlated.
-   (inj [Command:(cmd move [h (vec3 -2.2 0 0.2)] 1) []])
+   (inj [Command:(cmd move [h (vec3 -2.2 0 0)] 1) []])
    (inj [F_Command:(fact Command After Before 1 1) []])
    (inj [G:(goal F_Command self nil 1) []])
    (inj []
@@ -86,7 +86,7 @@ pgm_babbleA_1:(pgm [] []
       (fact G T0:(+ After 10ms) T0 1 1)
       [SYNC_ONCE T0 1 forever primary nil]
    )
-   (prb [1 "print" "injected (cmd move [h (vec3 -2.2 0 0.2)])" []])
+   (prb [1 "print" "injected (cmd move [h (vec3 -2.2 0 0)])" []])
 1) |[]
 (ipgm pgm_babbleA_1 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever primary nil 1]
@@ -198,7 +198,7 @@ pgm_babbleA_7:(pgm [] []
    (>= After (+ this.vw.ijt 700ms))
 []
    ; Move while holding the sphere to learn the re-use model.
-   (inj [Command:(cmd move [h (vec3 -0.9 -1.5 0)] 1) []])
+   (inj [Command:(cmd move [h (vec3 -0.5 0.2 0)] 1) []])
    (inj [F_Command:(fact Command After Before 1 1) []])
    (inj [G:(goal F_Command self nil 1) []])
    (inj []
@@ -206,7 +206,7 @@ pgm_babbleA_7:(pgm [] []
       (fact G T0:(+ After 10ms) T0 1 1)
       [SYNC_ONCE T0 1 forever primary nil]
    )
-   (prb [1 "print" "injected (cmd move [h (vec3 -0.9 -1.5 0)])" []])
+   (prb [1 "print" "injected (cmd move [h (vec3 -0.5 0.2 0)])" []])
 1) |[]
 (ipgm pgm_babbleA_7 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever primary nil 1]
@@ -318,7 +318,7 @@ pgm_babbleA_13:(pgm [] []
    (>= After (+ this.vw.ijt 1300ms))
 []
    ; Move while holding the cube to the initial position for the task and to learn the re-use model.
-   (inj [Command:(cmd move [h (vec3 20 0 0)] 1) []])
+   (inj [Command:(cmd move [h (vec3 0 -1 0)] 1) []])
    (inj [F_Command:(fact Command After Before 1 1) []])
    (inj [G:(goal F_Command self nil 1) []])
    (inj []
@@ -326,7 +326,7 @@ pgm_babbleA_13:(pgm [] []
       (fact G T0:(+ After 10ms) T0 1 1)
       [SYNC_ONCE T0 1 forever primary nil]
    )
-   (prb [1 "print" "injected (cmd move [h (vec3 20 0 0)])" []])
+   (prb [1 "print" "injected (cmd move [h (vec3 0 -1 0)])" []])
 1) |[]
 (ipgm pgm_babbleA_13 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever primary nil 1]
@@ -370,11 +370,30 @@ pgm_inject_drive_pass2:(pgm [] []
 (ipgm pgm_inject_drive_pass2 [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever primary nil 1]
 
-pgm_experimentingA_0:(pgm [] []
+pgm_experimentingA_00:(pgm [] []
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h position : :) After: Before: ::) [])
 []
    (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 0us)))
+[]
+   (inj [Command:(cmd move [h (vec3 -0.5 -1 0)] 1) []])
+   (inj [F_Command:(fact Command After Before 1 1) []])
+   (inj [G:(goal F_Command self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before processing.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected (cmd move [h (vec3 -0.5 -1 0)])" []])
+1) |[]
+(ipgm pgm_experimentingA_00 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_experimentingA_0:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h position : :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 100us)))
 []
    (inj [Command:(cmd release [h] 1) []])
    (inj [F_Command:(fact Command After Before 1 1) []])
@@ -393,9 +412,9 @@ pgm_experimentingA_1:(pgm [] []
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h position : :) After: Before: ::) [])
 []
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 100us)))
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 200us)))
 []
-   (inj [Command:(cmd move [h (vec3 -15 0 0)] 1) []])
+   (inj [Command:(cmd move [h (vec3 0.5 1 0)] 1) []])
    (inj [F_Command:(fact Command After Before 1 1) []])
    (inj [G:(goal F_Command self nil 1) []])
    (inj []
@@ -403,7 +422,7 @@ pgm_experimentingA_1:(pgm [] []
       (fact G T0:(+ After 10ms) T0 1 1)
       [SYNC_ONCE T0 1 forever primary nil]
    )
-   (prb [1 "print" "injected (cmd move [h (vec3 -15 0 0)])" []])
+   (prb [1 "print" "injected (cmd move [h (vec3 0.5 1 0)])" []])
 1) |[]
 (ipgm pgm_experimentingA_1 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
    [SYNC_ONCE now 0 forever primary nil 1]
@@ -412,7 +431,7 @@ pgm_experimentingA_2:(pgm [] []
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h position : :) After: Before: ::) [])
 []
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 200ms)))
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 300ms)))
 []
    (inj [Command:(cmd grab [h] 1) []])
    (inj [F_Command:(fact Command After Before 1 1) []])
@@ -431,7 +450,7 @@ pgm_experimentingA_3:(pgm [] []
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h position : :) After: Before: ::) [])
 []
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 300ms)))
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 400ms)))
 []
    (inj [Command:(cmd release [h] 1) []])
    (inj [F_Command:(fact Command After Before 1 1) []])
@@ -450,7 +469,7 @@ pgm_experimentingA_4:(pgm [] []
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h position : :) After: Before: ::) [])
 []
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 400ms)))
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 500ms)))
 []
    (inj [Command:(cmd grab [h] 1) []])
    (inj [F_Command:(fact Command After Before 1 1) []])
@@ -469,7 +488,7 @@ pgm_experimentingA_5:(pgm [] []
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h position : :) After: Before: ::) [])
 []
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 500ms)))
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 600ms)))
 []
    (inj [Command:(cmd release [h] 1) []])
    (inj [F_Command:(fact Command After Before 1 1) []])
@@ -488,9 +507,9 @@ pgm_experimentingA_6:(pgm [] []
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h position : :) After: Before: ::) [])
 []
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 600ms)))
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 700ms)))
 []
-   (inj [Command:(cmd move [h (vec3 5 0 0)] 1) []])
+   (inj [Command:(cmd move [h (vec3 -0.5 -1 0)] 1) []])
    (inj [F_Command:(fact Command After Before 1 1) []])
    (inj [G:(goal F_Command self nil 1) []])
    (inj []
@@ -507,7 +526,7 @@ pgm_experimentingA_7:(pgm [] []
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h position : :) After: Before: ::) [])
 []
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 700ms)))
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 800ms)))
 []
    (inj [Command:(cmd grab [h] 1) []])
    (inj [F_Command:(fact Command After Before 1 1) []])
@@ -526,7 +545,7 @@ pgm_experimentingA_8:(pgm [] []
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h position : :) After: Before: ::) [])
 []
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 800ms)))
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 900ms)))
 []
    (inj [Command:(cmd release [h] 1) []])
    (inj [F_Command:(fact Command After Before 1 1) []])
@@ -545,7 +564,7 @@ pgm_experimentingA_9:(pgm [] []
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h position : :) After: Before: ::) [])
 []
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 900ms)))
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 1000ms)))
 []
    (inj [Command:(cmd grab [h] 1) []])
    (inj [F_Command:(fact Command After Before 1 1) []])
@@ -564,9 +583,9 @@ pgm_experimentingA_10:(pgm [] []
    ; This fact repeats periodically. We use it as a "heartbeat".
    (ptn (fact (mk.val h position : :) After: Before: ::) [])
 []
-   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 1000ms)))
+   (>= After (+ this.vw.ijt (+ DRIVE_PASS1_END 1100ms)))
 []
-   (inj [Command:(cmd move [h (vec3 20 0 0)] 1) []])
+   (inj [Command:(cmd move [h (vec3 0 0.5 0)] 1) []])
    (inj [F_Command:(fact Command After Before 1 1) []])
    (inj [G:(goal F_Command self nil 1) []])
    (inj []

--- a/AERA/replicode_v1.2/user.classes.replicode
+++ b/AERA/replicode_v1.2/user.classes.replicode
@@ -5,6 +5,7 @@
 !class (vec2 x:nb y:nb)
 !class (vec3 x:nb y:nb z:nb)
 !class (vec vals:[])
+!class (quat x:nb y:nb z:nb w:nb)
 !class (speech_context (_obj {speaker:ent listener:ent}))
 
 !class (Ping (_obj {object:}))
@@ -28,6 +29,7 @@
 !dfn (grab :); arg0: an object.
 !dfn (release :); arg0: an object.
 !dfn (move :); arg0: an object, arg1: target position
+!dfn (rotate :); arg0: an object, ag1: target rotation
 !dfn (set_velocity_y :); arg0: an object, arg1: velocity.
 !dfn (set_acceleration_y :); arg0: an object, arg1: acceleration.
 !dfn (move_y_plus :); arg0: an object.
@@ -35,6 +37,7 @@
 !dfn (set_force_y :); arg0: an object, arg1: force.
 !dfn (set_state :); arg0: an object, arg1: the state.
 !dfn (tick :)
+!dfn (measure :); arg0: an entity to measure. e.g. measure [camera] to take a measurement with the camera.
 
 ; The sampling_period should be 2 * base_period, where base_period is from settings.xml.
 !def sampling_period 100ms
@@ -70,6 +73,7 @@ theta_z:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
 omega_x:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
 omega_y:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
 omega_z:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+rotation:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
 
 
 attachment:(ont 1) [[SYNC_ONCE now 0 forever root nil]]; usage: (mk.val self_right_hand attachment a_thing 1)
@@ -91,3 +95,7 @@ hand:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
 head:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
 cube:(ont 1) [[SYNC_ONCE now 1 forever root nil]]
 sphere:(ont 1) [[SYNC_ONCE now 1 forever root nil]]
+camera:(ont 1) [[SYNC_ONCE now 1 forever root nil]]
+red_box:(ont 1) [[SYNC_ONCE now 1 forever root nil]]
+green_box:(ont 1) [[SYNC_ONCE now 1 forever root nil]]
+blue_box:(ont 1) [[SYNC_ONCE now 1 forever root nil]]

--- a/doc/meeting-notes.txt
+++ b/doc/meeting-notes.txt
@@ -1087,10 +1087,11 @@ Simulator
 * DONE. Merge request to fix bug in abstract_f_ihlp (for Arash) https://github.com/IIIM-IS/AERA/pull/262
 
 next meeting
-* PTPX to accept objects with same "property-value"
+* DONE. PTPX to accept objects with same "attribute, value"
 * DONE. Make pull request to fix bug initializing CST binding map https://github.com/IIIM-IS/AERA/pull/260
 * Webots
-  * Re-add (possibly as a hack) moves limited to distance of 20.
+  * Set tpx_time_horizon="100000"
+  * Put a tray at the goal position (if not too hard) [Leonard]
   * Generalize CTPX for all strucured types (vec2, vec3, vec [], etc.) [Leonard]
   * Align aera_us with AERA time.
   * Use setup command for automatic discovery of AERA objects and commands

--- a/doc/meeting-notes.txt
+++ b/doc/meeting-notes.txt
@@ -1090,11 +1090,9 @@ next meeting
 * PTPX to accept objects with same "property-value"
 * DONE. Make pull request to fix bug initializing CST binding map https://github.com/IIIM-IS/AERA/pull/260
 * Webots
-  * Put a tray at goal position.
   * Re-add (possibly as a hack) moves limited to distance of 20.
   * Generalize CTPX for all strucured types (vec2, vec3, vec [], etc.) [Leonard]
   * Align aera_us with AERA time.
-  * Let AERA send "reset" message to reset the environment. (Use after grab fails.)
   * Use setup command for automatic discovery of AERA objects and commands
   * Get command efferent copy from Webots (move limit to +/- 20) [Maybe in the setup message or command reply. Need more discussion]
   * Try camera

--- a/doc/meeting-notes.txt
+++ b/doc/meeting-notes.txt
@@ -1089,17 +1089,22 @@ Simulator
 2023-07-27
 * DONE. Merge request for PTPX to accept objects with same "attribute, value" https://github.com/IIIM-IS/AERA/pull/263
 
+2023-08-10
+* DONE. Look for the AERA code for removing a model for disuse.
+  RESULT: Model view is "forever". I think it is not implemented. Couldn't find this described in the Replicode Tech Report.
+* Webots
+  * DONE. Try camera [Leonard]
+
 next meeting
 * DONE. Make pull request to fix bug initializing CST binding map https://github.com/IIIM-IS/AERA/pull/260
 * Webots
-  * Set tpx_time_horizon="100000"
-  * Put a tray at the goal position (if not too hard) [Leonard]
+  * Put a tray at the goal position
+  * Put boxes at initial position
   * Generalize CTPX for all strucured types (vec2, vec3, vec [], etc.) [Leonard]
   * Align aera_us with AERA time.
   * Use setup command for automatic discovery of AERA objects and commands
   * Get command efferent copy from Webots (move limit to +/- 20) [Maybe in the setup message or command reply. Need more discussion]
-  * Try camera
-* Demonstrate AERA removing model for disuse.
+  * Try Webots streaming to the Visualize [Chloe]
 * hand-grab-sphere
   * Represent sphere position without direct I/O input.
   * Make AERA take experimenting actions to test candidate PTPX models (instead of seed commands).

--- a/doc/meeting-notes.txt
+++ b/doc/meeting-notes.txt
@@ -1086,8 +1086,10 @@ Simulator
 2023-07-13
 * DONE. Merge request to fix bug in abstract_f_ihlp (for Arash) https://github.com/IIIM-IS/AERA/pull/262
 
+2023-07-27
+* DONE. Merge request for PTPX to accept objects with same "attribute, value" https://github.com/IIIM-IS/AERA/pull/263
+
 next meeting
-* DONE. PTPX to accept objects with same "attribute, value"
 * DONE. Make pull request to fix bug initializing CST binding map https://github.com/IIIM-IS/AERA/pull/260
 * Webots
   * Set tpx_time_horizon="100000"

--- a/doc/meeting-notes.txt
+++ b/doc/meeting-notes.txt
@@ -1078,14 +1078,23 @@ Simulator
   * Make CTPX work with vec3 for the move model DeltaP.
     * DONE. Add temporary special case in CTPX for vec3. [Jeff]
 
-next meeting
-* Cisco demo: Traceroute.
+2023-07-06
+* DONE. Merge pull request to fix out-of-bounds error (seen by Chloe) https://github.com/IIIM-IS/AERA/pull/261
 * Webots
-  * Make CTPX work with vec3 for the move model DeltaP.
-    * Generalize CTPX for all strucured types. [Leonard]
+  * DONE. Make CTPX work with vec3 for the move model DeltaP.
+
+next meeting
+* 5 slides for simple "hand" demo.
+* PTPX to accept objects with same "property-value"
+* DONE. Make pull request to fix bug initializing CST binding map https://github.com/IIIM-IS/AERA/pull/260
+* Cisco demo: Traceroute.
+  * Abduction to reconfigure route.
+* Webots
+  * Put a tray at goal position.
+  * Re-add (possibly as a hack) moves limited to distance of 20.
+  * Generalize CTPX for all strucured types (vec2, vec3, vec [], etc.) [Leonard]
+  * Align aera_us with AERA time.
   * Let AERA send "reset" message to reset the environment. (Use after grab fails.)
-  * init() should "instantly" set the arm position. Right now it moves to the init position and can hit objects.
-  * (Added hack to reset positions after release.)
   * Use setup command for automatic discovery of AERA objects and commands
   * Get command efferent copy from Webots (move limit to +/- 20) [Maybe in the setup message or command reply. Need more discussion]
   * Try camera

--- a/doc/meeting-notes.txt
+++ b/doc/meeting-notes.txt
@@ -1083,12 +1083,12 @@ Simulator
 * Webots
   * DONE. Make CTPX work with vec3 for the move model DeltaP.
 
+2023-07-13
+* DONE. Merge request to fix bug in abstract_f_ihlp (for Arash) https://github.com/IIIM-IS/AERA/pull/262
+
 next meeting
-* 5 slides for simple "hand" demo.
 * PTPX to accept objects with same "property-value"
 * DONE. Make pull request to fix bug initializing CST binding map https://github.com/IIIM-IS/AERA/pull/260
-* Cisco demo: Traceroute.
-  * Abduction to reconfigure route.
 * Webots
   * Put a tray at goal position.
   * Re-add (possibly as a hack) moves limited to distance of 20.

--- a/doc/meeting-notes.txt
+++ b/doc/meeting-notes.txt
@@ -1069,22 +1069,26 @@ Simulator
 * DONE. Make hand-grab-sphere work with (vec [25 0 0]) .
 * Webots
 
-next meeting
+2023-06-09
 * DONE. Make pull request for bound objects with sub-structures https://github.com/IIIM-IS/AERA/pull/257
 * Webots
   * DONE. Update AERA_Webots to use the AERA_Protobuf submodule https://github.com/IIIM-IS/AERA_Webots/pull/10
   * DONE. Put code in usr_operators in a namespace. Implement vec3 div. (No conflict with Windows div.)
+  * DONE (side effect). Reset the TCP connection when resetting the Webots simulation
   * Make CTPX work with vec3 for the move model DeltaP.
     * DONE. Add temporary special case in CTPX for vec3. [Jeff]
-    * Generalize CTPX for all strucured types.
+
+next meeting
+* Cisco demo: Traceroute.
+* Webots
+  * Make CTPX work with vec3 for the move model DeltaP.
+    * Generalize CTPX for all strucured types. [Leonard]
   * Let AERA send "reset" message to reset the environment. (Use after grab fails.)
-  * init() should "instantly" set the arm position. Right now it move to the init position and can hit objects.
+  * init() should "instantly" set the arm position. Right now it moves to the init position and can hit objects.
   * (Added hack to reset positions after release.)
   * Use setup command for automatic discovery of AERA objects and commands
   * Get command efferent copy from Webots (move limit to +/- 20) [Maybe in the setup message or command reply. Need more discussion]
-  * Reset the TCP connection when resetting the Webots simulation
   * Try camera
-* Cisco demo: Traceroute.
 * Demonstrate AERA removing model for disuse.
 * hand-grab-sphere
   * Represent sphere position without direct I/O input.

--- a/r_code/object.cpp
+++ b/r_code/object.cpp
@@ -303,6 +303,29 @@ void SysObject::trace(std::ostream& out) const {
 
 void SysObject::trace() const { trace(std::cout); }
 
+void Code::r_trace(ostream& out) const {
+  trace(out);
+
+  if (references_size() < 1)
+    // Done recursing.
+    return;
+
+  auto obj = get_reference(0);
+  if (obj->code_size() <= 2)
+    // Assume this is an ent or ont.
+    return;
+
+  switch (obj->code(0).getDescriptor()) {
+  case Atom::MODEL:
+  case Atom::COMPOSITE_STATE:
+    // Don't trace these big structures.
+    return;
+  }
+
+  out << endl;
+  obj->r_trace(out);
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 Mem *Mem::singleton_ = NULL;

--- a/r_code/object.cpp
+++ b/r_code/object.cpp
@@ -146,7 +146,7 @@ uint32 SysView::get_size() const {
   return 2 + code_.size() + references_.size();
 }
 
-void SysView::trace(std::ostream& out) {
+void SysView::trace(std::ostream& out) const {
 
   out << " code size: " << code_.size() << std::endl;
   out << " reference set size: " << references_.size() << std::endl;
@@ -259,7 +259,7 @@ uint32 SysObject::get_size() {
   return 5 + code_.size() + references_.size() + markers_.size() + view_set_size;
 }
 
-void SysObject::trace(std::ostream& out) {
+void SysObject::trace(std::ostream& out) const {
 
   out << "\n---object---\n";
   out << oid_ << std::endl;
@@ -301,7 +301,7 @@ void SysObject::trace(std::ostream& out) {
   }
 }
 
-void SysObject::trace() { trace(std::cout); }
+void SysObject::trace() const { trace(std::cout); }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/r_code/object.h
+++ b/r_code/object.h
@@ -344,6 +344,25 @@ public:
     trace(i, out, context);
     return out.str();
   }
+
+  /**
+   * Recursively call trace(out) to print the trace of this Code to the out stream, along
+   * the trace of each get_reference(0). (This doesn't print the trace of get_reference(0) if
+   * it is a mdl, cst, ent or ont.) This is useful, for example, to trace a fact as well as the
+   * mk.val it references.
+   */
+  void r_trace(std::ostream& out) const;
+
+  void r_trace() const { r_trace(std::cout); }
+
+  /**
+   * Return the r_trace as a string. For debugging purposes only (can be inefficient).
+   */
+  std::string r_trace_string() const {
+    std::ostringstream out;
+    r_trace(out);
+    return out.str();
+  }
 };
 
 // Implementation for local objects (non distributed).

--- a/r_code/object.h
+++ b/r_code/object.h
@@ -110,7 +110,7 @@ public:
 
   virtual void write(word32 *data) = 0;
   virtual void read(word32 *data) = 0;
-  virtual void trace(std::ostream& out) = 0;
+  virtual void trace(std::ostream& out) const = 0;
 };
 
 class _View;
@@ -124,7 +124,7 @@ public:
   void write(word32 *data) override;
   void read(word32 *data) override;
   uint32 get_size() const;
-  void trace(std::ostream& out) override;
+  void trace(std::ostream& out) const override;
 #ifdef WITH_DETAIL_OID
   int detail_oid_;
 #endif
@@ -152,8 +152,8 @@ public:
   void write(word32 *data) override;
   void read(word32 *data) override;
   uint32 get_size();
-  void trace(std::ostream& out) override;
-  void trace();
+  void trace(std::ostream& out)const override;
+  void trace() const;
 };
 
 // Interfaces for r_exec classes ////////////////////////////////////////////////////////////////////////
@@ -327,7 +327,7 @@ public:
   void trace() const { trace(std::cout); }
 
   /**
-   * Return the trace as a string. For debugging purposes only(can be inefficient).
+   * Return the trace as a string. For debugging purposes only (can be inefficient).
    */
   std::string trace_string() const {
     std::ostringstream out;

--- a/r_comp/decompiler.cpp
+++ b/r_comp/decompiler.cpp
@@ -271,6 +271,9 @@ uint32 Decompiler::decompile_references(r_comp::Image *image, unordered_map<uint
     if (n != image->object_names_.symbols_.end())
       // Already set the user-defined name in the first pass.
       continue;
+    if (object_names_.find(i) != object_names_.end())
+      // Already assigned by the passed-in object_names.
+      continue;
 
     Class *c = metadata_->get_class(sys_object->code_[0].asOpcode());
     string className = c->str_opcode;

--- a/r_comp/segments.h
+++ b/r_comp/segments.h
@@ -124,6 +124,7 @@ public:
   r_code::resized_vector<std::string> operator_names_;
   r_code::resized_vector<std::string> function_names_;
   r_code::resized_vector<Class> classes_by_opcodes_; // classes indexed by opcodes; used to retrieve member names; registers all classes (incl. set classes).
+  r_code::resized_vector<uint16> usr_classes_;
 
   Class *get_class(std::string &class_name);
   Class *get_class(uint16 opcode);

--- a/r_exec/binding_map.cpp
+++ b/r_exec/binding_map.cpp
@@ -403,7 +403,7 @@ _Fact *BindingMap::abstract_f_ihlp(const _Fact *f_ihlp) const { // bindings are 
 
   _ihlp->code(I_HLP_ARITY) = ihlp->code(I_HLP_ARITY);
 
-  _ihlp->add_reference(f_ihlp->get_reference(f_ihlp->code(I_HLP_OBJ).asIndex()));
+  _ihlp->add_reference(ihlp->get_reference(ihlp->code(I_HLP_OBJ).asIndex()));
 
   _f_ihlp->add_reference(_ihlp);
   return _f_ihlp;

--- a/r_exec/binding_map.cpp
+++ b/r_exec/binding_map.cpp
@@ -510,7 +510,9 @@ void BindingMap::abstract_member(const Code *object, uint16 index, Code *abstrac
     break;
   }case Atom::I_PTR:
     // If there is a SET or an OBJECT, then we use its structure.
-    if (object->code(ai).getDescriptor() == Atom::SET || object->code(ai).getDescriptor() == Atom::OBJECT) {
+    if (hasUserDefinedOperators(object->code(ai).asOpcode()))
+      abstracted_object->code(write_index) = get_structure_variable(object, ai);
+    else if (object->code(ai).getDescriptor() == Atom::SET || object->code(ai).getDescriptor() == Atom::OBJECT) {
 
       abstracted_object->code(write_index) = Atom::IPointer(extent_index);
 

--- a/r_exec/binding_map.cpp
+++ b/r_exec/binding_map.cpp
@@ -977,14 +977,8 @@ void HLPBindingMap::init_from_pattern(const Code *source) { // source is abstrac
   for (uint16 i = 1; i < source->code_size(); ++i) {
 
     Atom s = source->code(i);
-    switch (s.getDescriptor()) {
-    case Atom::VL_PTR: {
-      uint8 value_index = source->code(i).asIndex();
-      add_unbound_value(value_index);
-      break;
-    }default:
-      break;
-    }
+    if (s.getDescriptor() == Atom::VL_PTR)
+      add_unbound_value(s.asIndex());
   }
 
   for (uint16 i = 0; i < source->references_size(); ++i)

--- a/r_exec/binding_map.cpp
+++ b/r_exec/binding_map.cpp
@@ -365,7 +365,7 @@ bool ObjectValue::contains(const Code *o) const {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-_Fact *BindingMap::abstract_f_ihlp(_Fact *f_ihlp) const { // bindings are set already (coming from a mk.rdx caught by auto-focus).
+_Fact *BindingMap::abstract_f_ihlp(const _Fact *f_ihlp) const { // bindings are set already (coming from a mk.rdx caught by auto-focus).
 
   uint16 opcode;
   Code *ihlp = f_ihlp->get_reference(0);

--- a/r_exec/binding_map.h
+++ b/r_exec/binding_map.h
@@ -288,7 +288,7 @@ public:
 
   void init(const r_code::Code *object, uint16 index);
 
-  _Fact *abstract_f_ihlp(_Fact *fact) const; // for icst and imdl.
+  _Fact *abstract_f_ihlp(const _Fact *fact) const; // for icst and imdl.
 
   /**
    * Fill in the fresh fact object as an abstract copy of the original fact, creating new bindings as needed.

--- a/r_exec/binding_map.h
+++ b/r_exec/binding_map.h
@@ -397,7 +397,22 @@ private:
   bool match_bwd_timings(const _Fact *f_object, const _Fact *f_pattern);
 
   bool need_binding(r_code::Code *pattern) const;
-  void init_from_pattern(const r_code::Code *source, int16 position); // first source is f->obj.
+
+  /**
+   * If source->code(FACT_AFTER) and source->code(FACT_BEFORE) are VL_PTR, then set the respective
+   * after_index and before_index.
+   */
+  void init_timing_indexes(const r_code::Code* source, int16& after_index, int16& before_index) {
+    if (source->code_size() <= FACT_BEFORE)
+      // We don't expect this.
+      return;
+    if (source->code(FACT_AFTER).getDescriptor() == Atom::VL_PTR)
+      after_index = source->code(FACT_AFTER).asIndex();
+    if (source->code(FACT_BEFORE).getDescriptor() == Atom::VL_PTR)
+      before_index = source->code(FACT_BEFORE).asIndex();
+  }
+
+  void init_from_pattern(const r_code::Code *source);
 
   /**
    * Scan the structure in hlp at structure_index and call add_unbound_value for each VL_PTR.

--- a/r_exec/factory.cpp
+++ b/r_exec/factory.cpp
@@ -925,4 +925,19 @@ bool ICST::contains(const _Fact *component, uint16 &component_index) const {
 
   return false;
 }
+
+bool ICST::r_contains(const _Fact* component) const {
+
+  for (auto i = components_.begin(); i != components_.end(); ++i) {
+    if (*i == component)
+      return true;
+
+    if ((*i)->get_reference(0)->code(0).asOpcode() == Opcodes::ICst &&
+        ((ICST*)(*i)->get_reference(0))->r_contains(component))
+      return true;
+  }
+
+  return false;
+}
+
 }

--- a/r_exec/factory.h
+++ b/r_exec/factory.h
@@ -614,7 +614,21 @@ public:
 
   bool is_invalidated() override;
 
+  /**
+   * Check if the components_ contains the given component. This does not recurse.
+   * \param component The component to search for. This checks for the exact object (not a match).
+   * \param component_index If this returns true, set component_index to the index of the found component.
+   * \return True if found the component.
+   */
   bool contains(const _Fact *component, uint16 &component_index) const;
+
+  /**
+   * Check if the components_ or any sub icst contains the give component. (If a component is an f_icst, this
+   * recursively calls itself.)
+   * \param component The component to search for. This checks for the exact object (not a match).
+   * \return True if found the component.
+   */
+  bool r_contains(const _Fact* component) const;
 
   P<BindingMap> bindings_;
   std::vector<P<_Fact> > components_; // the inputs that triggered the building of the icst.

--- a/r_exec/init.cpp
+++ b/r_exec/init.cpp
@@ -490,7 +490,7 @@ static bool Init(FunctionLibrary* userOperatorLibrary,
 
   // Operators.
   typedef uint16 (*OpcodeRetriever)(const char *);
-  typedef void (*UserInit)(OpcodeRetriever);
+  typedef r_code::resized_vector<uint16> (*UserInit)(OpcodeRetriever);
   auto _Init = (UserInit)userOperatorLibrary->getFunction("Init");
   if (!_Init)
     return false;
@@ -505,7 +505,7 @@ static bool Init(FunctionLibrary* userOperatorLibrary,
   if (!GetOperatorName)
     return false;
 
-  _Init(RetrieveOpcode);
+  Metadata.usr_classes_ = _Init(RetrieveOpcode);
 
   typedef bool (*UserOperator)(const Context &);
 
@@ -629,4 +629,17 @@ std::string GetAxiomName(const uint16 index) {
 
   return Compiler.getObjectName(index);
 }
+
+bool hasUserDefinedOperators(const uint16 opcode) {
+  const std::vector<uint16> *usr_defined_opcodes = Metadata.usr_classes_.as_std();
+  return std::find(usr_defined_opcodes->begin(), usr_defined_opcodes->end(), opcode) != usr_defined_opcodes->end();
+}
+
+bool hasUserDefinedOperators(const std::string class_name) {
+  if (_Opcodes.find(class_name) == _Opcodes.end()) {
+    return false;
+  }
+  return hasUserDefinedOperators(_Opcodes[class_name]);
+}
+
 }

--- a/r_exec/init.h
+++ b/r_exec/init.h
@@ -236,6 +236,10 @@ bool r_exec_dll Init(FunctionLibrary* userOperatorLibrary,
 uint16 r_exec_dll GetOpcode(const char *name); // classes, operators and functions.
 
 std::string r_exec_dll GetAxiomName(const uint16 index); // for constant objects (ex: self, position, and other axioms).
+
+bool r_exec_dll hasUserDefinedOperators(const std::string class_name);
+
+bool r_exec_dll hasUserDefinedOperators(const uint16 opcode);
 }
 
 

--- a/r_exec/mem.cpp
+++ b/r_exec/mem.cpp
@@ -571,6 +571,7 @@ bool DiagnosticTimeState::step() {
     size_t n_jobs_to_run = min(reduction_job_queue_.size(), max_reduction_jobs_per_cycle);
     if (n_jobs_to_run > 0) {
       if (reduction_job_queue_index_ < n_jobs_to_run) {
+        // Add breakpoint here to check which reduction job leads to the failure.
         reduction_job_queue_[reduction_job_queue_index_]->update(Now());
         reduction_job_queue_[reduction_job_queue_index_] = NULL;
         ++reduction_job_queue_index_;
@@ -837,6 +838,33 @@ View* _Mem::inject_marker_value_from_io_device(
 }
 
 View* _Mem::inject_marker_value_from_io_device(
+  Code* obj, Code* prop, std::vector<Atom> val, Timestamp after, Timestamp before,
+  View::SyncMode sync_mode, Code* group)
+{
+  if (!obj || !prop)
+    // We don't expect this, but sanity check.
+    return NULL;
+
+  Code* object = new LObject(this);
+  uint16 extent_index = 4;
+  object->code(0) = Atom::Marker(GetOpcode("mk.val"), 4); // Caveat: arity does not include the opcode.
+  object->code(1) = Atom::RPointer(0); // obj
+  object->code(2) = Atom::RPointer(1); // prop
+  object->code(3) = Atom::IPointer(++extent_index);
+  object->code(4) = Atom::Float(1); // psln_thr.
+
+
+  object->set_reference(0, obj);
+  object->set_reference(1, prop);
+  object->code(extent_index) = Atom::Set(val.size());
+  for (uint16 i = 0; i < val.size(); ++i) {
+    object->code(++extent_index) = val[i];
+  }
+
+  return inject_fact_from_io_device(object, after, before, sync_mode, group);
+}
+
+View* _Mem::inject_marker_value_from_io_device(
   Code* obj, Code* prop, Code* val, Timestamp after, Timestamp before,
   View::SyncMode sync_mode, Code* group)
 {
@@ -854,6 +882,28 @@ View* _Mem::inject_marker_value_from_io_device(
   object->set_reference(0, obj);
   object->set_reference(1, prop);
   object->set_reference(2, val);
+
+  return inject_fact_from_io_device(object, after, before, sync_mode, group);
+}
+
+View* _Mem::inject_marker_value_from_io_device(
+  Code* obj, Code* prop, const std::string& val, Timestamp after, Timestamp before, View::SyncMode sync_mode, Code* group)
+{
+  if (!obj || !prop)
+    // We don't expect this, but sanity check.
+    return NULL;
+
+  Code* object = new LObject(this);
+  uint16 extent_index = 4;
+  object->code(0) = Atom::Marker(GetOpcode("mk.val"), 4); // Caveat: arity does not include the opcode.
+  object->code(1) = Atom::RPointer(0); // obj
+  object->set_reference(0, obj);
+  object->code(2) = Atom::RPointer(1); // prop
+  object->set_reference(1, prop);
+  object->code(3) = Atom::IPointer(++extent_index); // val
+  object->code(4) = Atom::Float(1); // psln_thr.
+
+  Utils::SetString<Code>(object, 3, val);
 
   return inject_fact_from_io_device(object, after, before, sync_mode, group);
 }

--- a/r_exec/mem.cpp
+++ b/r_exec/mem.cpp
@@ -885,6 +885,32 @@ View* _Mem::inject_marker_value_from_io_device(
   return inject_fact_from_io_device(object, after, before, sync_mode, group);
 }
 
+View* _Mem::inject_marker_value_from_io_device(
+  Code* obj, Code* prop, uint16 opcode, const vector<Atom>& vals, Timestamp after, Timestamp before,
+  View::SyncMode sync_mode, Code* group)
+{
+  if (!obj || !prop)
+    // We don't expect this, but sanity check.
+    return NULL;
+
+  Code* object = new LObject(this);
+  uint16 extent_index = 4;
+  object->code(0) = Atom::Marker(GetOpcode("mk.val"), 4); // Caveat: arity does not include the opcode.
+  object->code(1) = Atom::RPointer(0); // obj
+  object->set_reference(0, obj);
+  object->code(2) = Atom::RPointer(1); // prop
+  object->set_reference(1, prop);
+  object->code(3) = Atom::IPointer(++extent_index); // val
+  object->code(4) = Atom::Float(1); // psln_thr.
+
+  object->code(extent_index++) = Atom::Object(opcode, vals.size());
+  for (uint16 i = 0; i < vals.size(); ++i) {
+    object->code(extent_index++) = vals[i];
+  }
+
+  return inject_fact_from_io_device(object, after, before, sync_mode, group);
+}
+
 View* _Mem::inject_fact_from_io_device(
   Code* object, Timestamp after, Timestamp before, View::SyncMode sync_mode,
   Code* group)

--- a/r_exec/mem.h
+++ b/r_exec/mem.h
@@ -335,6 +335,25 @@ public:
 
   /**
    * Inject (fact (mk.val obj prop val 1) after before 1 1)
+   * [sync_mode after 1 1 group nil]
+   * where val is a set of Atoms.
+   * This is called from the I/O device to call the normal inject(view), then
+   * log the injection event.
+   * \param obj The object for the mk.val.
+   * \param prop The property for the mk.val.
+   * \param val The Atom value for the mk.val, such as Atom::Float(1).
+   * \param after The start of the fact time interval.
+   * \param before The end of the fact time interval.
+   * \param sync_mode The view sync mode, such as View::SYNC_PERIODIC.
+   * \param group The group of the view, such as get_stdin().
+   * \return The created View.
+   */
+  View* _Mem::inject_marker_value_from_io_device(
+    r_code::Code* obj, r_code::Code* prop, std::vector<Atom> val, Timestamp after, Timestamp before,
+    View::SyncMode sync_mode, r_code::Code* group);
+
+  /**
+   * Inject (fact (mk.val obj prop val 1) after before 1 1)
    * [sync_mode after 1 1 stdin nil]
    * where val is a simple Atom.
    * This is called from the I/O device to call the normal inject(view), then
@@ -478,6 +497,89 @@ public:
   {
     return inject_marker_value_from_io_device(
       obj, prop, val, after, before, View::SYNC_PERIODIC, get_stdin());
+  }
+
+  /**
+   * Inject (fact (mk.val obj prop val 1) after before 1 1)
+   * [sync_mode after 1 1 group nil]
+   * where val is a string object.
+   * This is called from the I/O device to call the normal inject(view), then
+   * log the injection event.
+   * \param obj The object for the mk.val.
+   * \param prop The property for the mk.val.
+   * \param val The value for the mk.val, which is a string object. This will
+   * add it to the references of the mkval.
+   * \param after The start of the fact time interval.
+   * \param before The end of the fact time interval.
+   * \param sync_mode The view sync mode, such as View::SYNC_PERIODIC.
+   * \param group The group of the view, such as get_stdin().
+   * \return The created View.
+   */
+  View* inject_marker_value_from_io_device(
+    r_code::Code* obj, r_code::Code* prop, const std::string& val, Timestamp after, Timestamp before,
+    View::SyncMode sync_mode, r_code::Code* group);
+
+  /**
+   * Inject (fact (mk.val obj prop val 1) after before 1 1)
+   * [sync_mode after 1 1 stdin nil]
+   * where val is a string object.
+   * This is called from the I/O device to call the normal inject(view), then
+   * log the injection event.
+   * \param obj The object for the mk.val.
+   * \param prop The property for the mk.val.
+   * \param val The value for the mk.val, which is a string object. This will
+   * add it to the references of the mkval.
+   * \param after The start of the fact time interval.
+   * \param before The end of the fact time interval.
+   * \param sync_mode The view sync mode, such as View::SYNC_PERIODIC.
+   * \return The created View.
+   */
+  View* inject_marker_value_from_io_device(
+    r_code::Code* obj, r_code::Code* prop, const std::string& val, Timestamp after, Timestamp before,
+    View::SyncMode sync_mode)
+  {
+    return inject_marker_value_from_io_device(obj, prop, val, after, before, sync_mode, get_stdin());
+  }
+
+  /**
+   * Inject (fact (mk.val obj prop val 1) after before 1 1)
+   * [SYNC_PERIODIC after 1 1 group nil]
+   * where val is a string object.
+   * This is called from the I/O device to call the normal inject(view), then
+   * log the injection event.
+   * \param obj The object for the mk.val.
+   * \param prop The property for the mk.val.
+   * \param val The value for the mk.val, which is a string object. This will
+   * add it to the references of the mkval.
+   * \param after The start of the fact time interval.
+   * \param before The end of the fact time interval.
+   * \param group The group of the view, such as get_stdin().
+   * \return The created View.
+   */
+  View* inject_marker_value_from_io_device(
+    r_code::Code* obj, r_code::Code* prop, const std::string& val, Timestamp after, Timestamp before, r_code::Code* group)
+  {
+    return inject_marker_value_from_io_device(obj, prop, val, after, before, View::SYNC_PERIODIC, group);
+  }
+
+  /**
+   * Inject (fact (mk.val obj prop val 1) after before 1 1)
+   * [SYNC_PERIODIC after 1 1 stdin nil]
+   * where val is a string object.
+   * This is called from the I/O device to call the normal inject(view), then
+   * log the injection event.
+   * \param obj The object for the mk.val.
+   * \param prop The property for the mk.val.
+   * \param val The value for the mk.val, which is a string object. This will
+   * add it to the references of the mkval.
+   * \param after The start of the fact time interval.
+   * \param before The end of the fact time interval.
+   * \return The created View.
+   */
+  View* inject_marker_value_from_io_device(
+    r_code::Code* obj, r_code::Code* prop, const std::string& val, Timestamp after, Timestamp before)
+  {
+    return inject_marker_value_from_io_device(obj, prop, val, after, before, View::SYNC_PERIODIC, get_stdin());
   }
 
   /**

--- a/r_exec/mem.h
+++ b/r_exec/mem.h
@@ -503,7 +503,7 @@ public:
   /**
    * Inject (fact (mk.val obj prop [o1 o2] 1) after before 1 1)
    * [sync_mode after 1 1 stdin nil]
-   * where val is a referenced Code object.
+   * where val is a set of referenced Code objects.
    * This is called from the I/O device to call the normal inject(view), then
    * log the injection event.
    * \param obj The object for the mk.val.
@@ -525,7 +525,7 @@ public:
   /**
    * Inject (fact (mk.val obj prop [o1 o2] 1) after before 1 1)
    * [SYNC_PERIODIC after 1 1 group nil]
-   * where val is a referenced Code object.
+   * where val is a set of referenced Code objects.
    * This is called from the I/O device to call the normal inject(view), then
    * log the injection event.
    * \param obj The object for the mk.val.
@@ -548,7 +548,7 @@ public:
   /**
    * Inject (fact (mk.val obj prop [o1 o2] 1) after before 1 1)
    * [SYNC_PERIODIC after 1 1 stdin nil]
-   * where val is a referenced Code object.
+   * where val is a set of referenced Code objects.
    * This is called from the I/O device to call the normal inject(view), then
    * log the injection event.
    * \param obj The object for the mk.val.
@@ -565,6 +565,93 @@ public:
   {
     return inject_marker_value_from_io_device(
       obj, prop, val, after, before, View::SYNC_PERIODIC, get_stdin());
+  }
+
+  /**
+   * Inject (fact (mk.val obj prop (opcode val1 val2 ...) 1) after before 1 1)
+   * [sync_mode after 1 1 group nil]
+   * where val1 val2 ... come from the vals Atom list.
+   * This is called from the I/O device to call the normal inject(view), then
+   * log the injection event.
+   * \param obj The object for the mk.val.
+   * \param prop The property for the mk.val.
+   * \param opcode The opcode for the value structure.
+   * \param vals The list of Atom for val1 val2 ....
+   * \param after The start of the fact time interval.
+   * \param before The end of the fact time interval.
+   * \param sync_mode The view sync mode, such as View::SYNC_PERIODIC.
+   * \param group The group of the view, such as get_stdin().
+   * \return The created View.
+   */
+  View* inject_marker_value_from_io_device(
+    r_code::Code* obj, r_code::Code* prop, uint16 opcode, const std::vector<r_code::Atom>& vals,
+    Timestamp after, Timestamp before, View::SyncMode sync_mode, r_code::Code* group);
+
+  /**
+   * Inject (fact (mk.val obj prop (opcode val1 val2 ...) 1) after before 1 1)
+   * [sync_mode after 1 1 stdin nil]
+   * where val1 val2 ... come from the vals Atom list.
+   * This is called from the I/O device to call the normal inject(view), then
+   * log the injection event.
+   * \param obj The object for the mk.val.
+   * \param prop The property for the mk.val.
+   * \param opcode The opcode for the value structure.
+   * \param vals The list of Atom for val1 val2 ....
+   * \param after The start of the fact time interval.
+   * \param before The end of the fact time interval.
+   * \param sync_mode The view sync mode, such as View::SYNC_PERIODIC.
+   * \return The created View.
+   */
+  View* inject_marker_value_from_io_device(
+    r_code::Code* obj, r_code::Code* prop, uint16 opcode, const std::vector<r_code::Atom>& vals,
+    Timestamp after, Timestamp before, View::SyncMode sync_mode)
+  {
+    return inject_marker_value_from_io_device(obj, prop, opcode, vals, after, before, sync_mode, get_stdin());
+  }
+
+  /**
+   * Inject (fact (mk.val obj prop (opcode val1 val2 ...) 1) after before 1 1)
+   * [SYNC_PERIODIC after 1 1 group nil]
+   * where val1 val2 ... come from the vals Atom list.
+   * This is called from the I/O device to call the normal inject(view), then
+   * log the injection event.
+   * \param obj The object for the mk.val.
+   * \param prop The property for the mk.val.
+   * \param opcode The opcode for the value structure.
+   * \param vals The list of Atom for val1 val2 ....
+   * \param after The start of the fact time interval.
+   * \param before The end of the fact time interval.
+   * \param group The group of the view, such as get_stdin().
+   * \return The created View.
+   */
+  View* inject_marker_value_from_io_device(
+    r_code::Code* obj, r_code::Code* prop, uint16 opcode, const std::vector<r_code::Atom>& vals,
+    Timestamp after, Timestamp before, r_code::Code* group)
+  {
+    return inject_marker_value_from_io_device(
+      obj, prop, opcode, vals, after, before, View::SYNC_PERIODIC, group);
+  }
+
+  /**
+   * Inject (fact (mk.val obj prop (opcode val1 val2 ...) 1) after before 1 1)
+   * [SYNC_PERIODIC after 1 1 stdin nil]
+   * where val1 val2 ... come from the vals Atom list.
+   * This is called from the I/O device to call the normal inject(view), then
+   * log the injection event.
+   * \param obj The object for the mk.val.
+   * \param prop The property for the mk.val.
+   * \param opcode The opcode for the value structure.
+   * \param vals The list of Atom for val1 val2 ....
+   * \param after The start of the fact time interval.
+   * \param before The end of the fact time interval.
+   * \return The created View.
+   */
+  View* inject_marker_value_from_io_device(
+    r_code::Code* obj, r_code::Code* prop, uint16 opcode, const std::vector<r_code::Atom>& vals,
+    Timestamp after, Timestamp before)
+  {
+    return inject_marker_value_from_io_device(
+      obj, prop, opcode, vals, after, before, View::SYNC_PERIODIC, get_stdin());
   }
 
   /**

--- a/r_exec/pattern_extractor.cpp
+++ b/r_exec/pattern_extractor.cpp
@@ -1038,6 +1038,10 @@ void CTPX::reduce(r_exec::View *input) {
     Atom target_val = target_->get_reference(0)->code(MK_VAL_VALUE);
     if (target_val.isFloat())
       need_guard = true;
+    else if (target_val.getDescriptor() == Atom::I_PTR) {
+      if (hasUserDefinedOperators(target_->get_reference(0)->code(target_val.asIndex()).asOpcode()))
+        need_guard = true;
+    }
   }
 
   auto period = duration_cast<microseconds>(Utils::GetTimestamp<Code>(consequent, FACT_AFTER) - Utils::GetTimestamp<Code>(target_, FACT_AFTER)); // sampling period.

--- a/r_exec/pattern_extractor.cpp
+++ b/r_exec/pattern_extractor.cpp
@@ -430,10 +430,7 @@ Code *_TPX::build_cst(const vector<Component> &components, BindingMap *bm, _Fact
 
 Code *_TPX::build_mdl_head(HLPBindingMap *bm, uint16 tpl_arg_count, _Fact *lhs, _Fact *rhs, uint16 &write_index, bool allow_shared_timing_vars) {
 
-  Code *mdl = _Mem::Get()->build_object(Atom::Model(Opcodes::Mdl, MDL_ARITY));
-
   Code* abstract_lhs = bm->abstract_object(lhs, false, allow_shared_timing_vars ? 0 : -1);
-  mdl->add_reference(abstract_lhs); // reference lhs.
 
   int rhs_first_search_index = (allow_shared_timing_vars ? 0 : -1);
   if (abstract_lhs->get_reference(0)->code(0).asOpcode() == Opcodes::IMdl) {
@@ -447,7 +444,15 @@ Code *_TPX::build_mdl_head(HLPBindingMap *bm, uint16 tpl_arg_count, _Fact *lhs, 
         imdl->code(exposed_after_index).getDescriptor() == Atom::VL_PTR)
       rhs_first_search_index = imdl->code(exposed_after_index).asIndex();
   }
-  mdl->add_reference(bm->abstract_object(rhs, false, rhs_first_search_index)); // reference rhs.
+  Code* abstract_rhs = bm->abstract_object(rhs, false, rhs_first_search_index);
+
+  return build_mdl_head_from_abstract(tpl_arg_count, abstract_lhs, abstract_rhs, write_index);
+}
+
+Code* _TPX::build_mdl_head_from_abstract(uint16 tpl_arg_count, Code* abstract_lhs, Code* abstract_rhs, uint16& write_index) {
+  Code* mdl = _Mem::Get()->build_object(Atom::Model(Opcodes::Mdl, MDL_ARITY));
+  mdl->add_reference(abstract_lhs); // reference lhs.
+  mdl->add_reference(abstract_rhs); // reference rhs.
 
   write_index = MDL_ARITY;
 

--- a/r_exec/pattern_extractor.cpp
+++ b/r_exec/pattern_extractor.cpp
@@ -758,10 +758,14 @@ void PTPX::reduce(r_exec::View *input) {
   r_code::list<Input>::const_iterator i;
   for (i = inputs_.begin(); i != inputs_.end();) { // filter out inputs irrelevant for the prediction.
 
-    if (i->input_->get_reference(0)->code(0).asOpcode() == Opcodes::Cmd) // no cmds as req lhs (because no bwd-operational); prefer: cmd->effect, effect->imdl.
+    if (i->input_->get_reference(0)->code(0).asOpcode() == Opcodes::Cmd)
+      // no cmds as req lhs (because no bwd-operational); prefer: cmd->effect, effect->imdl.
       i = inputs_.erase(i);
-    else if (!end_bm->intersect(i->bindings_) || // discard inputs that do not share values with the consequent.
-             i->input_->get_after() > consequent->get_after()) // discard inputs that started after the consequent started.
+    else if (i->input_->get_after() > consequent->get_after())
+      // discard inputs that started after the consequent started.
+      i = inputs_.erase(i);
+    else if (!end_bm->intersect(i->bindings_))
+      // discard inputs that do not share values with the consequent.
       i = inputs_.erase(i);
     else
       ++i;

--- a/r_exec/pattern_extractor.h
+++ b/r_exec/pattern_extractor.h
@@ -335,6 +335,10 @@ private:
   GuardBuilder *get_default_guard_builder(_Fact *cause, _Fact *consequent, std::chrono::microseconds period);
   GuardBuilder *find_guard_builder(_Fact *cause, _Fact *consequent, std::chrono::microseconds period);
 
+  static r_code::LocalObject build_expression_object(_Fact* target, _Fact* consequent, Atom op);
+
+  static r_code::resized_vector<r_code::Atom> evaluate_expression(r_code::LocalObject expression);
+
   bool build_mdl(_Fact *cause, _Fact *consequent, GuardBuilder *guard_builder, std::chrono::microseconds period);
   bool build_mdl(_Fact *f_icst, _Fact *cause_pattern, _Fact *consequent, GuardBuilder *guard_builder, std::chrono::microseconds period);
 

--- a/r_exec/pattern_extractor.h
+++ b/r_exec/pattern_extractor.h
@@ -253,8 +253,8 @@ protected:
   _Fact *make_f_icst(_Fact *component, _Fact*& component_pattern, P<r_code::Code> &new_cst);
   r_code::Code *build_cst(const std::vector<Component> &components, BindingMap *bm, _Fact *main_component);
 
-  r_code::Code *build_mdl_head(HLPBindingMap *bm, uint16 tpl_arg_count, _Fact *lhs, _Fact *rhs, uint16 &write_index, bool allow_shared_timing_vars = true);
-  r_code::Code* build_mdl_head_from_abstract(uint16 tpl_arg_count, r_code::Code* lhs, r_code::Code* rhs, uint16& write_index);
+  static r_code::Code *build_mdl_head(HLPBindingMap *bm, uint16 tpl_arg_count, _Fact *lhs, _Fact *rhs, uint16 &write_index, bool allow_shared_timing_vars = true);
+  static r_code::Code* build_mdl_head_from_abstract(uint16 tpl_arg_count, r_code::Code* lhs, r_code::Code* rhs, uint16& write_index);
   void build_mdl_tail(r_code::Code *mdl, uint16 write_index);
 
   void inject_hlps() const;

--- a/r_exec/pattern_extractor.h
+++ b/r_exec/pattern_extractor.h
@@ -254,6 +254,7 @@ protected:
   r_code::Code *build_cst(const std::vector<Component> &components, BindingMap *bm, _Fact *main_component);
 
   r_code::Code *build_mdl_head(HLPBindingMap *bm, uint16 tpl_arg_count, _Fact *lhs, _Fact *rhs, uint16 &write_index, bool allow_shared_timing_vars = true);
+  r_code::Code* build_mdl_head_from_abstract(uint16 tpl_arg_count, r_code::Code* lhs, r_code::Code* rhs, uint16& write_index);
   void build_mdl_tail(r_code::Code *mdl, uint16 write_index);
 
   void inject_hlps() const;

--- a/usr_operators/Operators/operators.cpp
+++ b/usr_operators/Operators/operators.cpp
@@ -91,6 +91,7 @@
 static uint16 Vec3Opcode;
 static uint16 Vec2Opcode;
 static uint16 VecOpcode;
+static uint16 QuatOpcode;
 
 namespace usr_operators {
 
@@ -135,6 +136,15 @@ bool add(const r_exec::Context &context) {
       }
       return true;
     }
+  }
+
+  if (lhs[0].asOpcode() == QuatOpcode && rhs[0].asOpcode() == QuatOpcode) {
+
+    context.setCompoundResultHead(Atom::Object(QuatOpcode, 4));
+    context.addCompoundResultPart(Atom::Float((*lhs.get_child(1))[0].asFloat() + (*rhs.get_child(1))[0].asFloat()));
+    context.addCompoundResultPart(Atom::Float((*lhs.get_child(2))[0].asFloat() + (*rhs.get_child(2))[0].asFloat()));
+    context.addCompoundResultPart(Atom::Float((*lhs.get_child(3))[0].asFloat() + (*rhs.get_child(3))[0].asFloat()));
+    context.addCompoundResultPart(Atom::Float((*lhs.get_child(4))[0].asFloat() + (*rhs.get_child(4))[0].asFloat()));
   }
 
   context.setAtomicResult(Atom::Nil());
@@ -183,6 +193,15 @@ bool sub(const r_exec::Context &context) {
     }
   }
 
+  if (lhs[0].asOpcode() == QuatOpcode && rhs[0].asOpcode() == QuatOpcode) {
+
+    context.setCompoundResultHead(Atom::Object(QuatOpcode, 4));
+    context.addCompoundResultPart(Atom::Float((*lhs.get_child(1))[0].asFloat() - (*rhs.get_child(1))[0].asFloat()));
+    context.addCompoundResultPart(Atom::Float((*lhs.get_child(2))[0].asFloat() - (*rhs.get_child(2))[0].asFloat()));
+    context.addCompoundResultPart(Atom::Float((*lhs.get_child(3))[0].asFloat() - (*rhs.get_child(3))[0].asFloat()));
+    context.addCompoundResultPart(Atom::Float((*lhs.get_child(4))[0].asFloat() - (*rhs.get_child(4))[0].asFloat()));
+  }
+
   context.setAtomicResult(Atom::Nil());
   return false;
 }
@@ -226,7 +245,8 @@ bool mul(const r_exec::Context &context) {
       }
       return true;
     }
-  } else if (lhs[0].asOpcode() == Vec3Opcode) {
+  }
+  else if (lhs[0].asOpcode() == Vec3Opcode) {
 
     if (rhs[0].isFloat()) {
 
@@ -263,7 +283,31 @@ bool mul(const r_exec::Context &context) {
       return true;
     }
   }
+  else if (lhs[0].asOpcode() == QuatOpcode && rhs[0].asOpcode() == QuatOpcode) {
 
+    float32 w1 = (*lhs.get_child(1))[0].asFloat();
+    float32 x1 = (*lhs.get_child(2))[0].asFloat();
+    float32 y1 = (*lhs.get_child(3))[0].asFloat();
+    float32 z1 = (*lhs.get_child(4))[0].asFloat();
+
+    float32 w2 = (*rhs.get_child(1))[0].asFloat();
+    float32 x2 = (*rhs.get_child(2))[0].asFloat();
+    float32 y2 = (*rhs.get_child(3))[0].asFloat();
+    float32 z2 = (*rhs.get_child(4))[0].asFloat();
+
+    float32 w_new = round((-x1 * x2 - y1 * y2 - z1 * z2 + w1 * w2) * 100.) / 100.;
+    float32 x_new = round(( x1 * w2 + y1 * z2 - z1 * y2 + w1 * x2) * 100.) / 100.;
+    float32 y_new = round((-x1 * z2 + y1 * w2 + z1 * x2 + w1 * y2) * 100.) / 100.;
+    float32 z_new = round(( x1 * y2 - y1 * x2 + z1 * w2 + w1 * z2) * 100.) / 100.;
+
+    context.setCompoundResultHead(Atom::Object(QuatOpcode, 4));
+    context.addCompoundResultPart(Atom::Float(w_new));
+    context.addCompoundResultPart(Atom::Float(x_new));
+    context.addCompoundResultPart(Atom::Float(y_new));
+    context.addCompoundResultPart(Atom::Float(z_new));
+
+    return true;
+  }
   context.setAtomicResult(Atom::Nil());
   return false;
 }
@@ -311,6 +355,35 @@ bool div(const r_exec::Context& context) {
       }
       return true;
     }
+  }
+  else if (lhs[0].asOpcode() == QuatOpcode && rhs[0].asOpcode() == QuatOpcode) {
+
+    //taking the conjugate here.
+    float32 w1 = (*lhs.get_child(1))[0].asFloat();
+    float32 x1 = -(*lhs.get_child(2))[0].asFloat();
+    float32 y1 = -(*lhs.get_child(3))[0].asFloat();
+    float32 z1 = -(*lhs.get_child(4))[0].asFloat();
+
+    float32 w2 = (*rhs.get_child(1))[0].asFloat();
+    float32 x2 = (*rhs.get_child(2))[0].asFloat();
+    float32 y2 = (*rhs.get_child(3))[0].asFloat();
+    float32 z2 = (*rhs.get_child(4))[0].asFloat();
+
+    // And take the conjugate again
+    float32 w_new = round((-x1 * x2 - y1 * y2 - z1 * z2 + w1 * w2) * 100.) / 100.;
+    float32 x_new = -round((x1 * w2 + y1 * z2 - z1 * y2 + w1 * x2) * 100.) / 100.;
+    float32 y_new = -round((-x1 * z2 + y1 * w2 + z1 * x2 + w1 * y2) * 100.) / 100.;
+    float32 z_new = -round((x1 * y2 - y1 * x2 + z1 * w2 + w1 * z2) * 100.) / 100.;
+
+    float32 _1 = w_new < 0 ? -1. : 1.;
+
+    context.setCompoundResultHead(Atom::Object(QuatOpcode, 4));
+    context.addCompoundResultPart(Atom::Float(_1 * w_new));
+    context.addCompoundResultPart(Atom::Float(_1 * x_new));
+    context.addCompoundResultPart(Atom::Float(_1 * y_new));
+    context.addCompoundResultPart(Atom::Float(_1 * z_new));
+
+    return true;
   }
 
   context.setAtomicResult(Atom::Nil());
@@ -362,6 +435,26 @@ bool dis(const r_exec::Context &context) {
     }
   }
 
+  if (lhs[0].asOpcode() == QuatOpcode && rhs[0].asOpcode() == QuatOpcode) {
+
+
+    float32 w1 = (*lhs.get_child(1))[0].asFloat();
+    float32 x1 = (*lhs.get_child(2))[0].asFloat();
+    float32 y1 = (*lhs.get_child(3))[0].asFloat();
+    float32 z1 = (*lhs.get_child(4))[0].asFloat();
+
+    float32 w2 = (*rhs.get_child(1))[0].asFloat();
+    float32 x2 = (*rhs.get_child(2))[0].asFloat();
+    float32 y2 = (*rhs.get_child(3))[0].asFloat();
+    float32 z2 = (*rhs.get_child(4))[0].asFloat();
+
+    float32 inner_product = x1 * x2 + y1 * y2 + z1 * z2 + w1 * w2;
+    float32 dis = acos(2 * inner_product * inner_product - 1);
+
+    context.setAtomicResult(Atom::Float(dis));
+
+  }
+
   context.setAtomicResult(Atom::Nil());
   return false;
 }
@@ -375,11 +468,13 @@ r_code::resized_vector<uint16> Operators::Init(OpcodeRetriever r) {
   const char* vec3 = "vec3";
   const char* vec2 = "vec2";
   const char* vec = "vec";
+  const char* quat = "quat";
 
   r_code::resized_vector<uint16> initialized_opcodes;
   initialized_opcodes.push_back(Vec3Opcode = r(vec3));
   initialized_opcodes.push_back(Vec2Opcode = r(vec2));
   initialized_opcodes.push_back(VecOpcode = r(vec));
+  initialized_opcodes.push_back(QuatOpcode = r(quat));
 
   return initialized_opcodes;
 }

--- a/usr_operators/Operators/operators.cpp
+++ b/usr_operators/Operators/operators.cpp
@@ -370,13 +370,16 @@ bool dis(const r_exec::Context &context) {
 
 }
 
-void Operators::Init(OpcodeRetriever r) {
+r_code::resized_vector<uint16> Operators::Init(OpcodeRetriever r) {
 
   const char* vec3 = "vec3";
   const char* vec2 = "vec2";
   const char* vec = "vec";
 
-  Vec3Opcode = r(vec3);
-  Vec2Opcode = r(vec2);
-  VecOpcode = r(vec);
+  r_code::resized_vector<uint16> initialized_opcodes;
+  initialized_opcodes.push_back(Vec3Opcode = r(vec3));
+  initialized_opcodes.push_back(Vec2Opcode = r(vec2));
+  initialized_opcodes.push_back(VecOpcode = r(vec));
+
+  return initialized_opcodes;
 }

--- a/usr_operators/Operators/operators.h
+++ b/usr_operators/Operators/operators.h
@@ -100,7 +100,7 @@ bool dis(const r_exec::Context &context);
 
 class Operators {
 public:
-  static void Init(OpcodeRetriever r);
+  static r_code::resized_vector<uint16> Init(OpcodeRetriever r);
 };
 
 

--- a/usr_operators/usr_operators.cpp
+++ b/usr_operators/usr_operators.cpp
@@ -91,11 +91,13 @@
 #include <cmath>
 
 
-void Init(OpcodeRetriever r) {
+r_code::resized_vector<uint16> Init(OpcodeRetriever r) {
 
-  Operators::Init(r);
+  r_code::resized_vector<uint16> val = Operators::Init(r);
 
   std::cout << "> usr operators initialized" << std::endl;
+
+  return val;
 }
 
 uint16 GetOperatorCount() {

--- a/usr_operators/usr_operators.h
+++ b/usr_operators/usr_operators.h
@@ -90,7 +90,7 @@
 
 
 extern "C" {
-void dll_export Init(OpcodeRetriever r); // OpcodeRetriever allows the dll to retrieve opcodes from the r_rxec dll without referencing the corresponding STL structures.
+  r_code::resized_vector<uint16> dll_export Init(OpcodeRetriever r); // OpcodeRetriever allows the dll to retrieve opcodes from the r_rxec dll without referencing the corresponding STL structures.
 
 // Operators //////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
During initialization, when custom-defined operators are loaded, the opcodes of classes with custom operators are returned and stored in r_exec::Metadata for convenient access. In the pattern extractor, we can now call a function "hasUserDefinedOperators(opcode)" to check whether an object pointed to by an I_PTR has custom-defined operators, thus suggesting that guards need to be built. All objects defined in usr_operators/Operators/operators.h/.cpp can thus be automatically included in the guard building process.