### PR TITLE
Don't use CTPX for anti-facts

### DIFF
--- a/r_exec/ast_controller.tpl.cpp
+++ b/r_exec/ast_controller.tpl.cpp
@@ -136,13 +136,16 @@ template<class U> void ASTController<U>::reduce(View *input) {
 
   Pred *prediction = input_object->get_pred();
   if (prediction) {
-    switch (prediction->get_target()->is_timeless_evidence(target_)) {
-    case MATCH_SUCCESS_POSITIVE:
-    case MATCH_SUCCESS_NEGATIVE: // a model predicted the next value of the target.
-      kill();
-      break;
-    case MATCH_FAILURE:
-      break;
+    // Don't cancel if a model made a prediction of an anti-fact.
+    if (prediction->get_target()->is_fact()) {
+      switch (prediction->get_target()->is_timeless_evidence(target_)) {
+      case MATCH_SUCCESS_POSITIVE:
+      case MATCH_SUCCESS_NEGATIVE: // a model predicted the next value of the target.
+        kill();
+        break;
+      case MATCH_FAILURE:
+        break;
+      }
     }
 
     reductionCS_.leave();

--- a/r_exec/auto_focus.cpp
+++ b/r_exec/auto_focus.cpp
@@ -188,7 +188,8 @@ inline View *AutoFocusController::inject_input(View *input) {
       if (i == 0) {
 
         primary_view = view;
-        if (ctpx_on_)
+        // Don't use CTPX to model changes in anti-facts.
+        if (ctpx_on_ && input_fact->is_fact())
           // Set time_to_live to 2 frame periods so that PASTController stays valid during the whole frame when CTPX may build models.
           _Mem::Get()->inject_null_program(new PASTController(this, view), output_group, 2 * output_group->get_upr()*Utils::GetBasePeriod(), true);
       }


### PR DESCRIPTION
Background: When the input to the auto focus controller is a mk.val like `(mk.val h position 10)` it creates an AST controller for it. AST means "atomic state" and is used to track if a state variable changes. In the next frame, if the input to the auto focus controller is another mk.val like `(mk.val h position 15)`, then it will invoke CTPX to try to find a model that explains the change. However, if the input to the auto focus controller is a prediction that matches the target of an AST controller, then this means that there is already a model that is making predictions for it and we don't need to invoke CTPX again. In this case the AST controller is canceled. 

Now we are doing experimentation with anti-facts, including models which predict anti-facts. The existing code seems to assume that the input to the auto focus controller will always be a fact (not an anti-fact), and this introduces some problems. Firstly, the simplest problem is that it doesn't make sense for CTPX to try to model the change of an anti-fact. Suppose one frame has:

    (|fact (mk.val h position 10) 100ms)

and the next frame has

    (|fact (mk.val h position 15) 200ms)

If h position isn't 10 and later it isn't 15, it doesn't make sense to try to make a model to predict this. Therefore, in this pull request we update the auto focus controller so that it doesn't create AST controller for an anti-fact.

The second problem is in the control of when to cancel an AST controller because there is already a model which predicts the target value. Similar to the logic in pull request #274, if the model predicts an anti-fact then there is no valid inference that the model is or isn't a predictor of the value being tracked by the AST controller. Therefore, we update the AST controller to not cancel if a model made a prediction of an anti-fact.