### PR TITLE
Add the identity operator (id X)

### DIFF
--- a/AERA/Demo1/std.replicode
+++ b/AERA/Demo1/std.replicode
@@ -82,6 +82,7 @@
 !op (is_sim :):bl
 !op (min : :):
 !op (max : :):
+!op (id :):
 
 ; operator aliases.
 !def now (_now)

--- a/AERA/replicode_v1.2/std.replicode
+++ b/AERA/replicode_v1.2/std.replicode
@@ -90,6 +90,7 @@
 !op (is_sim :):bl
 !op (min : :):
 !op (max : :):
+!op (id :):
 
 ; operator aliases.
 !def now (_now)

--- a/r_exec/init.cpp
+++ b/r_exec/init.cpp
@@ -423,6 +423,7 @@ bool InitOpcodes(const r_comp::Metadata& metadata) {
   Opcodes::MkActChg = _Opcodes.find("mk.act_chg")->second;
 
   Opcodes::Sim = _Opcodes.find("sim")->second;
+  Opcodes::Id = _Opcodes.find("id")->second;
 
   // load executive function Opcodes.
   Opcodes::Inject = _Opcodes.find("_inj")->second;
@@ -471,6 +472,7 @@ bool InitOpcodes(const r_comp::Metadata& metadata) {
   Operator::Register(operator_opcode++, is_sim);
   Operator::Register(operator_opcode++, minimum);
   Operator::Register(operator_opcode++, maximum);
+  Operator::Register(operator_opcode++, id);
 
   return true;
 }

--- a/r_exec/opcodes.cpp
+++ b/r_exec/opcodes.cpp
@@ -141,6 +141,7 @@ uint16 Opcodes::MkSlnChg;
 uint16 Opcodes::MkActChg;
 
 uint16 Opcodes::Sim;
+uint16 Opcodes::Id;
 
 uint16 Opcodes::Inject;
 uint16 Opcodes::Eject;

--- a/r_exec/opcodes.h
+++ b/r_exec/opcodes.h
@@ -151,6 +151,7 @@ public:
   static uint16 MkActChg;
 
   static uint16 Sim;
+  static uint16 Id;
 
   static uint16 Inject;
   static uint16 Eject;

--- a/r_exec/operator.cpp
+++ b/r_exec/operator.cpp
@@ -897,4 +897,18 @@ bool maximum(const Context &context) {
   return false;
 }
 
+bool id(const Context& context) {
+  Context arg = *context.get_child(1);
+
+  if (arg[0].isFloat()) {
+
+    context.setAtomicResult(Atom::Float(arg[0].asFloat()));
+    return true;
+  }
+  // TODO: Support copying a structured object (with possible nested structures).
+
+  context.setAtomicResult(Atom::Nil());
+  return false;
+}
+
 }

--- a/r_exec/operator.h
+++ b/r_exec/operator.h
@@ -241,6 +241,7 @@ bool fvw(const Context &context); // executive-dependent.
 bool is_sim(const Context &context);
 bool minimum(const Context &context);
 bool maximum(const Context &context);
+bool id(const Context& context);
 }
 
 


### PR DESCRIPTION
Similar to PR #279, we want to be able to make a model like this:

    mdl_displace_hand:(mdl [H: P0: (ti T0: T1:)] []
       (fact (cmd move [H: DeltaP:] :) T2: T1_cmd: : :)
       (|fact (mk.val H: position P0: :) T1_RHS: T3: : :)
    []
       T1_RHS:(+ T0 100ms)
       T3:(+ T1 100ms)
    []
       T2:(- T1_RHS 80ms)
       T1_cmd:(- T3 100ms)
       T0:(- T1_RHS 100ms)
       T1:(- T3 100ms)
       DeltaP:5

In this case the fixed value for `DeltaP` is just the number 5. The problem is that Replicode syntax doesn't allow `DeltaP:5`. (The opcode for an assignment guard is similar to I_PTR and must point to a structure value.)

As a solution, this PR adds the identity operator `(id X)` which just returns the value `X`. Now, the guard can be `DeltaP:(id 5)` which is valid syntax.
