### PR TITLE
Use Windows SDK 10.0.19041.0

### DIFF
--- a/AERA/AERA.vcxproj
+++ b/AERA/AERA.vcxproj
@@ -18,7 +18,7 @@
     <ProjectGuid>{689F2DDD-1858-499D-BA79-72BA02D00D45}</ProjectGuid>
     <RootNamespace>Test</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
     <ProjectName>AERA</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/output_window/output_window.vcxproj
+++ b/output_window/output_window.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{D6CF951E-F865-4A26-8CCC-D4D5C67EAF93}</ProjectGuid>
     <RootNamespace>output_window</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/r_code/r_code.vcxproj
+++ b/r_code/r_code.vcxproj
@@ -18,7 +18,7 @@
     <ProjectGuid>{6F4E1695-BBEF-46D1-B0C0-1B71A65FAD66}</ProjectGuid>
     <RootNamespace>r_code</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugVisualizer|Win32'" Label="Configuration">

--- a/r_comp/r_comp.vcxproj
+++ b/r_comp/r_comp.vcxproj
@@ -18,7 +18,7 @@
     <ProjectGuid>{345E47D7-90E9-482B-AD10-C11CC828E197}</ProjectGuid>
     <RootNamespace>r_comp</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugVisualizer|Win32'" Label="Configuration">

--- a/r_exec/r_exec.vcxproj
+++ b/r_exec/r_exec.vcxproj
@@ -18,7 +18,7 @@
     <ProjectGuid>{C36B96EC-EF72-4B21-87BE-2130E997BDA0}</ProjectGuid>
     <RootNamespace>r_exec</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugVisualizer|Win32'" Label="Configuration">

--- a/usr_operators/usr_operators.vcxproj
+++ b/usr_operators/usr_operators.vcxproj
@@ -18,7 +18,7 @@
     <ProjectGuid>{3DE12B3F-D45E-46E1-B501-E294009AD4B9}</ProjectGuid>
     <RootNamespace>usr_operators</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugVisualizer|Win32'" Label="Configuration">


### PR DESCRIPTION
The latest Visual Studio 2022 removes support for Windows SDK 10.0.18362.0, so update to 10.0.19041.0 . (This is similar to what we did in PR https://github.com/IIIM-IS/AERA/pull/271 .)