### PR TITLE
Prediction monitor: In update, only register a failure for predicted fact

### DIFF
--- a/r_exec/p_monitor.cpp
+++ b/r_exec/p_monitor.cpp
@@ -156,7 +156,11 @@ void PMonitor::update(Timestamp &next_target) { // executed by a time core, upon
   if (!target_->is_invalidated()) {
 
     // Received nothing matching the target's object so far (neither positively nor negatively).
-    if (rate_failures_)
+    // It is only a failure if the target is a fact. If the target is an anti-fact then reaching this
+    // point means that the object was not observed *as expected* (not a failure).
+    // TODO: If the model correctly predicts an anti-fact that the object won't be observed, then should we register
+    // a success for the model? If yes then what should "evidence" point? Maybe nil?
+    if (rate_failures_ && target_->get_pred()->get_target()->is_fact())
       controller_->register_pred_outcome(target_, false, NULL, 1, rate_failures_);
   }
   controller_->remove_monitor(this);


### PR DESCRIPTION
The Webots example has the following model (simplified):

    mdl_displace_hand:(mdl [H: P0: (ti T0: T1:)] []
       (fact (cmd move [H: (vec3 0.5 0 0)] :) T0_cmd: T1_cmd: : :)
       (|fact (mk.val H: position P0: :) T2: T3: : :))

Note that the RHS is an anti-fact. This model was created to use in backward chaining where the goal is for the hand H to not be at a position (so that a particular composite state will not hold). The model says "If the hand H has position P0 and the goal is to not have position P0, then move the hand by 0.5". This works great for achieving that goal.

The problem is that this model may also be instantiated in forward chaining. For example, during babbling sometimes the hand moves by 0.5. This model makes a prediction of the RHS which is the prediction of the anti-fact: If the hand H has position P0 and it moves by 0.5 then the hand will not have position P0. 

When a model makes a prediction, AERA sets up a prediction monitor. At the end of the predicted time interval, AERA calls the prediction monitor `update` method. Usually the model predicts a fact (not an anti-fact). If that fact is observed then a success is registered. If a contradictory fact is observed then a failure is registered. But if the model predicted a fact and no related fact is observed by the end of the time interval, then the prediction monitor `update` method also registers a failure. (So far so good.)

But what if the model predicts an anti-fact? It appears that support for this case was not implemented fully. If the model predicts an anti-fact which says a fact won't be observed but it is observed, then AERA already registers this as a failure. But at the end of the time interval, if no related fact is observed then the prediction is actually a success. We need to handle this case. This pull request updates the prediction monitor `update` method to only register a failure at the end of the prediction time interval if the prediction is a fact. If the prediction was an anti-fact then it doesn't register a failure, for the reasons just given. (Perhaps it should go further and register a success, but the success object needs to refer to evidence. But in this case, there is no evidence.)