### PR TITLE
In is_drive, also check for Ent

### DIFF
--- a/r_exec/factory.h
+++ b/r_exec/factory.h
@@ -509,7 +509,7 @@ public:
   bool is_requirement() const;
 
   bool is_self_goal() const;
-  bool is_drive() const { return (!has_sim() && is_self_goal()); }
+  bool is_drive() const { return (!has_sim() && is_self_goal() && get_target()->get_reference(0)->code(0).asOpcode() == Opcodes::Ent); }
 
   _Fact *get_target() const { return (_Fact *)get_reference(0); }
   _Fact *get_super_goal() const { return get_sim()->get_f_super_goal(); }


### PR DESCRIPTION
Background: A drive is a fact where the object is a simple token like `run`. For example, `(fact run 1s:400ms:0us 2s:0ms:0us 1 1)`. Currently, the method `is_drive` checks that a goal is drive if it is not a simulation, and that the actor is `self`. But it doesn't make sure that the object is a token like `run`.

This pull request adds this check to `is_drive`. (The way to check is because the object is defined as an `Ent`. This same check is [made elsewhere](https://github.com/IIIM-IS/AERA/blob/4436fe13458e46b1f54238024db8ce3cd923b24c/r_exec/mdl_controller.cpp#L304) too.)

Details on why this hasn't been an issue before now: Most goal objects are simulated goals during simulated backward chaining. Non-simulated goals are usually drives that are handled in `TopLevelMDLController::reduce`. But now we are working with non-simulated goals which are not drives in order to automate the "experimentation" phase. For example, `(fact (goal (|fact (mk.val h position 10))))` to not be at a position. This is handled in `PrimaryMDLController::reduce` which [makes sure that the goal is not a drive](https://github.com/IIIM-IS/AERA/blob/4436fe13458e46b1f54238024db8ce3cd923b24c/r_exec/mdl_controller.cpp#L1781). Without the fix in this pull request, the definition of `is_drive` is overly broad and so this goal is incorrectly ignored. 