### PR TITLE
Use microseconds for Timestamp period

### DIFF
--- a/AERA/replicode_v1.2/std.replicode
+++ b/AERA/replicode_v1.2/std.replicode
@@ -161,7 +161,7 @@
 !def RUN_ONCE false
 
 ; system internal constants.
-!def MAX_TIME 922337203685477580us; See Utils_MaxTime
+!def MAX_TIME 9223372036854775807us; See Utils_MaxTime
 ; EPOCH is used to convert between time stamp and duration.
 ; To convert a duration to a time stamp, use: (+ duration EPOCH)
 ; To convert a time stamp to a duration, use: (- timestamp EPOCH)

--- a/r_code/utils.h
+++ b/r_code/utils.h
@@ -354,8 +354,7 @@ public:
 };
 
 // This is Timestamp::max() duration_cast to microseconds and used to initialize a Timestamp.
-// The result is a slightly different value from Timestamp::max(), but convertible to/from microseconds.
-const Timestamp Utils_MaxTime(std::chrono::microseconds(922337203685477580LL));
+const Timestamp Utils_MaxTime(std::chrono::microseconds(9223372036854775807LL));
 
 }
 

--- a/r_code/utils.h
+++ b/r_code/utils.h
@@ -340,9 +340,6 @@ public:
   }
 
   static int32 GetResilience(Timestamp now, std::chrono::microseconds time_to_live, uint64 upr); // ttl: us, upr: us.
-  static int32 GetResilience(Timestamp now, Timestamp::duration time_to_live, uint64 upr) {
-    return GetResilience(now, std::chrono::duration_cast<std::chrono::microseconds>(time_to_live), upr);
-  }
   static int32 GetResilience(float32 resilience, float32 origin_upr, float32 destination_upr); // express the res in destination group, given the res in origin group.
 
   static std::string RelativeTime(Timestamp t);

--- a/r_exec/cst_controller.h
+++ b/r_exec/cst_controller.h
@@ -219,13 +219,7 @@ public:
   Fact *get_f_icst(HLPBindingMap *bindings, std::vector<P<_Fact> > *axiom_inputs, std::vector<P<_Fact> > *non_axiom_inputs) const;
 
   void inject_icst(Fact *production, float32 confidence, std::chrono::microseconds time_to_live) const; // here, resilience=time to live, in us.
-  void inject_icst(Fact *production, float32 confidence, Timestamp::duration time_to_live) const {
-    inject_icst(production, confidence, std::chrono::duration_cast<std::chrono::microseconds>(time_to_live));
-  }
   bool inject_prediction(Fact *prediction, float32 confidence, std::chrono::microseconds time_to_live) const; // here, resilience=time to live, in us; returns true if the prediction has actually been injected.
-  bool inject_prediction(Fact *prediction, float32 confidence, Timestamp::duration time_to_live) const {
-    return inject_prediction(prediction, confidence, std::chrono::duration_cast<std::chrono::microseconds>(time_to_live));
-  }
 
   void set_secondary_host(Group *host);
   Group *get_secondary_host() const;

--- a/r_exec/mem.h
+++ b/r_exec/mem.h
@@ -250,9 +250,6 @@ public:
   std::chrono::microseconds get_sim_time_horizon(std::chrono::microseconds horizon) const { 
     return std::chrono::microseconds((int64)(horizon.count() * sim_time_horizon_factor_)); 
   }
-  std::chrono::microseconds get_sim_time_horizon(Timestamp::duration horizon) const { 
-    return get_sim_time_horizon(std::chrono::duration_cast<std::chrono::microseconds>(horizon));
-  }
   std::chrono::microseconds get_tpx_time_horizon() const { return tpx_time_horizon_; }
   std::chrono::microseconds get_primary_thz() const { return primary_thz_; }
   std::chrono::microseconds get_secondary_thz() const { return secondary_thz_; }
@@ -816,13 +813,7 @@ public:
 
   // Called by cores.
   void register_reduction_job_latency(std::chrono::microseconds latency);
-  void register_reduction_job_latency(Timestamp::duration latency) {
-    register_reduction_job_latency(std::chrono::duration_cast<std::chrono::microseconds>(latency));
-  };
   void register_time_job_latency(std::chrono::microseconds latency);
-  void register_time_job_latency(Timestamp::duration latency) {
-    register_time_job_latency(std::chrono::duration_cast<std::chrono::microseconds>(latency)); 
-  };
   void inject_perf_stats();
 
   // rMem to rMem.


### PR DESCRIPTION
Background: In pull request #71, we changed to distinguish int values for `Timestamp` from duration in `std::chrono::microseconds`. This works, but the `Timestamp` type uses `std::chrono::system_clock` which does not use microseconds internally. Instead it uses units of the system clock "tick" where each tick period is 100 nanoseconds. This means that each math operation between a `Timestamp` and a duration in microseconds requires converting between the two different representations. This is done automatically by the compiler, but it is not desirable. There can be loss of accuracy and the `Timestamp` does not hold the full precision of the 64-bit microseconds value.

Fortunately, the C++ standard library is parameterized and I noticed that it is easy to control the `Timestamp` representation. This pull request uses the updated CoreLibrary where the `Timestamp` type uses the new `system_clock_us` where the [period is a microsecond](https://github.com/IIIM-IS/CoreLibrary/blob/05c4162fe76d32bcdefb85dd9b50c35d160ed5c8/CoreLibrary/types.h#L194) (not 100 nanoseconds). We update to use this new definition and remove some methods which are redundant because `Timestamp::duration` is now the same as `std::chrono::microseconds` as desired. We also update `Utils_MaxTime` to be the full 64-bit range of `Timestamp::max()` as desired.