### PR TITLE
Change to SDK 10.0.18362.0 (to support VS 2022). 

### DIFF
--- a/AERA/AERA.vcxproj
+++ b/AERA/AERA.vcxproj
@@ -18,7 +18,7 @@
     <ProjectGuid>{689F2DDD-1858-499D-BA79-72BA02D00D45}</ProjectGuid>
     <RootNamespace>Test</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <ProjectName>AERA</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,14 +13,11 @@ Prerequisites
 Following are the detailed steps for each platform to install the prerequisites.
 
 ## Windows
-To install Visual Studio, download and install Visual Studio Community Edition 2019 from
-https://visualstudio.microsoft.com/vs/older-downloads .
-In the installer, under "Desktop development with C++", check "Windows 10 SDK (10.0.17134.0)" and
+To install Visual Studio, download and install Visual Studio Community Edition 2022 from
+https://visualstudio.microsoft.com/vs/community . (If you already have Visual Studio 2019 installed,
+this also works. Visual Studio 2017 is no longer supported.)
+In the installer, under "Desktop development with C++", check "Windows 10 SDK (10.018362.0)" and
   "MSVC v141 - VS 2017 C++ build tools".
-  
-In case you have Visual Studio Community Edition 2022 installed, "Windows 10 SDK (10.0.17134.0)" will
-  not be listed as an option in the installer.
-Instead, you can download  "Windows 10 SDK (10.0.17134.12)" from https://developer.microsoft.com/windows/downloads/sdk-archive/ .
 
 To install Git, download and install GitHub for Desktop from https://desktop.github.com .
 

--- a/output_window/output_window.vcxproj
+++ b/output_window/output_window.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{D6CF951E-F865-4A26-8CCC-D4D5C67EAF93}</ProjectGuid>
     <RootNamespace>output_window</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/r_code/r_code.vcxproj
+++ b/r_code/r_code.vcxproj
@@ -18,7 +18,7 @@
     <ProjectGuid>{6F4E1695-BBEF-46D1-B0C0-1B71A65FAD66}</ProjectGuid>
     <RootNamespace>r_code</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugVisualizer|Win32'" Label="Configuration">

--- a/r_comp/r_comp.vcxproj
+++ b/r_comp/r_comp.vcxproj
@@ -18,7 +18,7 @@
     <ProjectGuid>{345E47D7-90E9-482B-AD10-C11CC828E197}</ProjectGuid>
     <RootNamespace>r_comp</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugVisualizer|Win32'" Label="Configuration">

--- a/r_exec/r_exec.vcxproj
+++ b/r_exec/r_exec.vcxproj
@@ -18,7 +18,7 @@
     <ProjectGuid>{C36B96EC-EF72-4B21-87BE-2130E997BDA0}</ProjectGuid>
     <RootNamespace>r_exec</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugVisualizer|Win32'" Label="Configuration">

--- a/usr_operators/usr_operators.vcxproj
+++ b/usr_operators/usr_operators.vcxproj
@@ -18,7 +18,7 @@
     <ProjectGuid>{3DE12B3F-D45E-46E1-B501-E294009AD4B9}</ProjectGuid>
     <RootNamespace>usr_operators</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugVisualizer|Win32'" Label="Configuration">


### PR DESCRIPTION
Currently, AERA builds which Visual Studio 2017 and 2019, but does not build on the latest Visual Studio 2022. This because AERA uses Windows SDK 10.0.17134.0, which is outdated and not available in Visual Studio 2022, which what most newcomers will install. (It's possible to do a special download and get it running in Visual Studio 2022 but this is difficult to install.)

This pull request updates the project files to change from SDK 10.0.17134.0 to 10.0.18362.0, which is available in Visual Studio 2022 and 2019. (Visual Studio 2017 will not be supported.) We also simplify the README because it's now possible to use the default Visual Studio download (instead of an archive download).