### PR TITLE
success object: Add optional obj_mk_rdx

### DIFF
--- a/AERA/replicode_v1.2/std.replicode
+++ b/AERA/replicode_v1.2/std.replicode
@@ -58,7 +58,7 @@
 !class (imdl (_obj {mdl:mdl tpl_args:[] args:[] wr_e:bl}))
 !class (pred (_obj {obj: sims:[::sim]}))
 !class (goal (_obj {obj: actr:ent sim:}))
-!class (success (_obj {obj: evd:}))
+!class (success (_obj {obj: evd: obj_mk_val:})); evd and obj_mk_val can be nil.
 !class (mk.grp_pair (_obj {primary:grp secondary:grp}))
 
 ; performance counters (latencies).

--- a/r_code/replicode_defs.h
+++ b/r_code/replicode_defs.h
@@ -257,7 +257,8 @@
 
 #define SUCCESS_OBJ 1
 #define SUCCESS_EVD 2
-#define SUCCESS_ARITY 3
+#define SUCCESS_OBJ_MK_RDX 3
+#define SUCCESS_ARITY 4
 
 
 #define GRP_PAIR_FIRST 1

--- a/r_exec/factory.cpp
+++ b/r_exec/factory.cpp
@@ -866,7 +866,7 @@ MkRdx::MkRdx(Code *imdl_fact, Code *input1, Code *input2, Code *output, float32 
 Success::Success() : LObject() {
 }
 
-Success::Success(_Fact *object, _Fact *evidence, float32 psln_thr) : LObject() {
+Success::Success(_Fact *object, _Fact *evidence, Code* object_mk_rdx, float32 psln_thr) : LObject() {
 
   code(0) = Atom::Object(Opcodes::Success, SUCCESS_ARITY);
   code(SUCCESS_OBJ) = Atom::RPointer(references_size());
@@ -878,6 +878,13 @@ Success::Success(_Fact *object, _Fact *evidence, float32 psln_thr) : LObject() {
   }
   else
     code(SUCCESS_EVD) = Atom::Nil();
+
+  if (object_mk_rdx) {
+    code(SUCCESS_OBJ_MK_RDX) = Atom::RPointer(references_size());
+    add_reference(object_mk_rdx);
+  }
+  else
+    code(SUCCESS_OBJ_MK_RDX) = Atom::Nil();
 
   code(SUCCESS_ARITY) = Atom::Float(psln_thr);
 }

--- a/r_exec/factory.h
+++ b/r_exec/factory.h
@@ -586,7 +586,8 @@ class r_exec_dll Success :
   public LObject {
 public:
   Success();
-  Success(_Fact *object, _Fact *evidence, float32 psln_thr);
+  Success(_Fact *object, _Fact *evidence, r_code::Code* object_mk_rdx, float32 psln_thr);
+  Success(_Fact* object, _Fact* evidence, float32 psln_thr): Success(object, evidence, NULL, psln_thr) {}
 
   /**
    * Get the object of this Success.

--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1370,7 +1370,7 @@ void TopLevelMDLController::predict(HLPBindingMap *bm, _Fact *input, Fact *f_imd
   MkRdx* ground_mk_rdx, vector<P<_Fact> >& already_predicted) { // no prediction here.
 }
 
-void TopLevelMDLController::register_pred_outcome(Fact *f_pred, bool success, _Fact *evidence, float32 confidence, bool rate_failures) {
+void TopLevelMDLController::register_pred_outcome(Fact *f_pred, Code* mk_rdx, bool success, _Fact *evidence, float32 confidence, bool rate_failures) {
 }
 
 void TopLevelMDLController::register_goal_outcome(Fact *goal, bool success, _Fact *evidence) const {
@@ -2352,7 +2352,7 @@ inline Fact* PrimaryMDLController::predict_simulated_evidence(_Fact *evidence, S
   return fact_pred;
 }
 
-void PrimaryMDLController::register_pred_outcome(Fact *f_pred, bool success, _Fact *evidence, float32 confidence, bool rate_failures) {
+void PrimaryMDLController::register_pred_outcome(Fact *f_pred, Code* mk_rdx, bool success, _Fact *evidence, float32 confidence, bool rate_failures) {
 
   f_pred->invalidate();
 
@@ -2366,7 +2366,7 @@ void PrimaryMDLController::register_pred_outcome(Fact *f_pred, bool success, _Fa
   if (!f_evidence) // failure: assert absence of the pred target.
     f_evidence = f_pred->get_pred()->get_target()->get_absentee();
 
-  Success *success_object = new Success(f_pred, f_evidence, 1);
+  Success *success_object = new Success(f_pred, f_evidence, mk_rdx, 1);
   Code *f_success_object;
   auto now = Now();
   // We print the result to the output below, after injecting f_success_object to get its OID.
@@ -2856,7 +2856,7 @@ void SecondaryMDLController::rate_model() { // acknowledge successes only; the p
     OUTPUT_LINE(MDL_REV, Utils::RelativeTime(Now()) << " mdl " << model->get_oid() << " phased in");
 }
 
-void SecondaryMDLController::register_pred_outcome(Fact *f_pred, bool success, _Fact *evidence, float32 confidence, bool rate_failures) { // success==false means executed in the thread of a time core; otherwise, executed in the same thread as for Controller::reduce().
+void SecondaryMDLController::register_pred_outcome(Fact *f_pred, Code* mk_rdx, bool success, _Fact *evidence, float32 confidence, bool rate_failures) { // success==false means executed in the thread of a time core; otherwise, executed in the same thread as for Controller::reduce().
 
   register_req_outcome(f_pred, success, rate_failures);
 }

--- a/r_exec/mdl_controller.h
+++ b/r_exec/mdl_controller.h
@@ -114,7 +114,7 @@ public:
    * Create a HLPBindingMap with the given values.
    * \param map The HLPBindingMap. This keeps a P<HLPBindingMap> for it.
    * \param ground A pointer to the Fact which is the ground for the bindings. This only keeps a pointer.
-   * \param ground_mk_rdx A pointer to the mk.rdx which made groung, or NULL if not available. This only keeps a pointer.
+   * \param ground_mk_rdx A pointer to the mk.rdx which made ground, or NULL if not available. This only keeps a pointer.
    */
   BindingResult(HLPBindingMap* map, Fact* ground, MkRdx* ground_mk_rdx)
   {
@@ -300,7 +300,7 @@ public:
 
   virtual void predict(HLPBindingMap *bm, _Fact *input, Fact *f_imdl, bool chaining_was_allowed, RequirementsPair &r_p, Fact *ground,
     MkRdx* ground_mk_rdx, std::vector<P<_Fact> >& already_predicted) = 0;
-  virtual void register_pred_outcome(Fact *f_pred, bool success, _Fact *evidence, float32 confidence, bool rate_failures) = 0;
+  virtual void register_pred_outcome(Fact *f_pred, r_code::Code* mk_rdx, bool success, _Fact *evidence, float32 confidence, bool rate_failures) = 0;
   virtual void register_req_outcome(Fact *f_pred, bool success, bool rate_failures) = 0;
 
   void add_requirement_to_rhs();
@@ -399,7 +399,7 @@ public:
 
   void predict(HLPBindingMap *bm, _Fact *input, Fact *f_imdl, bool chaining_was_allowed, RequirementsPair &r_p, Fact *ground,
     MkRdx* ground_mk_rdx, std::vector<P<_Fact> >& already_predicted) override;
-  void register_pred_outcome(Fact *f_pred, bool success, _Fact *evidence, float32 confidence, bool rate_failures) override;
+  void register_pred_outcome(Fact *f_pred, r_code::Code* mk_rdx, bool success, _Fact *evidence, float32 confidence, bool rate_failures) override;
   void register_goal_outcome(Fact *goal, bool success, _Fact *evidence) const override;
   void register_simulated_goal_outcome(Fact *goal, bool success, _Fact *evidence) const override;
   void register_req_outcome(Fact *f_pred, bool success, bool rate_failures) override;
@@ -475,7 +475,7 @@ public:
     MkRdx* ground_mk_rdx, std::vector<P<_Fact> >& already_predicted) override;
   bool inject_prediction(Fact *prediction, Fact *f_imdl, float32 confidence, Timestamp::duration time_to_live, r_code::Code *mk_rdx) const; // here, resilience=time to live, in us; returns true if the prediction has actually been injected.
 
-  void register_pred_outcome(Fact *f_pred, bool success, _Fact *evidence, float32 confidence, bool rate_failures) override;
+  void register_pred_outcome(Fact *f_pred, r_code::Code* mk_rdx, bool success, _Fact *evidence, float32 confidence, bool rate_failures) override;
   void register_req_outcome(Fact *f_pred, bool success, bool rate_failures) override;
 
   void register_goal_outcome(Fact *goal, bool success, _Fact *evidence) const override;
@@ -549,7 +549,7 @@ public:
 
   void predict(HLPBindingMap *bm, _Fact *input, Fact *f_imdl, bool chaining_was_allowed, RequirementsPair &r_p, Fact *ground,
     MkRdx* ground_mk_rdx, std::vector<P<_Fact> >& already_predicted) override;
-  void register_pred_outcome(Fact *f_pred, bool success, _Fact *evidence, float32 confidence, bool rate_failures) override;
+  void register_pred_outcome(Fact *f_pred, r_code::Code* mk_rdx, bool success, _Fact *evidence, float32 confidence, bool rate_failures) override;
   void register_req_outcome(Fact *f_pred, bool success, bool rate_failures) override;
 };
 }

--- a/r_exec/p_monitor.cpp
+++ b/r_exec/p_monitor.cpp
@@ -140,11 +140,11 @@ bool PMonitor::reduce(_Fact *input) { // input is always an actual fact.
     //uint32 oid=input->get_oid();
     switch (((Fact *)input)->is_evidence(prediction_target_)) {
     case MATCH_SUCCESS_POSITIVE:
-      controller_->register_pred_outcome(target_, true, input, input->get_cfd(), rate_failures_);
+      controller_->register_pred_outcome(target_, mk_rdx_, true, input, input->get_cfd(), rate_failures_);
       return true;
     case MATCH_SUCCESS_NEGATIVE:
       if (rate_failures_)
-        controller_->register_pred_outcome(target_, false, input, input->get_cfd(), rate_failures_);
+        controller_->register_pred_outcome(target_, mk_rdx_, false, input, input->get_cfd(), rate_failures_);
       return true;
     case MATCH_FAILURE:
       return false;
@@ -162,7 +162,7 @@ void PMonitor::update(Timestamp &next_target) { // executed by a time core, upon
     // TODO: If the model correctly predicts an anti-fact that the object won't be observed, then should we register
     // a success for the model? If yes then what should "evidence" point? Maybe nil?
     if (rate_failures_ && target_->get_pred()->get_target()->is_fact())
-      controller_->register_pred_outcome(target_, false, NULL, 1, rate_failures_);
+      controller_->register_pred_outcome(target_, mk_rdx_, false, NULL, 1, rate_failures_);
   }
   controller_->remove_monitor(this);
   next_target = Timestamp(seconds(0));


### PR DESCRIPTION
Background: Currently the success object is defined as:

    (success obj evidence)

where `obj` is a goal or prediction, and `evidence` is a fact which shows that the goal or prediction is achieved. (Alternatively, if the success object is linked from an anti-fact then it shows failure and `evidence` is the contradicting fact.) Take the case when `obj` is a prediction from a model like `(fact (pred (fact (mk.val h position 5))))` . In the next frame, the evidence `(fact (mk.val h position 5))` is observed, and a success object is injected with these values.

Note that the model made a prediction based on an actual LHS like `(fact (cmd move [h -20]))`, along with a requirement which contains the prerequisite environment state. This is all contained in the reduction marker which is already injected like `(mk.rdx f_imdl [fact_cmd requirement_mk_rdx] [fact_prediction])`. This contains a lot of information which could be useful later if the prediction fails, or if it succeeds and we want to make other models based on it (like GTPX).

This pull request updates the success object to add an optional field for the reduction marker:

    (success obj evidence obj_mk_val)

where `obj_mk_val` is the reduction marker which produced the goal/prediction, or `nil` if not available. In the code, the prediction monitor already has the reduction marker from when the prediction was made. When the prediction monitor injects the success object, it includes the reduction marker. Now all the information about a prediction can be recovered.
