### PR TITLE
r_exec: In update_timestamps, skip C_PTR

### DIFF
--- a/r_exec/mem.cpp
+++ b/r_exec/mem.cpp
@@ -414,6 +414,8 @@ static void update_timestamps(Timestamp time_reference, Atom* code, uint16 index
     update_timestamps(time_reference, code, atom.asIndex());
     break;
   case Atom::C_PTR:
+    // A C_PTR doesn't have a timestamp. Plus it uses I_PTR with a different meaning. Skip.
+    break;
   case Atom::SET:
   case Atom::OBJECT:
   case Atom::S_SET:


### PR DESCRIPTION
When `update_timestamps` sees an `I_PTR`, it recursively calls itself to update the code which is pointed to. But consider the code of `(set [this.vw.res 0])` (starting at index 11):
```
0	obj: 13 (ln/pgm/point_at) 5
1	   iptr: 6
2	   iptr: 7
3	   iptr: 8
4	   iptr: 9
5	   nb: 1.000000e+00
6	set: 0
7	set: 0
8	set: 0
9	set: 1
10	   iptr: 11
11	obj: 16 (e10/icmd/release_hand) 2
12	   fid: 3 (_set/neq/val_hld)
13	   iptr: 14
14	set: 2
15	   iptr: 17
16	   nb: 0.000000e+00
17	cptr: 3
18	   this
19	   view
20	   iptr: 4
```
The `C_PTR` at index 17 represents `this.vw.res`. Notice the `I_PTR` at index 20. Normally, an `I_PTR` gives the index in the current code object. But the representation of `C_PTR` re-uses `I_PTR` with a different meaning. In this case the 4 means argument number 4 of the `this.vw`, which is the `res`. In this case, `update_timestamps` should not treat it as a normal `I_PTR` and it should not recursively call itself. As discovered by @shmax13, this can cause a bug where `update_timestamps` keeps calling itself and causes a stack overflow.

Therefore, this PR updates `update_timestamps` to ignore a `C_PTR`. This is OK because a `C_PTR` doesn't have a timestamp, so there is nothing to update.