### PR TITLE
r_comp: Don't treat trailing space as comment continuation

### DIFF
--- a/r_comp/preprocessor.cpp
+++ b/r_comp/preprocessor.cpp
@@ -215,7 +215,7 @@ int32 RepliStruct::parse(std::istream *stream, const std::string& file_path, uin
     case 13:
       // remain inComment?
       if (in_comment) {
-        if ((lastc == ' ') || ((lastc == '.') && (lastcc == '.')))
+        if ((lastc == '.') && (lastcc == '.'))
           continue; // continue comment on next line
         else
           in_comment = false; // end comment


### PR DESCRIPTION
The Replicode spec says that a comment ending in " .." is continued to the next line. The preprocessor handles this and checks for "..". But it also treats a single space as a comment continuation. This causes problems since it is common for a comment to end in a space (since it's difficult to see in the text editor). This appeared as a problem in Linux where the end of line is just a newline (not like carriagereturn/newline in Windows). The handling of end of lines is a [separate issue](https://github.com/IIIM-IS/AERA/issues/293). This PR simply changes the preprocessor to not treat an ending space as a comment continuation.