### PR TITLE
Allow assignment guards to bind an object literal

### DIFF
--- a/r_exec/binding_map.cpp
+++ b/r_exec/binding_map.cpp
@@ -874,6 +874,10 @@ void BindingMap::bind_variable(Atom *code, uint8 id, uint16 value_index, Atom *i
   if (v_atom.isFloat())
     bind_variable(new AtomValue(this, v_atom), id);
   else switch (v_atom.getDescriptor()) {
+  case Atom::OBJECT:
+    // Assume this is an object literal like (vec3 -0.5 0 0).
+    bind_variable(new StructureValue(this, code, value_index), id);
+    break;
   case Atom::VALUE_PTR:
     bind_variable(new StructureValue(this, intermediate_results, v_atom.asIndex()), id);
     break;


### PR DESCRIPTION
We want to be able to make a model like this:

    mdl_displace_hand:(mdl [H: P0: (ti T0: T1:)] []
       (fact (cmd move [H: DeltaP:] :) T2: T1_cmd: : :)
       (|fact (mk.val H: position P0: :) T1_RHS: T3: : :)
    []
       T1_RHS:(+ T0 100ms)
       T3:(+ T1 100ms)
    []
       T2:(- T1_RHS 80ms)
       T1_cmd:(- T3 100ms)
       T0:(- T1_RHS 100ms)
       T1:(- T3 100ms)
       DeltaP:(vec3 -0.5 0 0))

Notice that the value of an assignment guard is usually an operator like `(- T3 100ms)` in the assignment for `T1`. But notice that the value of the assignment for `DeltaP` is the literal `(vec3 -0.5 0 0)`. Currently, the AERA code assumes that the value of an assignment guard is always the result of evaluating an operator. But we want to allow an object literal.

This pull request updates `BindingMap::bind_variable` to allow the value to be a structured object like `(vec3 -0.5 0 0)` .

NOTE: There also could be the case that a literal is a simple number like `DeltaP:5` . Right now the syntax of Replicode doesn't allow this, so we would have to update the code parser and possibly other places to support this. The workaround is to use an operator like `DeltaP:(+ 5 0)` .