### PR TITLE
In is_evidence, fix is evidence for anti fact target

### DIFF
--- a/r_exec/factory.cpp
+++ b/r_exec/factory.cpp
@@ -450,12 +450,13 @@ MatchResult _Fact::is_evidence(const _Fact *target) const {
 
     if (target->match_timings_overlap(this))
       return r;
-  } else if (target->code(0) == code(0)) { // check for a counter-evidence only if both the lhs and rhs are of the same kind of fact.
+  } else if (is_fact()) { // check for a counter-evidence only if the evidence is a fact.
 
     if (target->match_timings_inclusive(this)) { // check timings first as this is less expensive than the counter-evidence check.
 
       if (CounterEvidence(get_reference(0), target->get_reference(0)))
-        return MATCH_SUCCESS_NEGATIVE;
+        // If the target is an anti-fact, then counter-evidence is a positive success.
+        return target->is_anti_fact() ? MATCH_SUCCESS_POSITIVE : MATCH_SUCCESS_NEGATIVE;
     }
   }
   return MATCH_FAILURE;


### PR DESCRIPTION
Background: `is_evidence` is used to check if a fact is evidence for a target. If two objects have the same object/property but different values, then this is called "counter-evidence" for example consider:

    target:   (fact (mk.val h position 5))
    evidence: (fact (mk.val h position 10))

If the target position is 5 but the evidence is that the position is 10, then this is counter-evidence. In this case, `is_evidence` returns `MATCH_SUCCESS_NEGATIVE`. (This is different than `MATCH_FAILURE` which means that the two facts are unrelated.)

But now consider if the target is an anti-fact:

    target:   (|fact (mk.val h position 5))
    evidence: (fact (mk.val h position 10))

The target was to not have position 5, and the evidence is that the position is 10, which is not 5. The target was achieved! The problem is that `is_evidence` doesn't take into account if the target is an anti-fact and still returns `MATCH_SUCCESS_NEGATIVE` in this case. This pull request changes it to return `MATCH_SUCCESS_POSITIVE` in this case.