### PR TITLE
Minor code change to fix bug when intersecting two binding maps

### DIFF
--- a/r_exec/binding_map.cpp
+++ b/r_exec/binding_map.cpp
@@ -304,7 +304,8 @@ bool StructureValue::contains(const Atom *s) const {
       continue;
 
     if (a.isFloat() && _a.isFloat())
-      return Utils::Equal(a.asFloat(), _a.asFloat());
+      if (Utils::Equal(a.asFloat(), _a.asFloat()))
+        continue;
 
     return false;
   }


### PR DESCRIPTION
In the 'contains(...)' method called during intersect of two binding maps, when the checked for code object is an object consisting of floats, only the first one was compared to assess whether they are the same. Now it checks all fields of objects that are floats and only returns true when all parts of both sides are the same.