### PR TITLE
Remove unneded TemplateTimingsUpdater

### DIFF
--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -435,107 +435,6 @@ void MDLController::_store_requirement(r_code::list<RequirementEntry> *cache, Re
   requirements_.CS_.leave();
 }
 
-/**
- * TemplateTimingsUpdater is a helper class for retrieve_imdl_fwd, etc. to save an f_imdl template
- * timings and temporarily set them from another f_imdl. We won't need this if we implement
- * https://github.com/IIIM-IS/replicode/issues/137
- */
-class TemplateTimingsUpdater {
-public:
-  /**
-   * Create a TemplateTimingsUpdater and save the timings from f_imdl, then set them to the values from
-   * other_f_imdl so that Match will ignore any difference. The destructor will restore the values in f_imdl.
-   * \param f_imdl This updates the template timings in the imdl at f_imdl->get_reference(0).
-   * \param other_f_imdl Get the template timings in the imdl at other_f_imdl->get_reference(0).
-   * \param bm The binding map in case the timings in other_f_imdl are VL_PTR.
-   */
-  TemplateTimingsUpdater(_Fact *f_imdl, const _Fact *other_f_imdl, const HLPBindingMap *bm) {
-    do_narrow_timings_ = false;
-    f_imdl_ = f_imdl;
-    have_saved_template_timings_ = MDLController::get_imdl_template_timings(
-      f_imdl_->get_reference(0), save_template_after_, save_template_before_, false,
-      &template_after_ts_index_, &template_before_ts_index_);
-    if (!have_saved_template_timings_)
-      return;
-
-    // Temporarily make f_imdl_ template timings match the one from _f_imdl so that any difference is ignored.
-    auto other_imdl = other_f_imdl->get_reference(0);
-    auto other_template_set_index = other_imdl->code(I_HLP_TPL_ARGS).asIndex();
-    auto other_template_set_count = other_imdl->code(other_template_set_index).getAtomCount();
-    if (other_template_set_count < 2)
-      return;
-    auto other_template_after_index = other_template_set_index + (other_template_set_count - 1);
-    auto other_template_before_index = other_template_set_index + other_template_set_count;
-
-    if (!get_timestamp(
-        other_imdl, other_template_set_index + (other_template_set_count - 1), other_f_imdl_template_after_, bm))
-      return;
-    if (!get_timestamp(other_imdl, other_template_set_index + other_template_set_count, 
-        other_f_imdl_template_before_, bm))
-      return;
-
-    // When Match is updated with time interval comparison, it will do this test for strict overlap.
-    if (save_template_after_ < other_f_imdl_template_before_ && save_template_before_ > other_f_imdl_template_after_) {
-      Utils::SetTimestampStruct(f_imdl_->get_reference(0), template_after_ts_index_, other_f_imdl_template_after_);
-      Utils::SetTimestampStruct(f_imdl_->get_reference(0), template_before_ts_index_, other_f_imdl_template_before_);
-
-      // Enable narrow_timings() if the binding map has a first_index_ and the timings need to be narrowed.
-      do_narrow_timings_ = (bm->get_first_index() >= 2 &&
-        (save_template_after_ != other_f_imdl_template_after_ ||
-         save_template_before_ != other_f_imdl_template_before_));
-    }
-  }
-
-  /**
-   * Restore the timings to the f_imdl given to the constructor.
-   */
-  ~TemplateTimingsUpdater() {
-    if (have_saved_template_timings_) {
-      Utils::SetTimestampStruct(f_imdl_->get_reference(0), template_after_ts_index_, save_template_after_);
-      Utils::SetTimestampStruct(f_imdl_->get_reference(0), template_before_ts_index_, save_template_before_);
-    }
-  }
-
-  /**
-   * If the match was successful, call this to update the binding map with the narrowed match of
-   * the timing variables of the imdl objects given to the constructor. (This assumes that the timing
-   * variables in f_imdl are those in the binding map.)
-   * \param bm The same binding map given to the constructor which is updated to narrow the
-   * template timing variables.
-   */
-  void narrow_timings(HLPBindingMap* bm) {
-    if (do_narrow_timings_)
-      bm->match_timings(other_f_imdl_template_after_, other_f_imdl_template_before_,
-        bm->get_first_index() - 2, bm->get_first_index() - 1);
-  }
-
-  /**
-   * If imdl->code(index) is a VL_PTR for a timestamp struct in bm, then set timestamp to it. Otherwise if
-   * imdl->code(index) is an I_PTR to a timestamp struct, then set timestamp to it.
-   * Return true if timestamp was set, otherwise false.
-   */
-  static bool get_timestamp(Code* imdl, int index, Timestamp& timestamp, const HLPBindingMap *bm) {
-    if (imdl->code(index).getDescriptor() == Atom::VL_PTR &&
-        bm->is_timestamp(imdl->code(index).asIndex())) {
-      timestamp = Utils::GetTimestamp(bm->get_code(imdl->code(index).asIndex()));
-      return true;
-    }
-    if (imdl->code(index).getDescriptor() == Atom::I_PTR) {
-      timestamp = Utils::GetTimestamp(imdl, index);
-      return true;
-    }
-
-    return false;
-  }
-
-  _Fact *f_imdl_;
-  Timestamp other_f_imdl_template_after_, other_f_imdl_template_before_;
-  Timestamp save_template_after_, save_template_before_;
-  uint16 template_after_ts_index_, template_before_ts_index_;
-  bool have_saved_template_timings_;
-  bool do_narrow_timings_;
-};
-
 ChainingStatus MDLController::retrieve_simulated_imdl_fwd(const HLPBindingMap *bm, Fact *f_imdl, Sim* sim, vector<BindingResult>& results) {
 
   uint32 wr_count;
@@ -564,9 +463,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(const HLPBindingMap *b
           // Temporarily make f_imdl wr_enabled match the one from _f_imdl so that any difference is ignored.
           f_imdl->get_reference(0)->code(I_HLP_WEAK_REQUIREMENT_ENABLED) = Atom::Boolean(
             _f_imdl->get_reference(0)->code(I_HLP_WEAK_REQUIREMENT_ENABLED).asBoolean());
-          TemplateTimingsUpdater timingsUpdater(f_imdl, _f_imdl, &_original);
           if (_original.match_fwd_strict(_f_imdl, f_imdl)) { // tpl args will be valuated in bm, but not in f_imdl yet.
-            timingsUpdater.narrow_timings(&_original);
 
             r = WEAK_REQUIREMENT_ENABLED;
             results.push_back(BindingResult(new HLPBindingMap(_original), (*e).evidence_));
@@ -598,9 +495,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(const HLPBindingMap *b
 
             _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
             HLPBindingMap _original(bm); // matching updates the binding map; always start afresh.
-            TemplateTimingsUpdater timingsUpdater(f_imdl, _f_imdl, &_original);
             if (_original.match_fwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE) { // tpl args will be valuated in bm.
-              timingsUpdater.narrow_timings(&_original);
 
               results.push_back(BindingResult(new HLPBindingMap(_original), NULL));
               requirements_.CS_.leave();
@@ -632,9 +527,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(const HLPBindingMap *b
 
             _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
             HLPBindingMap _original(bm); // matching updates the binding map; always start afresh.
-            TemplateTimingsUpdater timingsUpdater(f_imdl, _f_imdl, &_original);
             if (_original.match_fwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE) {
-              timingsUpdater.narrow_timings(&_original);
 
               negative_cfd = (*e).confidence_;
               r = STRONG_REQUIREMENT_NO_WEAK_REQUIREMENT;
@@ -658,9 +551,7 @@ ChainingStatus MDLController::retrieve_simulated_imdl_fwd(const HLPBindingMap *b
 
             _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
             HLPBindingMap _original(bm); // matching updates the binding map; always start afresh.
-            TemplateTimingsUpdater timingsUpdater(f_imdl, _f_imdl, &_original);
             if (_original.match_fwd_strict(_f_imdl, f_imdl)) {
-              timingsUpdater.narrow_timings(&_original);
 
               bool strong_matches_weak =
                 (strong_requirement_ground && HLPBindingMap(_original).match_fwd_lenient
@@ -719,10 +610,8 @@ ChainingStatus MDLController::retrieve_simulated_imdl_bwd(HLPBindingMap *bm, Fac
 
           _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
           HLPBindingMap _original(bm); // matching updates the binding map; always start afresh.
-          TemplateTimingsUpdater timingsUpdater(f_imdl, _f_imdl, &_original);
           // Use match_fwd because the f_imdl time interval matches the binding map's fwd_after and fwd_before from the model LHS.
           if (_original.match_fwd_strict(_f_imdl, f_imdl)) { // tpl args will be valuated in bm, but not in f_imdl yet.
-            timingsUpdater.narrow_timings(&_original);
 
             bm->load(&_original);
             r = WEAK_REQUIREMENT_ENABLED;
@@ -753,10 +642,8 @@ ChainingStatus MDLController::retrieve_simulated_imdl_bwd(HLPBindingMap *bm, Fac
 
             _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
             HLPBindingMap _original(bm); // matching updates the binding map; always start afresh.
-            TemplateTimingsUpdater timingsUpdater(f_imdl, _f_imdl, &_original);
             // Use match_fwd because the f_imdl time interval matches the binding map's fwd_after and fwd_before from the model LHS.
             if (_original.match_fwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE) { // tpl args will be valuated in bm.
-              timingsUpdater.narrow_timings(&_original);
 
               bm->load(&_original);
               strong_requirement_ground = (*e).evidence_;
@@ -788,10 +675,8 @@ ChainingStatus MDLController::retrieve_simulated_imdl_bwd(HLPBindingMap *bm, Fac
 
             _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
             HLPBindingMap _original(bm); // matching updates the binding map; always start afresh.
-            TemplateTimingsUpdater timingsUpdater(f_imdl, _f_imdl, &_original);
             // Use match_fwd because the f_imdl time interval matches the binding map's fwd_after and fwd_before from the model LHS.
             if (_original.match_fwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE) {
-              timingsUpdater.narrow_timings(&_original);
 
               negative_cfd = (*e).confidence_;
               r = STRONG_REQUIREMENT_NO_WEAK_REQUIREMENT;
@@ -815,10 +700,8 @@ ChainingStatus MDLController::retrieve_simulated_imdl_bwd(HLPBindingMap *bm, Fac
 
             _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
             HLPBindingMap _original(bm); // matching updates the binding map; always start afresh.
-            TemplateTimingsUpdater timingsUpdater(f_imdl, _f_imdl, &_original);
             // Use match_fwd because the f_imdl time interval matches the binding map's fwd_after and fwd_before from the model LHS.
             if (_original.match_fwd_strict(_f_imdl, f_imdl)) {
-              timingsUpdater.narrow_timings(&_original);
 
               bool strong_matches_weak =
                 (strong_requirement_ground && HLPBindingMap(_original).match_fwd_lenient
@@ -1089,10 +972,8 @@ ChainingStatus MDLController::retrieve_imdl_bwd(HLPBindingMap *bm, Fact *f_imdl,
 
         _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
         HLPBindingMap _original(bm); // matching updates the binding map; always start afresh.
-        TemplateTimingsUpdater timingsUpdater(f_imdl, _f_imdl, &_original);
         // Use match_fwd because the f_imdl time interval matches the binding map's fwd_after and fwd_before from the model LHS.
         if (_original.match_fwd_strict(_f_imdl, f_imdl)) { // tpl args will be valuated in bm, but not in f_imdl yet.
-          timingsUpdater.narrow_timings(&_original);
 
           r = WEAK_REQUIREMENT_ENABLED;
           bm->load(&_original);
@@ -1122,10 +1003,8 @@ ChainingStatus MDLController::retrieve_imdl_bwd(HLPBindingMap *bm, Fact *f_imdl,
 
           _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
           HLPBindingMap _original(bm); // matching updates the binding map; always start afresh.
-          TemplateTimingsUpdater timingsUpdater(f_imdl, _f_imdl, &_original);
           // Use match_fwd because the f_imdl time interval matches the binding map's fwd_after and fwd_before from the model LHS.
           if (_original.match_fwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE) { // tpl args will be valuated in bm.
-            timingsUpdater.narrow_timings(&_original);
 
             strong_requirement_ground = (*e).evidence_;
             requirements_.CS_.leave();
@@ -1152,10 +1031,8 @@ ChainingStatus MDLController::retrieve_imdl_bwd(HLPBindingMap *bm, Fact *f_imdl,
 
           _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
           HLPBindingMap _original(bm); // matching updates the binding map; always start afresh.
-          TemplateTimingsUpdater timingsUpdater(f_imdl, _f_imdl, &_original);
           // Use match_fwd because the f_imdl time interval matches the binding map's fwd_after and fwd_before from the model LHS.
           if (_original.match_fwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE) {
-            timingsUpdater.narrow_timings(&_original);
 
             negative_cfd = (*e).confidence_;
             r = STRONG_REQUIREMENT_NO_WEAK_REQUIREMENT;
@@ -1174,10 +1051,8 @@ ChainingStatus MDLController::retrieve_imdl_bwd(HLPBindingMap *bm, Fact *f_imdl,
         else {
           _Fact *_f_imdl = (*e).evidence_->get_pred()->get_target();
           HLPBindingMap _original(bm); // matching updates the binding map; always start afresh.
-          TemplateTimingsUpdater timingsUpdater(f_imdl, _f_imdl, &_original);
           // Use match_fwd because the f_imdl time interval matches the binding map's fwd_after and fwd_before from the model LHS.
           if (_original.match_fwd_strict(_f_imdl, f_imdl)) {
-            timingsUpdater.narrow_timings(&_original);
 
             bool strong_matches_weak =
               (strong_requirement_ground && HLPBindingMap(_original).match_fwd_lenient
@@ -1647,10 +1522,8 @@ void PrimaryMDLController::store_requirement(_Fact *f_p_f_imdl, MDLController *c
           HLPBindingMap _original(bindings_);
           _original.reset_fwd_timings(f_imdl);
           // Use logic similar to retrieve_simulated_imdl_bwd.
-          TemplateTimingsUpdater timingsUpdater(f_imdl, _f_imdl, &_original);
           if (_original.match_fwd_lenient(_f_imdl, f_imdl) == MATCH_SUCCESS_NEGATIVE &&
               f_imdl->get_cfd() >= (*e).confidence_) {
-            timingsUpdater.narrow_timings(&_original);
 
             // The strong requirement disables the weak.
             (*e).evidence_->get_pred()->get_defeasible_consequence()->invalidate();

--- a/r_exec/mdl_controller.h
+++ b/r_exec/mdl_controller.h
@@ -308,19 +308,18 @@ public:
   void register_requirement(_Fact *f_pred, RequirementsPair &r_p);
 
   /**
-   * Get the last two values from the imdl template values, assuming that they are the timings
+   * Get the two timestamps from the last template value which is a ti value, assuming that they are the timings
    * from the prerequisite model.
    * \param imdl The imdl object.
    * \param after Set this to the after timestamp (if this returns true).
    * \param before Set this to the before timestamp (if this returns true).
-   * \param allow_ti If true, allow the last template value to be a (ti After: Before:). If omitted, use true.
    * \param (optional) after_ts_index If not NULL, set this to the index in imdl Code array of the after time stamp structure.
    * \param (optional)  before_ts_index If not NULL, set this to the index in imdl Code array of the before time stamp structure.
    * \return True for success, otherwise false if there are not enough template parameters,
    * or if the value is some type other than a timestamp (such as an unbound variable).
    */
   static bool get_imdl_template_timings(
-    r_code::Code* imdl, Timestamp& after, Timestamp& before, bool allow_ti = true, uint16* after_ts_index = NULL, uint16* before_ts_index = NULL);
+    r_code::Code* imdl, Timestamp& after, Timestamp& before, uint16* after_ts_index = NULL, uint16* before_ts_index = NULL);
 };
 
 class PMDLController :
@@ -504,7 +503,7 @@ public:
   void abduce_no_simulation(Fact *super_goal, bool opposite, float32 confidence, _Fact* f_p_f_success = NULL);
 
   /**
-   * Get the last two values from the template parameters, assuming that they are the timings
+   * Get the two timestamps from the last template value which is a ti value, assuming that they are the timings
    * from the prerequisite model. This evaluates the backward guards if needed.
    * \param bm The binding map, which is not changed.
    * \param after Set this to the after timestamp (if this returns true).


### PR DESCRIPTION
Pull request #250 implemented the `(ti after before)` time interval structure which we now use for the template timings. That updated the method `get_imdl_template_timings` to optionally handle this as well as the previous method of two separate timestamps (without `ti`) for backwards compatibility. Now that we have updated all of the hand-coded models in the seed code and examples (and the CTPX model builder now uses `ti`), we don't need the backwards compatibility. Also, the `TemplateTimingsUpdater` class is not needed because "smart matching" of timings is now done automatically for `ti` values (as explained in PR #250).

This pull request removes the unneeded `TemplateTimingsUpdater` class and simplifies `get_imdl_template_timings` because it only needs to work with the `ti` value.