### PR TITLE
Calculation of the score for plans

### DIFF
--- a/AERA/AERA.vcxproj
+++ b/AERA/AERA.vcxproj
@@ -143,6 +143,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="AERA_main.cpp" />
+    <ClCompile Include="take_vehicles_io_device.cpp" />
     <ClCompile Include="IODevices\TCP\AERA_Protobuf\tcp_connection.cpp" />
     <ClCompile Include="IODevices\TCP\AERA_Protobuf\tcp_data_message.pb.cc" />
     <ClCompile Include="IODevices\TCP\tcp_io_device.cpp" />
@@ -153,6 +154,7 @@
     <ClCompile Include="tower_of_hanoi_io_device.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="take_vehicles_io_device.h" />
     <ClInclude Include="IODevices\TCP\AERA_Protobuf\tcp_connection.h" />
     <ClInclude Include="IODevices\TCP\AERA_Protobuf\tcp_data_message.pb.h" />
     <ClInclude Include="IODevices\TCP\AERA_Protobuf\utils.h" />

--- a/AERA/AERA.vcxproj
+++ b/AERA/AERA.vcxproj
@@ -143,6 +143,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="AERA_main.cpp" />
+    <ClCompile Include="open_door_io_device.cpp" />
     <ClCompile Include="take_vehicles_io_device.cpp" />
     <ClCompile Include="IODevices\TCP\AERA_Protobuf\tcp_connection.cpp" />
     <ClCompile Include="IODevices\TCP\AERA_Protobuf\tcp_data_message.pb.cc" />
@@ -154,6 +155,7 @@
     <ClCompile Include="tower_of_hanoi_io_device.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="open_door_io_device.h" />
     <ClInclude Include="take_vehicles_io_device.h" />
     <ClInclude Include="IODevices\TCP\AERA_Protobuf\tcp_connection.h" />
     <ClInclude Include="IODevices\TCP\AERA_Protobuf\tcp_data_message.pb.h" />

--- a/AERA/AERA.vcxproj
+++ b/AERA/AERA.vcxproj
@@ -150,6 +150,7 @@
     <ClCompile Include="IODevices\video_screen\video_screen_io_device.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="test_mem.cpp" />
+    <ClCompile Include="tower_of_hanoi_io_device.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="IODevices\TCP\AERA_Protobuf\tcp_connection.h" />
@@ -161,6 +162,7 @@
     <ClInclude Include="main.h" />
     <ClInclude Include="settings.h" />
     <ClInclude Include="test_mem.h" />
+    <ClInclude Include="tower_of_hanoi_io_device.h" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="settings.xml">

--- a/AERA/AERA.vcxproj.filters
+++ b/AERA/AERA.vcxproj.filters
@@ -19,6 +19,9 @@
     <ClCompile Include="IODevices\TCP\AERA_Protobuf\tcp_connection.cpp">
       <Filter>IODevices\TCP\AERA_Protobuf</Filter>
     </ClCompile>
+    <ClCompile Include="tower_of_hanoi_io_device.cpp">
+      <Filter>IODevices\tower_of_hanoi</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="settings.h" />
@@ -41,6 +44,9 @@
     </ClInclude>
     <ClInclude Include="IODevices\TCP\AERA_Protobuf\tcp_connection.h">
       <Filter>IODevices\TCP\AERA_Protobuf</Filter>
+    </ClInclude>
+    <ClInclude Include="tower_of_hanoi_io_device.h">
+      <Filter>IODevices\tower_of_hanoi</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -70,6 +76,9 @@
     </Filter>
     <Filter Include="IODevices\TCP\AERA_Protobuf">
       <UniqueIdentifier>{ce2ba5d1-fcef-4708-80fe-1d70bea0460c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="IODevices\tower_of_hanoi">
+      <UniqueIdentifier>{154315f7-1369-4472-b55d-b4f1e43601db}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/AERA/AERA.vcxproj.filters
+++ b/AERA/AERA.vcxproj.filters
@@ -25,6 +25,9 @@
     <ClCompile Include="take_vehicles_io_device.cpp">
       <Filter>IODevices\take_vehicles</Filter>
     </ClCompile>
+    <ClCompile Include="open_door_io_device.cpp">
+      <Filter>IODevices\open_door</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="settings.h" />
@@ -53,6 +56,9 @@
     </ClInclude>
     <ClInclude Include="take_vehicles_io_device.h">
       <Filter>IODevices\take_vehicles</Filter>
+    </ClInclude>
+    <ClInclude Include="open_door_io_device.h">
+      <Filter>IODevices\open_door</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -88,6 +94,9 @@
     </Filter>
     <Filter Include="IODevices\take_vehicles">
       <UniqueIdentifier>{b0329e2a-cc74-4655-99ac-ddf93d42b13f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="IODevices\open_door">
+      <UniqueIdentifier>{a0019123-562b-46b4-af8f-b332bee5b333}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/AERA/AERA.vcxproj.filters
+++ b/AERA/AERA.vcxproj.filters
@@ -22,6 +22,9 @@
     <ClCompile Include="tower_of_hanoi_io_device.cpp">
       <Filter>IODevices\tower_of_hanoi</Filter>
     </ClCompile>
+    <ClCompile Include="take_vehicles_io_device.cpp">
+      <Filter>IODevices\take_vehicles</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="settings.h" />
@@ -47,6 +50,9 @@
     </ClInclude>
     <ClInclude Include="tower_of_hanoi_io_device.h">
       <Filter>IODevices\tower_of_hanoi</Filter>
+    </ClInclude>
+    <ClInclude Include="take_vehicles_io_device.h">
+      <Filter>IODevices\take_vehicles</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -79,6 +85,9 @@
     </Filter>
     <Filter Include="IODevices\tower_of_hanoi">
       <UniqueIdentifier>{154315f7-1369-4472-b55d-b4f1e43601db}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="IODevices\take_vehicles">
+      <UniqueIdentifier>{b0329e2a-cc74-4655-99ac-ddf93d42b13f}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/AERA/main.cpp
+++ b/AERA/main.cpp
@@ -89,6 +89,7 @@
 #include "IODevices/video_screen/video_screen_io_device.h"
 #include "tower_of_hanoi_io_device.h"
 #include "take_vehicles_io_device.h"
+#include "open_door_io_device.h"
 #include "../usr_operators/usr_operators.h"
 #include "test_mem.h"
 #include "../r_exec/init.h"
@@ -367,6 +368,9 @@ int32 start_AERA(const char* file_name, const char* decompiled_file_name) {
     }
     else if (settings.io_device_.compare("take_vehicles") == 0) {
       mem = new take_vehicles::TakeVehiclesIODevice();
+    }
+    else if (settings.io_device_.compare("open_door") == 0) {
+      mem = new OpenDoorIODevice();
     }
     else {
       std::cout << "Unrecognized io_device \"" << settings.io_device_ << "\"" << std::endl;

--- a/AERA/main.cpp
+++ b/AERA/main.cpp
@@ -88,6 +88,7 @@
 #include "IODevices/TCP/tcp_io_device.h"
 #include "IODevices/video_screen/video_screen_io_device.h"
 #include "tower_of_hanoi_io_device.h"
+#include "take_vehicles_io_device.h"
 #include "../usr_operators/usr_operators.h"
 #include "test_mem.h"
 #include "../r_exec/init.h"
@@ -363,6 +364,9 @@ int32 start_AERA(const char* file_name, const char* decompiled_file_name) {
     }
     else if (settings.io_device_.compare("tower_of_hanoi") == 0) {
       mem = new tower_of_hanoi::TowerOfHanoiIODevice(settings.source_file_name_);
+    }
+    else if (settings.io_device_.compare("take_vehicles") == 0) {
+      mem = new take_vehicles::TakeVehiclesIODevice();
     }
     else {
       std::cout << "Unrecognized io_device \"" << settings.io_device_ << "\"" << std::endl;

--- a/AERA/main.cpp
+++ b/AERA/main.cpp
@@ -87,6 +87,7 @@
 #include "../r_comp/decompiler.h"
 #include "IODevices/TCP/tcp_io_device.h"
 #include "IODevices/video_screen/video_screen_io_device.h"
+#include "tower_of_hanoi_io_device.h"
 #include "../usr_operators/usr_operators.h"
 #include "test_mem.h"
 #include "../r_exec/init.h"
@@ -359,6 +360,9 @@ int32 start_AERA(const char* file_name, const char* decompiled_file_name) {
         mem = new video_screen::VideoScreenIoDevice<r_exec::LObject, r_exec::MemStatic>();
       else
         mem = new video_screen::VideoScreenIoDevice<r_exec::LObject, r_exec::MemVolatile>();
+    }
+    else if (settings.io_device_.compare("tower_of_hanoi") == 0) {
+      mem = new tower_of_hanoi::TowerOfHanoiIODevice(settings.source_file_name_);
     }
     else {
       std::cout << "Unrecognized io_device \"" << settings.io_device_ << "\"" << std::endl;

--- a/AERA/open_door_io_device.cpp
+++ b/AERA/open_door_io_device.cpp
@@ -1,0 +1,110 @@
+#include "open_door_io_device.h"
+
+using namespace r_code;
+using namespace r_exec;
+using namespace std::chrono;
+
+OpenDoorIODevice::OpenDoorIODevice() : handle_type_() {
+}
+
+bool OpenDoorIODevice::load(const std::vector<r_code::Code*>* objects, uint32 stdin_oid, uint32 stdout_oid, uint32 self_oid) {
+	if (!MemExec::load(objects, stdin_oid, stdout_oid, self_oid))
+		return false;
+
+  move_opcode_ = r_exec::GetOpcode("move");
+  turn_opcode_ = r_exec::GetOpcode("turn");
+  push_opcode_ = r_exec::GetOpcode("push");
+  pull_opcode_ = r_exec::GetOpcode("pull");
+
+  door_object_ = MemStatic::find_object(objects, "d");
+  handle_object_ = MemStatic::find_object(objects, "h");
+  you_object_ = MemStatic::find_object(objects, "you");
+
+  position_property_ = MemStatic::find_object(objects, "position");
+  state_property_ = MemStatic::find_object(objects, "state");
+  type_property_ = MemStatic::find_object(objects, "type");
+
+  open_state_ = MemStatic::find_object(objects, "open");
+  closed_state_ = MemStatic::find_object(objects, "closed");
+  unlocked_state_ = MemStatic::find_object(objects, "unlocked");
+
+  turning_type_ = MemStatic::find_object(objects, "turning");
+  push_type_ = MemStatic::find_object(objects, "t_push");
+  pull_type_ = MemStatic::find_object(objects, "t_pull");
+
+  start_point_position_ = MemStatic::find_object(objects, "start_point");
+  at_door_position_ = MemStatic::find_object(objects, "at_door");
+  room_position_ = MemStatic::find_object(objects, "room");
+
+  position_ = start_point_position_;
+  //handle_type_ = push_type_;
+  door_state_ = closed_state_;
+
+  return true;
+}
+
+Code* OpenDoorIODevice::eject(Code* command) {
+  uint16 function = (command->code(CMD_FUNCTION).atom_ >> 8) & 0x000000FF;
+  uint16 args_set_index = command->code(CMD_ARGS).asIndex();
+
+  if (function == move_opcode_) {
+    Code* you = command->get_reference(command->code(args_set_index + 1).asIndex());
+    Code* new_pos = command->get_reference(command->code(args_set_index + 2).asIndex());
+
+    if (new_pos == start_point_position_)
+      position_ = new_pos;
+    else if (new_pos == at_door_position_) {
+      position_ = new_pos;
+      if (handle_type_.empty())
+        handle_type_.push_back(pull_type_);
+    }
+    else if (new_pos == room_position_ && door_state_ == open_state_)
+      position_ = new_pos;
+
+    return command;
+  }
+  else if (function == turn_opcode_) {
+    Code* handle = command->get_reference(command->code(args_set_index + 1).asIndex());
+    if (handle_type_.size() != 0 && handle_type_[0] == turning_type_ && handle == handle_object_) {
+      door_state_ = unlocked_state_;
+    }
+
+    return command;
+  }
+  else if (function == push_opcode_) {
+    Code* door = command->get_reference(command->code(args_set_index + 1).asIndex());
+    if (door == door_object_) {
+      if (handle_type_.size() != 0 && handle_type_[0] == push_type_) {
+        door_state_ = open_state_;
+      }
+      if (handle_type_.size() != 0 && handle_type_[0] == turning_type_ && door_state_ == unlocked_state_) {
+        door_state_ = open_state_;
+      }
+    }
+
+    return command;
+  }
+  else if (function == pull_opcode_) {
+    Code* door = command->get_reference(command->code(args_set_index + 1).asIndex());
+    if (handle_type_.size() != 0 && handle_type_[0] == pull_type_ && door == door_object_) {
+      door_state_ = open_state_;
+    }
+
+    return command;
+  }
+
+  return NULL;
+}
+
+void OpenDoorIODevice::on_time_tick() {
+  auto now = r_exec::Now();
+
+  MemStatic::inject_marker_value_from_io_device(you_object_, position_property_, position_,
+    now, now + MemStatic::get_sampling_period());
+
+  MemStatic::inject_marker_value_from_io_device(door_object_, state_property_, door_state_,
+    now, now + MemStatic::get_sampling_period());
+
+  MemStatic::inject_marker_value_from_io_device(handle_object_, type_property_, handle_type_,
+    now, now + MemStatic::get_sampling_period());
+}

--- a/AERA/open_door_io_device.h
+++ b/AERA/open_door_io_device.h
@@ -1,0 +1,62 @@
+#ifndef open_door_io_device_h
+#define open_door_io_device_h
+
+#include "../r_exec/mem.h"
+
+class OpenDoorIODevice : public r_exec::MemExec<r_exec::LObject, r_exec::MemStatic> {
+
+public:
+  OpenDoorIODevice();
+
+  // Called in main.cpp
+  bool load(const std::vector<r_code::Code*>* objects, uint32 stdin_oid, uint32 stdout_oid, uint32 self_oid) override;
+
+  /**
+  * Receive a command from AERA.
+  *
+  * \return The given command if it is executed as-is, or a new command object of the command
+  * that is actually executed. The program controller will make a fact from the command and
+  * inject it as the efferent copy. However, if the command is not executed, then return NULL
+  * and the program controller will put an anti-fact of the command in the mk.rdx reduction.
+  */
+  r_code::Code* eject(r_code::Code* command) override;
+
+  // Called in DiagnosticTimeState::step()
+  void on_diagnostic_time_tick() override { on_time_tick(); }
+
+protected:
+  // Objects can be injected into the working memory from here (use injection functions from _Mem)
+  void on_time_tick();
+
+  uint16 move_opcode_;
+  uint16 turn_opcode_;
+  uint16 push_opcode_;
+  uint16 pull_opcode_;
+
+  r_code::Code* door_object_;
+  r_code::Code* handle_object_;
+  r_code::Code* you_object_;
+
+  r_code::Code* position_property_;
+  r_code::Code* state_property_;
+  r_code::Code* type_property_;
+
+  r_code::Code* open_state_;
+  r_code::Code* closed_state_;
+  r_code::Code* unlocked_state_;
+
+  r_code::Code* turning_type_;
+  r_code::Code* push_type_;
+  r_code::Code* pull_type_;
+
+  r_code::Code* start_point_position_;
+  r_code::Code* at_door_position_;
+  r_code::Code* room_position_;
+
+
+  r_code::Code* position_;
+  r_code::Code* door_state_;
+  std::vector<r_code::Code*> handle_type_;
+};
+
+#endif

--- a/AERA/replicode_v1.2/hand-grab-sphere-learn.replicode
+++ b/AERA/replicode_v1.2/hand-grab-sphere-learn.replicode
@@ -57,19 +57,20 @@ S3:(cst [] []
 |[]
 [stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
-!def pH0 25
-!def pS0 0
+!def pH0 20
+!def pC0 10
+!def pS0 5
 !def pS1 15
 
 ; Execute babble pass A commands.
 !def DRIVE_PASS1_START 1300ms
-!def DRIVE_PASS1_END (+ DRIVE_PASS1_START 300ms)
+!def DRIVE_PASS1_END (+ DRIVE_PASS1_START 100ms)
 ; Execute experimenting pass A commands.
 !def DRIVE_PASS2_START (+ DRIVE_PASS1_END 600ms)
 
 ; Initial conditions.
 start:(pgm [] [] [] []
-   (inj [State:(mk.val e1 emulator_state [nil 20 10 5] 1) []])
+   (inj [State:(mk.val e1 emulator_state [nil pH0 pC0 pS0] 1) []])
    (inj []
       (fact State After:(now) (+ After sampling_period) 1 1)
       [SYNC_PERIODIC now 1 1 emulator nil]

--- a/AERA/replicode_v1.2/hand-grab-sphere.replicode
+++ b/AERA/replicode_v1.2/hand-grab-sphere.replicode
@@ -12,13 +12,13 @@ c:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 c_is_a_cube:(mk.val c essence cube 1) |[]
 (fact c_is_a_cube 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 c_is_a_hand:(mk.val c essence hand 1) |[]
-; This is needed for S3.
+; This is needed for cst_ObjectPos.
 (|fact c_is_a_hand 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 s:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
 s_is_a_sphere:(mk.val s essence sphere 1) |[]
 (fact s_is_a_sphere 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 s_is_a_hand:(mk.val s essence hand 1) |[]
-; This is needed for S3.
+; This is needed for cst_ObjectPos.
 (|fact s_is_a_hand 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
 
 ; Internal state used by the programs to emulate the environment.
@@ -41,7 +41,7 @@ pgm_inject_in_emulator_group:(pgm [] []
    [SYNC_ONCE now 0 forever primary nil 1]
 
 ; Hand H has position P.
-S0:(cst [] []
+cst_HandPos:(cst [] []
    (fact (mk.val H: essence hand :) T0: T1: : :); Changed X to hand.
    (fact (mk.val H: position P: :) T0: T1: : :)
 |[]
@@ -49,7 +49,7 @@ S0:(cst [] []
 [stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; When I move H by offset DeltaP, then H will be at position P1.
-M0:(mdl [H: P0: (ti T0: T1:)] []
+mdl_Move:(mdl [H: P0: (ti T0: T1:)] []
    (fact (cmd move [H: DeltaP:] :) T2: T1_cmd: : :); Change T1 to T1_cmd.
    (fact (mk.val H: position P1: :) T1_RHS: T3: : :); Change T1 to T1_RHS.
 []
@@ -65,58 +65,58 @@ M0:(mdl [H: P0: (ti T0: T1:)] []
    T1:(- T3 100ms)
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
-; If we observe state S0 (hand H has position P0), then if M0 predicts something (position P1) it will be right.
-M1:(mdl [] []
-   (fact (icst S0 [] [H: P0:] : :) T0: T1: : :)
-   (fact (imdl M0 [H: P0: (ti T0: T1:)] [DeltaP: P1: T1_RHS: T3:] : :) T0: T1: : :); T2: is not exposed from M0. T1_RHS is also exposed.
+; If we observe state cst_HandPos (hand H has position P0), then if mdl_Move predicts something (position P1) it will be right.
+mdl_Move_req:(mdl [] []
+   (fact (icst cst_HandPos [] [H: P0:] : :) T0: T1: : :)
+   (fact (imdl mdl_Move [H: P0: (ti T0: T1:)] [DeltaP: P1: T1_RHS: T3:] : :) T0: T1: : :); T2: is not exposed from mdl_Move. T1_RHS is also exposed.
 |[]
 |[]
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; A thing C of kind X occupies position P. (Modified to exclude when C is a hand.)
-S3:(cst [] []
+cst_ObjectPos:(cst [] []
    (fact (mk.val C: essence X: :) T0: T1: : :)
    (fact (mk.val C: position P: :) T0: T1: : :)
-   (|fact (mk.val C: essence hand :) T0: T1: : :); Don't duplicate S0, which is for hands.
+   (|fact (mk.val C: essence hand :) T0: T1: : :); Don't duplicate cst_HandPos, which is for hands.
 |[]
 |[]
 [stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; One hand H is at a position P and another thing C is at the same position and the hand is not holding anything.
-S1:(cst [] []
-   (fact (icst S0 [] [H: P:] : :) T0: T1: : :)
-   (fact (icst S3 [] [C: X: P:] : :) T0: T1: : :); X is also exposed from S3.
+cst_NotHolding:(cst [] []
+   (fact (icst cst_HandPos [] [H: P:] : :) T0: T1: : :)
+   (fact (icst cst_ObjectPos [] [C: X: P:] : :) T0: T1: : :); X is also exposed from cst_ObjectPos.
    (fact (mk.val H: holding [] :) T0: T1: : :); Change anti-fact to fact of holding [].
 |[]
 |[]
 [stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; When the hand H is asked to grab whatever, then H will be holding it.
-M2:(mdl [H: C: (ti T0: T1:)] []
+mdl_Grab:(mdl [H: C: (ti T0: T1:)] []
    (fact (cmd grab [H:] :) T2: T1_cmd: : :); Change T1 to T1_cmd.
    (fact (mk.val H: holding [C:] :) T1_RHS: T3: : :); Change T1 to T1_RHS.
 []
-   T1_RHS:(+ T0 100ms); Copy from M0.
-   T3:(+ T1 100ms);     Copy from M0.
+   T1_RHS:(+ T0 100ms); Copy from mdl_Move.
+   T3:(+ T1 100ms);     Copy from mdl_Move.
 []
-   T2:(- T1_RHS 80ms);  Copy from M0.
-   T1_cmd:(- T3 100ms); Copy from M0.
-   T0:(- T1_RHS 100ms); Copy from M0.
-   T1:(- T3 100ms);     Copy from M0.
+   T2:(- T1_RHS 80ms);  Copy from mdl_Move.
+   T1_cmd:(- T3 100ms); Copy from mdl_Move.
+   T0:(- T1_RHS 100ms); Copy from mdl_Move.
+   T1:(- T3 100ms);     Copy from mdl_Move.
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
-; M2 will work (hand H will be holding something) if it is at the same position as hand H and H is not already holding anything.
-M3:(mdl [] []
-   (fact (icst S1 [] [H: P: C: X:] : :) T0: T1: : :); X is also exposed from S1.
-   (fact (imdl M2 [H: C: (ti T0: T1:)] [T1_RHS: T3:] : :) T0: T1: : :); T2 is not exposed from M2. T1_RHS is also exposed.
+; mdl_Grab will work (hand H will be holding something) if it is at the same position as hand H and H is not already holding anything.
+mdl_Grab_req:(mdl [] []
+   (fact (icst cst_NotHolding [] [H: P: C: X:] : :) T0: T1: : :); X is also exposed from cst_NotHolding.
+   (fact (imdl mdl_Grab [H: C: (ti T0: T1:)] [T1_RHS: T3:] : :) T0: T1: : :); T2 is not exposed from mdl_Grab. T1_RHS is also exposed.
 |[]
 |[]
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; Hand H and object C are at the same position P and H is already holding C.
-S2:(cst [] []
-   (fact (icst S0 [] [H: P:] : :) T0: T1: : :)
-   (fact (icst S3 [] [C: X: P:] : :) T0: T1: : :); X is also exposed from S3.
+cst_Holding:(cst [] []
+   (fact (icst cst_HandPos [] [H: P:] : :) T0: T1: : :)
+   (fact (icst cst_ObjectPos [] [C: X: P:] : :) T0: T1: : :); X is also exposed from cst_ObjectPos.
    (fact (mk.val H: holding [C:] :) T0: T1: : :)
 []
    (<> C nil); Make sure the object C is not nil.
@@ -125,45 +125,45 @@ S2:(cst [] []
 [stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; When my hand H is holding a thing C and I release my hand, it is not holding anymore.
-M4:(mdl [H: C: T0: T1:] []
+mdl_Release:(mdl [H: C: T0: T1:] []
    (fact (cmd release [H:] :) T2: T1_cmd: : :); Change T1 to T1_cmd.
    (fact (mk.val H: holding [] :) T1_RHS: T3: : :); Change T1 to T1_RHS. Change anti-fact to fact of holding [].
 []
-   T1_RHS:(+ T0 100ms); Copy from M0.
-   T3:(+ T1 100ms);     Copy from M0.
+   T1_RHS:(+ T0 100ms); Copy from mdl_Move.
+   T3:(+ T1 100ms);     Copy from mdl_Move.
 []
-   T2:(- T1_RHS 80ms);  Copy from M0.
-   T1_cmd:(- T3 100ms); Copy from M0.
-   T0:(- T1_RHS 100ms); Copy from M0.
-   T1:(- T3 100ms);     Copy from M0.
+   T2:(- T1_RHS 80ms);  Copy from mdl_Move.
+   T1_cmd:(- T3 100ms); Copy from mdl_Move.
+   T0:(- T1_RHS 100ms); Copy from mdl_Move.
+   T1:(- T3 100ms);     Copy from mdl_Move.
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
-; M4 will work (hand H will not be holding some C) if it is at the same position as hand H and H is already holding it.
-M5:(mdl [] []
-   (fact (icst S2 [] [H: P: C: X:] : :) T0: T1: : :); X is also exposed from S2.
-   (fact (imdl M4 [H: C: T0: T1:] [T1_RHS: T3:] : :) T0: T1: : :); T2 is not exposed from M4. T1_RHS is also exposed.
+; mdl_Release will work (hand H will not be holding some C) if it is at the same position as hand H and H is already holding it.
+mdl_Release_req:(mdl [] []
+   (fact (icst cst_Holding [] [H: P: C: X:] : :) T0: T1: : :); X is also exposed from cst_Holding.
+   (fact (imdl mdl_Release [H: C: T0: T1:] [T1_RHS: T3:] : :) T0: T1: : :); T2 is not exposed from mdl_Release. T1_RHS is also exposed.
 |[]
 |[]
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
-; When model M0 fires the prediction of the next position P1 of hand H, something C will also be at the same position P1.
-M6:(mdl [H: C: P0: (ti T0: T1:)] []
-   (fact (imdl M0 [H: P0: (ti T0: T1:)] [DeltaP: P1: T1_RHS: T3:] : :) T0_cmd: T1_cmd: : :); Change timings from T1 T3 to T0_cmd T1_cmd. T2 is not exposed from M0. T1_RHS is also exposed.
+; When model mdl_Move fires the prediction of the next position P1 of hand H, something C will also be at the same position P1.
+mdl_MoveObject:(mdl [H: C: P0: (ti T0: T1:)] []
+   (fact (imdl mdl_Move [H: P0: (ti T0: T1:)] [DeltaP: P1: T1_RHS: T3:] : :) T0_cmd: T1_cmd: : :); Change timings from T1 T3 to T0_cmd T1_cmd. T2 is not exposed from mdl_Move. T1_RHS is also exposed.
    (fact (mk.val C: position P1: :) T1_RHS: T3: : :); Fix bug as explained: Change C to P1. Change T1 to T1_RHS.
 []
-   T1_RHS:(+ T0 100ms); Repeat from M0.
-   T3:(+ T1 100ms);     Repeat from M0.
+   T1_RHS:(+ T0 100ms); Repeat from mdl_Move.
+   T3:(+ T1 100ms);     Repeat from mdl_Move.
 []
-   T0_cmd:(- T1_RHS 80ms);  Copy from M0.
-   T1_cmd:(- T3 100ms);     Copy from M0.
-   T0:(- T1_RHS 100ms);     Copy from M0.
-   T1:(- T3 100ms);         Copy from M0.
+   T0_cmd:(- T1_RHS 80ms);  Copy from mdl_Move.
+   T1_cmd:(- T3 100ms);     Copy from mdl_Move.
+   T0:(- T1_RHS 100ms);     Copy from mdl_Move.
+   T1:(- T3 100ms);         Copy from mdl_Move.
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
 
 ; When hand H is holding some C and the hand moves to position P1, then C will also be at P1.
-M7:(mdl [] []
-   (fact (icst S2 [] [H: P: C: X:] : :) T0: T1: : :); X is also exposed from S2.
-   (fact (imdl M6 [H: C: P: (ti T0: T1:)] [DeltaP: P1: T1_RHS: T3:] : :) T0: T1: : :); M6 template needs P. T0_M0 T1_M0, DeltaP, P1 and T1_RHS are exposed. T2 is not exposed from M6.
+mdl_MoveObject_req:(mdl [] []
+   (fact (icst cst_Holding [] [H: P: C: X:] : :) T0: T1: : :); X is also exposed from cst_Holding.
+   (fact (imdl mdl_MoveObject [H: C: P: (ti T0: T1:)] [DeltaP: P1: T1_RHS: T3:] : :) T0: T1: : :); mdl_MoveObject template needs P. T0_mdl_Move T1_mdl_Move, DeltaP, P1 and T1_RHS are exposed. T2 is not exposed from mdl_MoveObject.
 |[]
 |[]
 [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]

--- a/AERA/replicode_v1.2/open-door.replicode
+++ b/AERA/replicode_v1.2/open-door.replicode
@@ -1,0 +1,294 @@
+; ==== Entities and ontologies ====
+d:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+h:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+you:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+has_handle:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val d has_handle h 1)
+type:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val h type [<turning/t_push/t_pull>] 1)
+state:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val d state <open/closed> 1)
+; position is used as (mk.val you position <door/room>)
+; move cmd is used as (cmd move [destination])
+
+; Door states
+open:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+closed:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+unlocked:(ont 1) [[SYNC_ONCE now 0 forever root nil]] ; After the handle has been turned
+
+; Handle types
+turning:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+t_push:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+t_pull:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+; unknown:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+
+start_point:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+at_door:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+room:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+
+; Essences
+door:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+handle:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+yourself:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+
+d_is_a_door:(mk.val d essence door 1) |[]
+(fact d_is_a_door 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+h_is_a_handle:(mk.val h essence handle 1) |[]
+(fact h_is_a_handle 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+you_is_yourself:(mk.val you essence yourself 1) |[]
+(fact you_is_yourself 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+d_has_handle_h:(mk.val d has_handle h 1) |[]
+(fact d_has_handle_h 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+
+; ==== CSTs ====
+cst_YouPosition:(cst [] []
+    (fact (mk.val Y: essence yourself :) T0: T1: : :)
+    (fact (mk.val Y: position P: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_DoorState:(cst [] []
+    (fact (mk.val D: essence door :) T0: T1: : :)
+    (fact (mk.val D: state S: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_HandleType:(cst [] []
+    (fact (mk.val H: essence handle :) T0: T1: : :)
+    (fact (mk.val H: type [T:] :) T0: T1: : :)
+    (fact (mk.val D: essence door :) T0: T1: : :)
+    (fact (mk.val D: has_handle H: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_HandleUnknownType:(cst [] []
+    (fact (mk.val H: essence handle :) T0: T1: : :)
+    (fact (mk.val H: type [] :) T0: T1: : :)
+    (fact (mk.val D: essence door :) T0: T1: : :)
+    (fact (mk.val D: has_handle H: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_TurningUnlocked:(cst [] []
+    (fact (icst cst_DoorState [] [D: unlocked] : :) v1: v2: : :)
+    (fact (icst cst_HandleType [] [H: turning D:] : :) v1: v2: : :)
+
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Models ====
+mdl_Move:(mdl [Y: P: (ti v1: v2:)] []
+    (fact (cmd move [Y: P:] :) v4: v5: : :)
+    (fact (mk.val Y: position P: :) v7: v8: : :)
+[]
+    v7:(add v1 100ms)
+    v8:(add v2 100ms)
+[]
+    v1:(sub v7 100ms)
+    v2:(sub v8 100ms)
+    v4:(sub v7 80ms)
+    v5:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_Move_req1:(mdl [] []
+    (fact (icst cst_YouPosition [] [Y: P:] : :) v1: v2: : :)
+    (fact (imdl mdl_Move [Y: P1: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_Move_req2:(mdl [] []
+    (fact (icst cst_DoorState [] [D: open] : :) v1: v2: : :)
+    (fact (imdl mdl_Move [Y: room (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Can't move to room if door is closed
+mdl_Move_anti1:(mdl [] []
+    (fact (icst cst_DoorState [] [D: closed] : :) v1: v2: : :)
+    (|fact (imdl mdl_Move [you room (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Can't move to room if door is unlocked (must be pushed first)
+mdl_Move_anti2:(mdl [] []
+    (fact (icst cst_DoorState [] [D: unlocked] : :) v1: v2: : :)
+    (|fact (imdl mdl_Move [you room (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Move to the door to get information about the type
+mdl_Move_reuse1:(mdl [Y: (ti v1: v2:)] []
+    (fact (imdl mdl_Move [Y: at_door (ti v1: v2:)] [v6: v7:] : :) v8: v9: : :)
+    (fact (mk.val H: type [T:] :) v6: v7: : :)
+[]
+   v6:(add v1 100ms)
+   v7:(add v2 100ms)
+[]
+   v1:(sub v6 100ms)
+   v2:(sub v7 100ms)
+   v8:(sub v6 80ms)
+   v9:(sub v7 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_Move_reuse1_req1:(mdl [] []
+    (fact (icst cst_HandleUnknownType [] [H: D:] : :) v1: v2: : :)
+    (fact (imdl mdl_Move_reuse1 [you (ti v1: v2:)] [v4: v5: H: T:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; Turning the handle unlocks the door
+mdl_Turn:(mdl [H: (ti v1: v2:)] []
+    (fact (cmd turn [H:] :) v4: v5: : :)
+    (fact (mk.val D: state unlocked :) v7: v8: : :)
+[]
+    v7:(add v1 100ms)
+    v8:(add v2 100ms)
+[]
+    v1:(sub v7 100ms)
+    v2:(sub v8 100ms)
+    v4:(sub v7 80ms)
+    v5:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_Turn_req1:(mdl [] []
+    (fact (icst cst_HandleType [] [H: turning D:] : :) v1: v2: : :)
+    (fact (imdl mdl_Turn [H: (ti v1: v2:)] [D: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+mdl_Push:(mdl [D: (ti v1: v2:)] []
+    (fact (cmd push [D:] :) v4: v5: : :)
+    (fact (mk.val D: state open :) v7: v8: : :)
+[]
+    v7:(add v1 100ms)
+    v8:(add v2 100ms)
+[]
+    v1:(sub v7 100ms)
+    v2:(sub v8 100ms)
+    v4:(sub v7 80ms)
+    v5:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_Push_req1:(mdl [] []
+    (fact (icst cst_HandleType [] [H: t_push D:] : :) v1: v2: : :)
+    (fact (imdl mdl_Push [D: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If the door is unlocked and the handle is of type turning you can push
+mdl_Push_req2:(mdl [] []
+    (fact (icst cst_TurningUnlocked [] [D: H:] : :) v1: v2: : :)
+    (fact (imdl mdl_Push [D: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+mdl_Pull:(mdl [D: (ti v1: v2:)] []
+    (fact (cmd pull [D:] :) v4: v5: : :)
+    (fact (mk.val D: state open :) v7: v8: : :)
+[]
+    v7:(add v1 100ms)
+    v8:(add v2 100ms)
+[]
+    v1:(sub v7 100ms)
+    v2:(sub v8 100ms)
+    v4:(sub v7 80ms)
+    v5:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_Pull_req1:(mdl [] []
+    (fact (icst cst_HandleType [] [H: t_pull D:] : :) v1: v2: : :)
+    (fact (imdl mdl_Pull [D: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Drive ====
+!def DRIVE_START 300ms
+
+m_drive:(mdl [] []
+   ; The goal target timings are the same as the drive timings.
+   (fact (mk.val you position room 1) T0: T1: 1 1)
+   (fact run T0: T1: ::)
+|[]
+|[]
+[stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+pgm_inject_drive:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val h essence handle :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt DRIVE_START))
+[]
+   ; The end of the time interval will be used in m_drive as the end of the goal interval.
+   (inj [f_run:(fact run After (+ Before 400ms) 1 1) []])
+   (inj [G:(goal f_run self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before injecting the drive.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected drive" []])
+1) |[]
+(ipgm pgm_inject_drive [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+
+; ==== Eject programs ====
+pgm_eject_cmd_move:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd move [Y: P:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd move [Y P] 1)
+1) |[]
+(ipgm pgm_eject_cmd_move [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_eject_cmd_turn:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd turn [H:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd turn [H] 1)
+1) |[]
+(ipgm pgm_eject_cmd_turn [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_eject_cmd_push:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd push [D:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd push [D] 1)
+1) |[]
+(ipgm pgm_eject_cmd_push [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_eject_cmd_pull:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd pull [D:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd pull [D] 1)
+1) |[]
+(ipgm pgm_eject_cmd_pull [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+

--- a/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-full-2-bigger-than.replicode
+++ b/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-full-2-bigger-than.replicode
@@ -1,0 +1,451 @@
+; With three-parameter command (block to from)
+
+
+; ==== Entities and ontologies ====
+big_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+medium_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+small_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+left_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+center_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+right_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+bigger_than:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val big_block bigger_than small_block 1)
+has_blocks:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val left_pole has_blocks [medium_block small_block] 1) or (mk.val left_pole has_blocks [] 1) order is bigger -> smaller
+pole:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+
+
+; ==== Facts ====
+big_block_is_bigger_than_medium:(mk.val big_block bigger_than medium_block 1) |[]
+(fact big_block_is_bigger_than_medium 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+big_block_is_bigger_than_small:(mk.val big_block bigger_than small_block 1) |[]
+(fact big_block_is_bigger_than_small 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_bigger_than_small:(mk.val medium_block bigger_than small_block 1) |[]
+(fact medium_block_is_bigger_than_small 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+left_pole_is_a_pole:(mk.val left_pole essence pole 1) |[]
+(fact left_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+center_pole_is_a_pole:(mk.val center_pole essence pole 1) |[]
+(fact center_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+right_pole_is_a_pole:(mk.val right_pole essence pole 1) |[]
+(fact right_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+big_block_is_not_a_pole:(mk.val big_block essence pole 1) |[]
+(|fact big_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_not_a_pole:(mk.val medium_block essence pole 1) |[]
+(|fact medium_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+small_block_is_not_a_pole:(mk.val small_block essence pole 1) |[]
+(|fact small_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+
+; ==== CSTs ====
+cst_PoleIsEmpty:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [] :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_PoleHasOneBlock:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B:] :) T0: T1: : :)
+    (|fact (mk.val B: essence pole :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_PoleHasTwoBlocks:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B1: B2:] :) T0: T1: : :)
+    (fact (mk.val B1: bigger_than B2: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_PoleHasThreeBlocks:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B1: B2: B3:] :) T0: T1: : :)
+    (fact (mk.val B1: bigger_than B2: :) T0: T1: : :)
+    (fact (mk.val B2: bigger_than B3: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_OneEmpty:(cst [] []
+    (fact (icst cst_PoleHasOneBlock [] [P1: B:] : :) T0: T1: : :)
+    (fact (icst cst_PoleIsEmpty [] [P2:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_TwoEmpty:(cst [] []
+    (fact (icst cst_PoleHasTwoBlocks [] [P1: B1: B2:] : :) T0: T1: : :)
+    (fact (icst cst_PoleIsEmpty [] [P2:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_ThreeEmpty:(cst [] []
+    (fact (icst cst_PoleHasThreeBlocks [] [P1: B1: B2: B3:] : :) T0: T1: : :)
+    (fact (icst cst_PoleIsEmpty [] [P2:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_OneOne:(cst [] []
+    (fact (icst cst_PoleHasOneBlock [] [P1: B1:] : :) T0: T1: : :)
+    (fact (icst cst_PoleHasOneBlock [] [P2: B2:] : :) T0: T1: : :)
+    (fact (mk.val B1: bigger_than B2: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_OneTwo:(cst [] []
+    (fact (icst cst_PoleHasOneBlock [] [P1: B1:] : :) T0: T1: : :)
+    (fact (icst cst_PoleHasTwoBlocks [] [P2: B2: B3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; The pole with one block has the small
+cst_SmallOneTwo:(cst [] []
+    (fact (icst cst_OneTwo [] [P1: B1: P2: B3: B2:] : :) T0: T1: : :)
+    (fact (mk.val B2: bigger_than B1: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; The pole with one block has the medium
+cst_MediumOneTwo:(cst [] []
+    (fact (icst cst_OneTwo [] [P1: B2: P2: B3: B1:] : :) T0: T1: : :)
+    (fact (mk.val B3: bigger_than B2: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; The pole with one block has the big
+cst_BigOneTwo:(cst [] []
+    (fact (icst cst_OneTwo [] [P1: B3: P2: B2: B1:] : :) T0: T1: : :)
+    (fact (mk.val B3: bigger_than B2: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Models ====
+; Moving block B to pole P will make P have one block B
+mdl_MoveMakesOne:(mdl [B: P: P1: (ti v1: v2:)] []
+    (fact (cmd move_block [B: P: P1:] :) v4: v5: : :)
+    (fact (mk.val P: has_blocks [B:] :) v7: v8: : :)
+[]
+    v7:(add v1 100ms)
+    v8:(add v2 100ms)
+[]
+    v1:(sub v7 100ms)
+    v2:(sub v8 100ms)
+    v4:(sub v7 80ms)
+    v5:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_req1:(mdl [] []
+    (fact (icst cst_OneEmpty [] [P1: B: P2:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesOne [B: P2: P1: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_req2:(mdl [] []
+    (fact (icst cst_TwoEmpty [] [P1: B1: B2: P2:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesOne [B2: P2: P1: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_req3:(mdl [] []
+    (fact (icst cst_ThreeEmpty [] [P1: B1: B2: B3: P2:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesOne [B3: P2: P1: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_req4:(mdl [] []
+   (fact (icst cst_OneOne [] [P1: B1: P2: B2:] : :) v1: v2: : :)
+   (fact (imdl mdl_MoveMakesOne [B2: P1: P2: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_hack1:(mdl [] []
+    (fact (icst cst_ThreeEmpty [] [left_pole B1: B2: B3: right_pole] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesOne [B3: right_pole left_pole (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_hack2:(mdl [] []
+    (fact (icst cst_TwoEmpty [] [left_pole B1: B2: center_pole] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesOne [B2: center_pole left_pole (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_reuse1:(mdl [B: P: P1: (ti v1: v2:)] []
+    (fact (imdl mdl_MoveMakesOne [B: P: P1: (ti v1: v2:)] [v6: v7:] : :) v8: v9: : :)
+    (fact (mk.val P1: has_blocks [] :) v6: v7: : :)
+[]
+   v6:(add v1 100ms)
+   v7:(add v2 100ms)
+[]
+   v1:(sub v6 100ms)
+   v2:(sub v7 100ms)
+   v8:(sub v6 80ms)
+   v9:(sub v7 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_reuse1_req:(mdl [] []
+    (fact (icst cst_OneEmpty [] [P1: B: P2:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesOne_reuse1 [B: P2: P1: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_reuse2:(mdl [B: P: P1: (ti v1: v2:)] []
+    (fact (imdl mdl_MoveMakesOne [B: P: P1: (ti v1: v2:)] [v6: v7:] : :) v8: v9: : :)
+    (fact (mk.val P1: has_blocks [B1:] :) v6: v7: : :)
+[]
+   v6:(add v1 100ms)
+   v7:(add v2 100ms)
+[]
+   v1:(sub v6 100ms)
+   v2:(sub v7 100ms)
+   v8:(sub v6 80ms)
+   v9:(sub v7 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_reuse2_req:(mdl [] []
+    (fact (icst cst_TwoEmpty [] [P1: B1: B2: P2:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesOne_reuse2 [B2: P2: P1: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_reuse3:(mdl [B: P: P1: (ti v1: v2:)] []
+    (fact (imdl mdl_MoveMakesOne [B: P: P1: (ti v1: v2:)] [v6: v7:] : :) v8: v9: : :)
+    (fact (mk.val P1: has_blocks [B1: B2:] :) v6: v7: : :)
+[]
+    v6:(add v1 100ms)
+    v7:(add v2 100ms)
+[]
+    v1:(sub v6 100ms)
+    v2:(sub v7 100ms)
+    v8:(sub v6 80ms)
+    v9:(sub v7 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_reuse3_req:(mdl [] []
+    (fact (icst cst_ThreeEmpty [] [P1: B1: B2: B3: P2:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesOne_reuse3 [B3: P2: P1: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_anti1:(mdl [] []
+    (fact (icst cst_TwoEmpty [] [P1: B1: B2: P2:] : :) v1: v2: : :)
+    (|fact (imdl mdl_MoveMakesOne [B1: P2: P1: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_anti2:(mdl [] []
+    (fact (icst cst_ThreeEmpty [] [P1: B1: B2: B3: P2:] : :) v1: v2: : :)
+    (|fact (imdl mdl_MoveMakesOne [B2: P2: P1: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_anti3:(mdl [] []
+    (fact (icst cst_ThreeEmpty [] [P1: B1: B2: B3: P2:] : :) v1: v2: : :)
+    (|fact (imdl mdl_MoveMakesOne [B1: P2: P1: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; Moving block B to pole P will make P have two blocks B1 and B
+mdl_MoveMakesTwo:(mdl [B: P: P1: (ti v1: v2:)] []
+    (fact (cmd move_block [B: P: P1:] :) v4: v5: : :)
+    (fact (mk.val P: has_blocks [B1: B:] :) v7: v8: : :)
+[]
+    v7:(add v1 100ms)
+    v8:(add v2 100ms)
+[]
+    v1:(sub v7 100ms)
+    v2:(sub v8 100ms)
+    v4:(sub v7 80ms)
+    v5:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Can move the small from the medium to the big
+mdl_MoveMakesTwo_req1:(mdl [] []
+    (fact (icst cst_BigOneTwo [] [P1: B3: P2: B2: B1:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesTwo [B1: P1: (ti v1: v2:)] [B3: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Can move the small from the big to the medium
+mdl_MoveMakesTwo_req2:(mdl [] []
+    (fact (icst cst_MediumOneTwo [] [P1: B2: P2: B3: B1:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesTwo [B1: P1: (ti v1: v2:)] [B2: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesTwo_req3:(mdl [] []
+    (fact (icst cst_OneOne [] [P1: B1: P2: B2:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesTwo [B2: P1: (ti v1: v2:)] [B1: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesTwo_reuse1:(mdl [B: P: P1: (ti v1: v2:)] []
+    (fact (imdl mdl_MoveMakesTwo [B: P: P1: (ti v1: v2:)] [B1: v6: v7:] : :) v8: v9: : :)
+    (fact (mk.val P1: has_blocks [B2:] :) v6: v7: : :)
+[]
+    v6:(add v1 100ms)
+    v7:(add v2 100ms)
+[]
+    v1:(sub v6 100ms)
+    v2:(sub v7 100ms)
+    v8:(sub v6 80ms)
+    v9:(sub v7 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesTwo_reuse2:(mdl [B: P: P1: (ti v1: v2:)] []
+   (fact (imdl mdl_MoveMakesTwo [B: P: P1: (ti v1: v2:)] [B1: v6: v7:] : :) v8: v9: : :)
+   (fact (mk.val P1: has_blocks [] :) v6: v7: : :)
+[]
+   v6:(add v1 100ms)
+   v7:(add v2 100ms)
+[]
+   v1:(sub v6 100ms)
+   v2:(sub v7 100ms)
+   v8:(sub v6 80ms)
+   v9:(sub v7 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesTwo_anti1:(mdl [] []
+   (fact (icst cst_OneTwo [] [P1: B1: P2: B2: B3:] : :) v1: v2: : :)
+   (|fact (imdl mdl_MoveMakesTwo [B2: P1: (ti v1: v2:)] [B1: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesTwo_anti2:(mdl [] []
+    (fact (icst cst_TwoEmpty [] [P1: B1: B2: P2:] : :) v1: v2: : :)
+    (|fact (imdl mdl_MoveMakesTwo [B1: P2: (ti v1: v2:)] [B2: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; Moving block B to pole P will make P have three blocks B3, B2 and B
+mdl_MoveMakesThree:(mdl [B: P: P1: (ti v1: v2:)] []
+    (fact (cmd move_block [B: P: P1:] :) v4: v5: : :)
+    (fact (mk.val P: has_blocks [B3: B2: B:] :) v7: v8: : :)
+[]
+    v7:(add v1 100ms)
+    v8:(add v2 100ms)
+[]
+    v1:(sub v7 100ms)
+    v2:(sub v8 100ms)
+    v4:(sub v7 80ms)
+    v5:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Can move the small on the medium-big stack
+mdl_MoveMakesThree_req1:(mdl [] []
+    (fact (icst cst_SmallOneTwo [] [P1: B1: P2: B3: B2:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesThree [B1: P2: (ti v1: v2:)] [B3: B2: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesThree_reuse1:(mdl [B: P: P1: (ti v1: v2:)] []
+    (fact (imdl mdl_MoveMakesThree [B: P: P1: (ti v1: v2:)] [B3: B2: v6: v7:] : :) v8: v9: : :)
+    (fact (mk.val P1: has_blocks [] :) v6: v7: : :)
+[]
+    v6:(add v1 100ms)
+    v7:(add v2 100ms)
+[]
+    v1:(sub v6 100ms)
+    v2:(sub v7 100ms)
+    v8:(sub v6 80ms)
+    v9:(sub v7 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesThree_anti1:(mdl [] []
+    (fact (icst cst_ThreeEmpty [] [P1: B1: B2: B3: P2:] : :) v1: v2: : :)
+    (|fact (imdl mdl_MoveMakesThree [B1: P2: (ti v1: v2:)] [P1: B2: B3: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesThree_anti2:(mdl [] []
+    (fact (icst cst_ThreeEmpty [] [P1: B1: B2: B3: P2:] : :) v1: v2: : :)
+    (|fact (imdl mdl_MoveMakesThree [B2: P2: (ti v1: v2:)] [P1: B1: B3: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Drive ====
+m_drive1:(mdl [] []
+    ; The goal target timings are the same as the drive timings.
+    (fact (mk.val center_pole has_blocks [medium_block small_block] :) T0: T1: : :)
+    (fact run T0: T1: ::)
+|[]
+|[]
+[stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+run2:(ent 1) [[SYNC_ONCE now 0 forever root nil]]
+m_drive2:(mdl [] []
+    ; The goal target timings are the same as the drive timings.
+    (fact (mk.val right_pole has_blocks [big_block medium_block small_block] :) T0: T1: : :)
+    (fact run2 T0: T1: ::)
+|[]
+|[]
+[stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+!def DRIVE_START 300ms
+
+pgm_inject_drive:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt DRIVE_START))
+[]
+   ; The end of the time interval will be used in m_drive as the end of the goal interval.
+   (inj [f_run:(fact run After (+ Before 600ms) 1 1) []])
+   (inj [G:(goal f_run self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before injecting the drive.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected drive" []])
+1) |[]
+(ipgm pgm_inject_drive [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+
+; ==== Eject programs ====
+pgm_eject_cmd_move_block:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd move_block [B: P: P1:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd move_block [B P P1] 1)
+1) |[]
+(ipgm pgm_eject_cmd_move_block [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]

--- a/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-full-3-bigger-than.replicode
+++ b/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-full-3-bigger-than.replicode
@@ -1,0 +1,448 @@
+; ==== Entities and ontologies ====
+big_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+medium_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+small_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+left_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+center_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+right_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+bigger_than:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val big_block bigger_than small_block 1)
+has_blocks:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val left_pole has_blocks [medium_block small_block] 1) or (mk.val left_pole has_blocks [] 1) order is bigger -> smaller
+pole:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+
+
+; ==== Facts ====
+big_block_is_bigger_than_medium:(mk.val big_block bigger_than medium_block 1) |[]
+(fact big_block_is_bigger_than_medium 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+big_block_is_bigger_than_small:(mk.val big_block bigger_than small_block 1) |[]
+(fact big_block_is_bigger_than_small 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_bigger_than_small:(mk.val medium_block bigger_than small_block 1) |[]
+(fact medium_block_is_bigger_than_small 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+left_pole_is_a_pole:(mk.val left_pole essence pole 1) |[]
+(fact left_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+center_pole_is_a_pole:(mk.val center_pole essence pole 1) |[]
+(fact center_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+right_pole_is_a_pole:(mk.val right_pole essence pole 1) |[]
+(fact right_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+big_block_is_not_a_pole:(mk.val big_block essence pole 1) |[]
+(|fact big_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_not_a_pole:(mk.val medium_block essence pole 1) |[]
+(|fact medium_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+small_block_is_not_a_pole:(mk.val small_block essence pole 1) |[]
+(|fact small_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+
+; ==== CSTs ====
+cst_PoleIsEmpty:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [] :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_PoleHasOneBlock:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B:] :) T0: T1: : :)
+    (|fact (mk.val B: essence pole :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_PoleHasTwoBlocks:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B1: B2:] :) T0: T1: : :)
+    (fact (mk.val B1: bigger_than B2: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_PoleHasThreeBlocks:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B1: B2: B3:] :) T0: T1: : :)
+    (fact (mk.val B1: bigger_than B2: :) T0: T1: : :)
+    (fact (mk.val B2: bigger_than B3: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_OneEmpty:(cst [] []
+    (fact (icst cst_PoleHasOneBlock [] [P1: B:] : :) T0: T1: : :)
+    (fact (icst cst_PoleIsEmpty [] [P2:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_TwoEmpty:(cst [] []
+    (fact (icst cst_PoleHasTwoBlocks [] [P1: B1: B2:] : :) T0: T1: : :)
+    (fact (icst cst_PoleIsEmpty [] [P2:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_ThreeEmpty:(cst [] []
+    (fact (icst cst_PoleHasThreeBlocks [] [P1: B1: B2: B3:] : :) T0: T1: : :)
+    (fact (icst cst_PoleIsEmpty [] [P2:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_OneOne:(cst [] []
+    (fact (icst cst_PoleHasOneBlock [] [P1: B1:] : :) T0: T1: : :)
+    (fact (icst cst_PoleHasOneBlock [] [P2: B2:] : :) T0: T1: : :)
+    (fact (mk.val B1: bigger_than B2: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_OneTwo:(cst [] []
+    (fact (icst cst_PoleHasOneBlock [] [P1: B1:] : :) T0: T1: : :)
+    (fact (icst cst_PoleHasTwoBlocks [] [P2: B2: B3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; The pole with one block has the small
+cst_SmallOneTwo:(cst [] []
+    (fact (icst cst_OneTwo [] [P1: B1: P2: B3: B2:] : :) T0: T1: : :)
+    (fact (mk.val B2: bigger_than B1: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; The pole with one block has the medium
+cst_MediumOneTwo:(cst [] []
+    (fact (icst cst_OneTwo [] [P1: B2: P2: B3: B1:] : :) T0: T1: : :)
+    (fact (mk.val B3: bigger_than B2: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; The pole with one block has the big
+cst_BigOneTwo:(cst [] []
+    (fact (icst cst_OneTwo [] [P1: B3: P2: B2: B1:] : :) T0: T1: : :)
+    (fact (mk.val B3: bigger_than B2: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Models ====
+; Moving block B to pole P will make P have one block B
+mdl_MoveMakesOne:(mdl [B: P: (ti v1: v2:)] []
+    (fact (cmd move_block [B: P:] :) v4: v5: : :)
+    (fact (mk.val P: has_blocks [B:] :) v7: v8: : :)
+[]
+    v7:(add v1 100ms)
+    v8:(add v2 100ms)
+[]
+    v1:(sub v7 100ms)
+    v2:(sub v8 100ms)
+    v4:(sub v7 80ms)
+    v5:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_req1:(mdl [] []
+    (fact (icst cst_OneEmpty [] [P1: B: P2:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesOne [B: P2: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_req2:(mdl [] []
+    (fact (icst cst_TwoEmpty [] [P1: B1: B2: P2:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesOne [B2: P2: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_req3:(mdl [] []
+    (fact (icst cst_ThreeEmpty [] [P1: B1: B2: B3: P2:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesOne [B3: P2: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_req4:(mdl [] []
+   (fact (icst cst_OneOne [] [P1: B1: P2: B2:] : :) v1: v2: : :)
+   (fact (imdl mdl_MoveMakesOne [B2: P1: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; mdl_MoveMakesOne_hack1:(mdl [] []
+;     (fact (icst cst_ThreeEmpty [] [left_pole B1: B2: B3: right_pole] : :) v1: v2: : :)
+;     (fact (imdl mdl_MoveMakesOne [B3: right_pole (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; mdl_MoveMakesOne_hack2:(mdl [] []
+;     (fact (icst cst_TwoEmpty [] [left_pole B1: B2: center_pole] : :) v1: v2: : :)
+;     (fact (imdl mdl_MoveMakesOne [B2: center_pole (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_reuse1:(mdl [B: P: (ti v1: v2:)] []
+    (fact (imdl mdl_MoveMakesOne [B: P: (ti v1: v2:)] [v6: v7:] : :) v8: v9: : :)
+    (fact (mk.val P1: has_blocks [] :) v6: v7: : :)
+[]
+   v6:(add v1 100ms)
+   v7:(add v2 100ms)
+[]
+   v1:(sub v6 100ms)
+   v2:(sub v7 100ms)
+   v8:(sub v6 80ms)
+   v9:(sub v7 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_reuse1_req:(mdl [] []
+    (fact (icst cst_OneEmpty [] [P1: B: P2:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesOne_reuse1 [B: P2: (ti v1: v2:)] [P1: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_reuse2:(mdl [B: P: (ti v1: v2:)] []
+    (fact (imdl mdl_MoveMakesOne [B: P: (ti v1: v2:)] [v6: v7:] : :) v8: v9: : :)
+    (fact (mk.val P1: has_blocks [B1:] :) v6: v7: : :)
+[]
+   v6:(add v1 100ms)
+   v7:(add v2 100ms)
+[]
+   v1:(sub v6 100ms)
+   v2:(sub v7 100ms)
+   v8:(sub v6 80ms)
+   v9:(sub v7 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_reuse2_req:(mdl [] []
+    (fact (icst cst_TwoEmpty [] [P1: B1: B2: P2:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesOne_reuse2 [B2: P2: (ti v1: v2:)] [P1: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_reuse3:(mdl [B: P: (ti v1: v2:)] []
+    (fact (imdl mdl_MoveMakesOne [B: P: (ti v1: v2:)] [v6: v7:] : :) v8: v9: : :)
+    (fact (mk.val P1: has_blocks [B1: B2:] :) v6: v7: : :)
+[]
+    v6:(add v1 100ms)
+    v7:(add v2 100ms)
+[]
+    v1:(sub v6 100ms)
+    v2:(sub v7 100ms)
+    v8:(sub v6 80ms)
+    v9:(sub v7 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_reuse3_req:(mdl [] []
+    (fact (icst cst_ThreeEmpty [] [P1: B1: B2: B3: P2:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesOne_reuse3 [B3: P2: (ti v1: v2:)] [P1: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_anti1:(mdl [] []
+    (fact (icst cst_TwoEmpty [] [P1: B1: B2: P2:] : :) v1: v2: : :)
+    (|fact (imdl mdl_MoveMakesOne [B1: P2: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_anti2:(mdl [] []
+    (fact (icst cst_ThreeEmpty [] [P1: B1: B2: B3: P2:] : :) v1: v2: : :)
+    (|fact (imdl mdl_MoveMakesOne [B2: P2: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOne_anti3:(mdl [] []
+    (fact (icst cst_ThreeEmpty [] [P1: B1: B2: B3: P2:] : :) v1: v2: : :)
+    (|fact (imdl mdl_MoveMakesOne [B1: P2: (ti v1: v2:)] [v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; Moving block B to pole P will make P have two blocks B1 and B
+mdl_MoveMakesTwo:(mdl [B: P: (ti v1: v2:)] []
+    (fact (cmd move_block [B: P:] :) v4: v5: : :)
+    (fact (mk.val P: has_blocks [B1: B:] :) v7: v8: : :)
+[]
+    v7:(add v1 100ms)
+    v8:(add v2 100ms)
+[]
+    v1:(sub v7 100ms)
+    v2:(sub v8 100ms)
+    v4:(sub v7 80ms)
+    v5:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Can move the small from the medium to the big
+mdl_MoveMakesTwo_req1:(mdl [] []
+    (fact (icst cst_BigOneTwo [] [P1: B3: P2: B2: B1:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesTwo [B1: P1: (ti v1: v2:)] [B3: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Can move the small from the big to the medium
+mdl_MoveMakesTwo_req2:(mdl [] []
+    (fact (icst cst_MediumOneTwo [] [P1: B2: P2: B3: B1:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesTwo [B1: P1: (ti v1: v2:)] [B2: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesTwo_req3:(mdl [] []
+    (fact (icst cst_OneOne [] [P1: B1: P2: B2:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesTwo [B2: P1: (ti v1: v2:)] [B1: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesTwo_reuse1:(mdl [B: P: (ti v1: v2:)] []
+    (fact (imdl mdl_MoveMakesTwo [B: P: (ti v1: v2:)] [B1: v6: v7:] : :) v8: v9: : :)
+    (fact (mk.val P: has_blocks [B2:] :) v6: v7: : :)
+[]
+    v6:(add v1 100ms)
+    v7:(add v2 100ms)
+[]
+    v1:(sub v6 100ms)
+    v2:(sub v7 100ms)
+    v8:(sub v6 80ms)
+    v9:(sub v7 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesTwo_reuse2:(mdl [B: P: (ti v1: v2:)] []
+   (fact (imdl mdl_MoveMakesTwo [B: P: (ti v1: v2:)] [B1: v6: v7:] : :) v8: v9: : :)
+   (fact (mk.val P1: has_blocks [] :) v6: v7: : :)
+[]
+   v6:(add v1 100ms)
+   v7:(add v2 100ms)
+[]
+   v1:(sub v6 100ms)
+   v2:(sub v7 100ms)
+   v8:(sub v6 80ms)
+   v9:(sub v7 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesTwo_anti1:(mdl [] []
+   (fact (icst cst_OneTwo [] [P1: B1: P2: B2: B3:] : :) v1: v2: : :)
+   (|fact (imdl mdl_MoveMakesTwo [B2: P1: (ti v1: v2:)] [B1: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesTwo_anti2:(mdl [] []
+    (fact (icst cst_TwoEmpty [] [P1: B1: B2: P2:] : :) v1: v2: : :)
+    (|fact (imdl mdl_MoveMakesTwo [B1: P2: (ti v1: v2:)] [B2: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; Moving block B to pole P will make P have three blocks B3, B2 and B
+mdl_MoveMakesThree:(mdl [B: P: (ti v1: v2:)] []
+    (fact (cmd move_block [B: P:] :) v4: v5: : :)
+    (fact (mk.val P: has_blocks [B3: B2: B:] :) v7: v8: : :)
+[]
+    v7:(add v1 100ms)
+    v8:(add v2 100ms)
+[]
+    v1:(sub v7 100ms)
+    v2:(sub v8 100ms)
+    v4:(sub v7 80ms)
+    v5:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Can move the small on the medium-big stack
+mdl_MoveMakesThree_req1:(mdl [] []
+    (fact (icst cst_SmallOneTwo [] [P1: B1: P2: B3: B2:] : :) v1: v2: : :)
+    (fact (imdl mdl_MoveMakesThree [B1: P2: (ti v1: v2:)] [B3: B2: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesThree_reuse1:(mdl [B: P: (ti v1: v2:)] []
+    (fact (imdl mdl_MoveMakesThree [B: P: (ti v1: v2:)] [B3: B2: v6: v7:] : :) v8: v9: : :)
+    (fact (mk.val P1: has_blocks [] :) v6: v7: : :)
+[]
+    v6:(add v1 100ms)
+    v7:(add v2 100ms)
+[]
+    v1:(sub v6 100ms)
+    v2:(sub v7 100ms)
+    v8:(sub v6 80ms)
+    v9:(sub v7 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesThree_anti1:(mdl [] []
+    (fact (icst cst_ThreeEmpty [] [P1: B1: B2: B3: P2:] : :) v1: v2: : :)
+    (|fact (imdl mdl_MoveMakesThree [B1: P2: (ti v1: v2:)] [P1: B2: B3: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesThree_anti2:(mdl [] []
+    (fact (icst cst_ThreeEmpty [] [P1: B1: B2: B3: P2:] : :) v1: v2: : :)
+    (|fact (imdl mdl_MoveMakesThree [B2: P2: (ti v1: v2:)] [P1: B1: B3: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Drive ====
+m_drive1:(mdl [] []
+    ; The goal target timings are the same as the drive timings.
+    (fact (mk.val center_pole has_blocks [medium_block small_block] :) T0: T1: : :)
+    (fact run T0: T1: ::)
+|[]
+|[]
+[stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+run2:(ent 1) [[SYNC_ONCE now 0 forever root nil]]
+m_drive2:(mdl [] []
+    ; The goal target timings are the same as the drive timings.
+    (fact (mk.val right_pole has_blocks [big_block medium_block small_block] :) T0: T1: : :)
+    (fact run2 T0: T1: ::)
+|[]
+|[]
+[stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+!def DRIVE_START 300ms
+
+pgm_inject_drive:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt DRIVE_START))
+[]
+   ; The end of the time interval will be used in m_drive as the end of the goal interval.
+   (inj [f_run:(fact run After (+ Before 600ms) 1 1) []])
+   (inj [G:(goal f_run self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before injecting the drive.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected drive" []])
+1) |[]
+(ipgm pgm_inject_drive [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+
+; ==== Eject programs ====
+pgm_eject_cmd_move_block:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd move_block [B: P:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd move_block [B P] 1)
+1) |[]
+(ipgm pgm_eject_cmd_move_block [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]

--- a/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-full-bigger-than.replicode
+++ b/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-full-bigger-than.replicode
@@ -1,0 +1,598 @@
+; This file has models ans csts copied from the learned ones
+
+; ==== Entities and ontologies ====
+big_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+medium_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+small_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+left_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+center_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+right_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+bigger_than:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val big_block bigger_than small_block 1)
+has_blocks:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val left_pole has_blocks [medium_block small_block] 1) or (mk.val left_pole has_blocks [] 1) order is bigger -> smaller
+pole:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+
+!dfn (move_block :); arg0: a block, arg1: target position (pole)
+
+
+; ==== Facts ====
+big_block_is_bigger_than_medium:(mk.val big_block bigger_than medium_block 1) |[]
+(fact big_block_is_bigger_than_medium 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+big_block_is_bigger_than_small:(mk.val big_block bigger_than small_block 1) |[]
+(fact big_block_is_bigger_than_small 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_bigger_than_small:(mk.val medium_block bigger_than small_block 1) |[]
+(fact medium_block_is_bigger_than_small 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+left_pole_is_a_pole:(mk.val left_pole essence pole 1) |[]
+(fact left_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+center_pole_is_a_pole:(mk.val center_pole essence pole 1) |[]
+(fact center_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+right_pole_is_a_pole:(mk.val right_pole essence pole 1) |[]
+(fact right_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+big_block_is_not_a_pole:(mk.val big_block essence pole 1) |[]
+(|fact big_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_not_a_pole:(mk.val medium_block essence pole 1) |[]
+(|fact medium_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+small_block_is_not_a_pole:(mk.val small_block essence pole 1) |[]
+(|fact small_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+
+; ==== CSTs ====
+cst_PoleIsEmpty:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [] :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_PoleHasOneBlock:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B:] :) T0: T1: : :)
+    (|fact (mk.val B: essence pole :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_PoleHasTwoBlocks:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B1: B2:] :) T0: T1: : :)
+    (fact (mk.val B1: bigger_than B2: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_PoleHasThreeBlocks:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B1: B2: B3:] :) T0: T1: : :)
+    (fact (mk.val B1: bigger_than B2: :) T0: T1: : :)
+    (fact (mk.val B2: bigger_than B3: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; ----------------------------------------------
+
+cst_586:(cst [] []
+   (fact (mk.val B1: bigger_than B2: :) v2: v3: : :)
+   (|fact (mk.val B1: essence pole :) v2: v3: : :)
+   (fact (icst cst_PoleHasOneBlock [] [P1: B2:] : :) v2: v3: : :)
+   (fact (icst cst_PoleHasTwoBlocks [] [P2: B1: B3:] : :) v2: v3: : :)
+   (fact (icst cst_PoleIsEmpty [] [P3:] : :) v2: v3: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_591:(cst [] []
+   (fact (mk.val B1: bigger_than B2: :) v2: v3: : :)
+   (|fact (mk.val B1: essence pole :) v2: v3: : :)
+   (fact (icst cst_PoleIsEmpty [] [P1:] : :) v2: v3: : :)
+   (fact (icst cst_PoleHasThreeBlocks [] [P2: B1: B3: B2:] : :) v2: v3: : :)
+   (fact (icst cst_PoleIsEmpty [] [P3:] : :) v2: v3: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_1631:(cst [] []
+   (fact (mk.val B1: bigger_than B2: :) v2: v3: : :)
+   (fact (mk.val B1: bigger_than B3: :) v2: v3: : :)
+   (|fact (mk.val B2: essence pole :) v2: v3: : :)
+   (fact (icst cst_PoleHasTwoBlocks [] [P1: B2: B3:] : :) v2: v3: : :)
+   (fact (icst cst_PoleHasOneBlock [] [P2: B1:] : :) v2: v3: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Models ====
+; After moving block B to pole P, another pole P1 will be empty
+; mdl_214
+mdl_MoveEmptiesOtherPole:(mdl [B: (ti v1: v2:)] []
+   (fact (cmd move_block [B: P:] :) v4: v5: : :)
+   (fact (mk.val P1: has_blocks [] :) v7: v8: : :)
+[]
+   v7:(add v1 100ms)
+   v8:(add v2 100ms)
+[]
+   v1:(sub v7 100ms)
+   v2:(sub v8 100ms)
+   v4:(sub v7 80ms)
+   v5:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If a pole P1 has one block, the block can be moved to pole P and P1 will be empty
+; mdl_215
+mdl_MoveEmptiesOtherPole_req1:(mdl [] []
+   (fact (icst cst_PoleHasOneBlock [] [P1: B:] : :) v3: v4: : :)
+   (fact (imdl mdl_MoveEmptiesOtherPole [B: (ti v3: v4:)] [P: P1: v6: v7:] : :) v3: v4: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; After block B1 has been moved to pole P and pole P1 is empty, pole P will have two blocks B and B1
+; mdl_296
+mdl_MoveEmptiesOtherPole_reuse1:(mdl [B: (ti v1: v2:)] []
+   (fact (imdl mdl_MoveEmptiesOtherPole [B1: (ti v1: v2:)] [P: P1: v6: v7:] : :) v8: v9: : :)
+   (fact (mk.val P: has_blocks [B: B1:] :) v6: v7: : :)
+[]
+   v6:(add v1 100ms)
+   v7:(add v2 100ms)
+[]
+   v1:(sub v6 100ms)
+   v2:(sub v7 100ms)
+   v8:(sub v6 80ms)
+   v9:(sub v7 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has block B, block B1 can be moved to P so P will have blocks B and B1 (and pole P1 will be empty)
+; mdl_297
+mdl_MoveEmptiesOtherPole_reuse1_req1:(mdl [] []
+   (fact (icst cst_PoleHasOneBlock [] [P: B:] : :) v3: v4: : :)
+   (fact (imdl mdl_MoveEmptiesOtherPole_reuse1 [B: (ti v3: v4:)] [B1: P: P1: v7: v8:] : :) v3: v4: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; After moving block B to pole P, P will have three blocks B1, B2 and B (and pole P1 will be empty)
+; mdl_489
+mdl_MoveEmptiesOtherPole_reuse2:(mdl [v0: (ti v1: v2:)] []
+   (fact (imdl mdl_MoveEmptiesOtherPole [B: (ti v1: v2:)] [P: P1: v6: v7:] : :) v8: v9: : :)
+   (fact (mk.val P: has_blocks [B1: B2: B:] :) v6: v7: : :)
+[]
+   v6:(add v1 100ms)
+   v7:(add v2 100ms)
+[]
+   v1:(sub v6 100ms)
+   v2:(sub v7 100ms)
+   v8:(sub v6 80ms)
+   v9:(sub v7 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has two blocks B1 and B2, moving block B to P will make P have three blocks B1, B2 and B (and pole P1 will be empty)
+; mdl_490
+mdl_MoveEmptiesOtherPole_reuse2_req1:(mdl [] []
+   (fact (icst cst_PoleHasTwoBlocks [] [P: B1: B2:] : :) v5: v6: : :)
+   (fact (imdl mdl_MoveEmptiesOtherPole_reuse2 [[P: P1:] (ti v5: v6:)] [B: P: P1: v9: v10: B1: B2:] : :) v5: v6: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Moving block B to pole P will make P have one block B
+; mdl_218 (v0 is unused)
+mdl_MoveMakesOne:(mdl [v0: (ti v1: v2:)] []
+   (fact (cmd move_block [B: P:] :) v5: v6: : :)
+   (fact (mk.val P: has_blocks [B:] :) v7: v8: : :)
+[]
+   v7:(add v1 100ms)
+   v8:(add v2 100ms)
+[]
+   v1:(sub v7 100ms)
+   v2:(sub v8 100ms)
+   v5:(sub v7 80ms)
+   v6:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P is empty, a block can be moved to it
+; mdl_219
+mdl_MoveMakesOne_req1:(mdl [] []
+   (fact (icst cst_PoleIsEmpty [] [P:] : :) v1: v2: : :)
+   (fact (imdl mdl_MoveMakesOne [[] (ti v1: v2:)] [B: P: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Moving block B to P will make P1 have one block B1
+; mdl_256
+mdl_MoveMakesOne_reuse1:(mdl [v0: (ti v1: v2:)] []
+   (fact (imdl mdl_MoveMakesOne [[] (ti v1: v2:)] [B: P: v7: v8:] : :) v5: v6: : :)
+   (fact (mk.val P1: has_blocks [B1:] :) v7: v8: : :)
+[]
+   v7:(add v1 100ms)
+   v8:(add v2 100ms)
+[]
+   v1:(sub v7 100ms)
+   v2:(sub v8 100ms)
+   v5:(sub v7 80ms)
+   v6:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; With old time variable names
+; mdl_MoveMakesOne_reuse1:(mdl [v0: (ti v1: v2:)] []
+;    (fact (imdl mdl_MoveMakesOne [[] (ti v1: v2:)] [B: P: v5: v6:] : :) v7: v8: : :)
+;    (fact (mk.val P1: has_blocks [B1:] :) v5: v6: : :)
+; []
+;    v5:(add v1 100ms)
+;    v6:(add v2 100ms)
+; []
+;    v1:(sub v5 100ms)
+;    v2:(sub v6 100ms)
+;    v7:(sub v5 80ms)
+;    v8:(sub v6 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P1 has blocks B1 and B, moving block B to P will make P1 have only block B1
+; mdl_257
+mdl_MoveMakesOne_reuse1_req1:(mdl [] []
+   (fact (icst cst_PoleHasTwoBlocks [] [P1: B1: B:] : :) v5: v6: : :)
+   (fact (imdl mdl_MoveMakesOne_reuse1 [[P: P1:] (ti v5: v6:)] [B: P: v8: v9: P1: B1:] : :) v5: v6: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; After moving block B to pole P, another pole P1 will have two blocks B1 and B2 (and P will have one block B)
+; mdl_536
+mdl_MoveMakesOne_reuse2:(mdl [v0: (ti v1: v2:)] []
+   (fact (imdl mdl_MoveMakesOne [[] (ti v1: v2:)] [B: P: v5: v6:] : :) v7: v8: : :)
+   (fact (mk.val P1: has_blocks [B1: B2:] :) v5: v6: : :)
+[]
+   v5:(add v1 100ms)
+   v6:(add v2 100ms)
+[]
+   v1:(sub v5 100ms)
+   v2:(sub v6 100ms)
+   v7:(sub v5 80ms)
+   v8:(sub v6 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P1 has three blocks B1, B2 and B, moving B to another pole P will make P1 have two blocks B1 and B2 and P will have one block B
+; mdl_537
+mdl_MoveMakesOne_reuse2_req1:(mdl [] []
+   (fact (icst cst_PoleHasThreeBlocks [] [P1: B1: B2: B:] : :) v7: v8: : :)
+   (fact (imdl mdl_MoveMakesOne_reuse2 [[P: P1: B1:] (ti v7: v8:)] [B: P: v10: v11: P1: B1: B2:] : :) v7: v8: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; mdl_HackMoveMakesOne_FutureEmptiesOtherPole:(mdl [v0: (ti v1: v2:)] []
+;    (fact (imdl mdl_MoveMakesOne_reuse1 [[center_pole left_pole] (ti v1: v2:)] [small_block center_pole v7: v8: left_pole medium_block] : :) v5: v6: : :)
+;    (fact (imdl mdl_MoveEmptiesOtherPole [medium_block (ti v3: v4:)] [right_pole left_pole v7: v8:] : :) v7: v8: : :)
+; []
+;    v7:(add v1 100ms)
+;    v8:(add v2 100ms)
+; []
+;    v1:(sub v7 100ms)
+;    v2:(sub v8 100ms)
+;    v5:(sub v7 80ms)
+;    v6:(sub v8 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P1:left_pole has blocks B1 and B, moving block B to P:center_pole will make P1:left_pole have only block B1
+; mdl_Hack_MoveFromLeftPole:(mdl [] []
+;    (fact (icst cst_PoleHasTwoBlocks [] [left_pole B1: B:] : :) v5: v6: : :)
+;    (fact (imdl mdl_MoveMakesOne_reuse1 [[center_pole left_pole] (ti v5: v6:)] [B: center_pole v8: v9: left_pole B1:] : :) v5: v6: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Moving block B to pole P will make another pole P1 have one block B1 (similar to mdl_MoveMakesOne_reuse1 but as a command mdl)
+; mdl_260
+mdl_MoveMakesOtherOne:(mdl [v0: (ti v1: v2:)] []
+   (fact (cmd move_block [B: P:] :) v5: v6: : :)
+   (fact (mk.val P1: has_blocks [B1:] :) v9: v10: : :)
+[]
+   v9:(add v1 100ms)
+   v10:(add v2 100ms)
+[]
+   v1:(sub v9 100ms)
+   v2:(sub v10 100ms)
+   v5:(sub v9 80ms)
+   v6:(sub v10 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_MoveMakesOtherOne_hack:(mdl [v0: (ti v1: v2:)] []
+   (fact (cmd move_block [small_block center_pole] :) v5: v6: : :)
+   (fact (mk.val left_pole has_blocks [medium_block] :) v9: v10: : :)
+[]
+   v9:(add v1 100ms)
+   v10:(add v2 100ms)
+[]
+   v1:(sub v9 100ms)
+   v2:(sub v10 100ms)
+   v5:(sub v9 80ms)
+   v6:(sub v10 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P1 has blocks B1 and B, moving block B to P will make P1 have only block B1 (similar to mdl_MoveMakesOne_reuse1_req1 but without any pole receiving a block)
+; mdl_261
+mdl_MoveMakesOtherOne_req1:(mdl [] []
+   (fact (icst cst_PoleHasTwoBlocks [] [P1: B1: B:] : :) v5: v6: : :)
+   (fact (imdl mdl_MoveMakesOtherOne [[P: P1:] (ti v5: v6:)] [B: P: P1: B1: v8: v9:] : :) v5: v6: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; mdl_MoveMakesOtherOne_reuse1:(mdl [v0: (ti v1: v2:)] []
+;    (fact (imdl mdl_MoveMakesOtherOne [[] (ti v1: v2:)] [B: P: P1: B1: v5: v6:] : :) v7: v8: : :)
+;    (fact (mk.val P1: has_blocks [B1: B2:] :) v5: v6: : :)
+; []
+;    v5:(add v1 100ms)
+;    v6:(add v2 100ms)
+; []
+;    v1:(sub v5 100ms)
+;    v2:(sub v6 100ms)
+;    v7:(sub v5 80ms)
+;    v8:(sub v6 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; mdl_HackMoveMakesLeftPoleOne:(mdl [] []
+;    (fact (icst cst_PoleHasTwoBlocks [] [left_pole medium_block small_block] : :) v5: v6: : :)
+;    (fact (imdl mdl_MoveMakesOtherOne [[center_pole left_pole] (ti v5: v6:)] [small_block center_pole left_pole medium_block v8: v9:] : :) v5: v6: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Moving block B to pole P will make pole P have two blocks B1 and B
+; mdl_300
+mdl_MoveMakesTwo:(mdl [B1: (ti v1: v2:)] []
+   (fact (cmd move_block [B: P:] :) v5: v6: : :)
+   (fact (mk.val P: has_blocks [B1: B:] :) v7: v8: : :)
+[]
+   v7:(add v1 100ms)
+   v8:(add v2 100ms)
+[]
+   v1:(sub v7 100ms)
+   v2:(sub v8 100ms)
+   v5:(sub v7 80ms)
+   v6:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has one block B1, moving B to P will make P have two blocks B1 and B
+mdl_MoveMakesTwo_req1:(mdl [] []
+   (fact (icst cst_PoleHasOneBlock [] [P: B1:] : :) v3: v4: : :)
+   (fact (imdl mdl_MoveMakesTwo [B1: (ti v3: v4:)] [B: P: v6: v7:] : :) v3: v4: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; After moving block B to pole P, P will have three blocks B1, B2 and B (similar to mdl_497 but as a command mdl, no pole remains empty)
+; mdl_493
+mdl_MoveMakesThree:(mdl [v0: (ti v1: v2:)] []
+   (fact (cmd move_block [B: P:] :) v5: v6: : :)
+   (fact (mk.val P: has_blocks [B1: B2: B:] :) v9: v10: : :)
+[]
+   v9:(add v1 100ms)
+   v10:(add v2 100ms)
+[]
+   v1:(sub v9 100ms)
+   v2:(sub v10 100ms)
+   v5:(sub v9 80ms)
+   v6:(sub v10 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has two blocks B1 and B2, moving block B to P will make P have three blocks B1, B2 and B (similar to mdl_498 but no pole remains empty)
+; mdl_494
+mdl_MoveMakesThree_req1:(mdl [] []
+   (fact (icst cst_PoleHasTwoBlocks [] [P: B1: B2:] : :) v5: v6: : :)
+   (fact (imdl mdl_MoveMakesThree [[P: B1:] (ti v5: v6:)] [B: P: B1: B2: v8: v9:] : :) v5: v6: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; After moving block B to pole P, another pole P1 will have two blocks B1 and B2 (similar to mdl_547 but as a command model, no pole receives block)
+; mdl_540
+mdl_MoveMakesOtherTwo:(mdl [v0: (ti v1: v2:)] []
+   (fact (cmd move_block [B: P:] :) v5: v6: : :)
+   (fact (mk.val P1: has_blocks [B1: B2:] :) v10: v11: : :)
+[]
+   v10:(add v1 100ms)
+   v11:(add v2 100ms)
+[]
+   v1:(sub v10 100ms)
+   v2:(sub v11 100ms)
+   v5:(sub v10 80ms)
+   v6:(sub v11 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P1 has three blocks B1, B2 and B, moving B to another pole P will make P1 have two blocks B1 and B2 (similar to mdl_548 but no pole receives block)
+; mdl_541
+mdl_MoveMakesOtherTwo_req1:(mdl [] []
+   (fact (icst cst_PoleHasThreeBlocks [] [P1: B1: B2: B:] : :) v7: v8: : :)
+   (fact (imdl mdl_MoveMakesOtherTwo [[P: P1: B1:] (ti v7: v8:)] [B: P: P1: B1: B2: v10: v11:] : :) v7: v8: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; mdl_1446:(mdl [v0: (ti v1: v2:)] []
+;    (fact (imdl mdl_MoveEmptiesOtherPole [v3: (ti v1: v2:)] [v4: v5: v6: v7:] : :) v8: v9: : :)
+;    (fact (mk.val v4: has_blocks [v3:] :) v6: v7: : :)
+; []
+;    v6:(add v1 100ms)
+;    v7:(add v2 100ms)
+; []
+;    v1:(sub v6 100ms)
+;    v2:(sub v7 100ms)
+;    v8:(sub v6 80ms)
+;    v9:(sub v7 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; mdl_1447:(mdl [] []
+;    (fact (icst cst_PoleIsEmpty [] [v0:] : :) v1: v2: : :)
+;    (fact (imdl mdl_1446 [[] (ti v1: v2:)] [v3: v0: v4: v5: v6:] : :) v1: v2: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ---- Don't move block that is under another one ----
+
+; If pole P1 has one block B2, pole P2 has two blocks B1 and B3 (B1 > B3), pole P3 is empty and B1 is bigger than B2, then it's not possible to move B1 to P1 (correct)
+; mdl_587
+mdl_MoveMakesOne_anti1:(mdl [] []
+    (fact (icst cst_586 [] [B1: B2: P1: P2: B3: P3:] : :) v9: v10: : :)
+    (|fact (imdl mdl_MoveMakesOne [[] (ti v9: v10:)] [B1: P1: v13: v14:] : :) v9: v10: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P1 has one block B2, pole P2 has two blocks B1 and B3 (B1 > B3), pole P3 is empty and B1 is bigger than B2, then it's not possible to move B1 to P3
+mdl_MoveMakesOne_anti1_bis:(mdl [] []
+    (fact (icst cst_586 [] [B1: B2: P1: P2: B3: P3:] : :) v9: v10: : :)
+    (|fact (imdl mdl_MoveMakesOne [[] (ti v9: v10:)] [B1: P3: v13: v14:] : :) v9: v10: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P2 has three blocks B1, B3 and B3, poles P1 and P3 are empty and B1 is bigger than B2, then it's not possible to move B1 to P1 (correct)
+; mdl_592
+mdl_MoveMakesOne_anti2:(mdl [] []
+    (fact (icst cst_591 [] [B1: B2: P1: P2: B3: P3:] : :) v9: v10: : :)
+    (|fact (imdl mdl_MoveMakesOne [[] (ti v9: v10:)] [B1: P1: v12: v13:] : :) v9: v10: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P2 has three blocks B1, B3 and B3, poles P1 and P3 are empty and B1 is bigger than B2, then it's not possible to move B1 to P3
+mdl_MoveMakesOne_anti2_bis:(mdl [] []
+    (fact (icst cst_591 [] [B1: B2: P1: P2: B3: P3:] : :) v9: v10: : :)
+    (|fact (imdl mdl_MoveMakesOne [[] (ti v9: v10:)] [B1: P3: v12: v13:] : :) v9: v10: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P2 has three blocks B1, B3 and B3, poles P1 and P3 are empty and B1 is bigger than B2, then it's not possible to move B3 to P1
+mdl_593:(mdl [] []
+    (fact (icst cst_591 [] [B1: B2: P1: P2: B3: P3:] : :) v9: v10: : :)
+    (|fact (imdl mdl_MoveMakesOne [[] (ti v9: v10:)] [B3: P1: v12: v13:] : :) v9: v10: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P2 has three blocks B1, B3 and B3, poles P1 and P3 are empty and B1 is bigger than B2, then it's not possible to move B3 to P3
+mdl_593_bis:(mdl [] []
+    (fact (icst cst_591 [] [B1: B2: P1: P2: B3: P3:] : :) v9: v10: : :)
+    (|fact (imdl mdl_MoveMakesOne [[] (ti v9: v10:)] [B3: P3: v12: v13:] : :) v9: v10: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; If pole P1 has two blocks B1 and B2, then it's not possible to move B1 to another pole P2 (correct)
+; mdl_1629
+mdl_MoveMakesTwo_anti1:(mdl [] []
+   (fact (icst cst_PoleHasTwoBlocks [] [P1: B1: B2:] : :) v3: v4: : :)
+   (|fact (imdl mdl_MoveMakesTwo [B3: (ti v3: v4:)] [B1: P2: v7: v8:] : :) v3: v4: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P1 has two blocks B2 and B3 and pole P2 has one block B1, then it's not possible to move B2 to P2 (correct)
+; mdl_1632
+mdl_MoveMakesTwo_anti2:(mdl [] []
+   (fact (icst cst_1631 [] [B1: B2: B3: P1: P2:] : :) v5: v6: : :)
+   (|fact (imdl mdl_MoveMakesTwo [B1: (ti v5: v6:)] [B2: P2: v7: v8:] : :) v5: v6: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+
+; ==== Drive ====
+m_drive1:(mdl [] []
+    ; The goal target timings are the same as the drive timings.
+    (fact (mk.val center_pole has_blocks [medium_block small_block] :) T0: T1: : :)
+    (fact run T0: T1: ::)
+|[]
+|[]
+[stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+run2:(ent 1) [[SYNC_ONCE now 0 forever root nil]]
+m_drive2:(mdl [] []
+    ; The goal target timings are the same as the drive timings.
+    (fact (mk.val right_pole has_blocks [big_block medium_block small_block] :) T0: T1: : :)
+    (fact run2 T0: T1: ::)
+|[]
+|[]
+[stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+!def DRIVE_START 300ms
+
+pgm_inject_drive:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt DRIVE_START))
+[]
+   ; The end of the time interval will be used in m_drive as the end of the goal interval.
+   (inj [f_run:(fact run2 After (+ Before 700ms) 1 1) []])
+   (inj [G:(goal f_run self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before injecting the drive.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected drive" []])
+1) |[]
+(ipgm pgm_inject_drive [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+
+; ==== Babble programs ====
+; anti_position_drive:(ent 1) [[SYNC_ONCE now 0 forever root nil]]
+; m_anti_position_drive:(mdl [P: B1: B2:] []
+;    ; The goal target timings are the same as the drive timings.
+;    (|fact (mk.val P: has_blocks [B1: B2:] 1) T0: T1: 1 1)
+;    (fact anti_position_drive T0: T1: ::)
+; |[]
+; |[]
+; [stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; pgm_babbleA_1:(pgm [] []
+;     ; This fact repeats periodically. We use it as a "heartbeat".
+;     (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+; []
+;     (>= After (+ this.vw.ijt 300ms))
+; []
+;     (inj [Drive:(imdl m_anti_position_drive [left_pole medium_block small_block] [] false 1) []])
+;     (inj [F_Drive:(fact Drive (+ After 100ms) (+ Before 200ms) 1 1) []])
+;     (inj [G_F_Drive:(goal F_Drive self nil 1) []])
+;     (inj []
+;         (fact G_F_Drive T0:(+ After 10ms) T0 1 1)
+;         [SYNC_ONCE T0 1 forever primary nil]
+;     )
+;
+;     ; Move the medium block to the center
+;     (inj [Command:(cmd move_block [small_block right_pole] 1) []])
+;     (inj [F_Command:(fact Command After Before 1 1) []])
+;     (inj [G:(goal F_Command self nil 1) []])
+;     (inj []
+;         ; Delay a little to allow predictions for this sampling period before processing.
+;         (fact G T0:(+ After 10ms) T0 1 1)
+;         [SYNC_ONCE T0 1 forever primary nil]
+;     )
+;     (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+; 1) |[]
+; (ipgm pgm_babbleA_1 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+;    [SYNC_ONCE now 0 forever primary nil 1]
+
+
+; ==== Eject programs ====
+pgm_eject_cmd_move_block:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd move_block [B: P:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd move_block [B P] 1)
+1) |[]
+(ipgm pgm_eject_cmd_move_block [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]

--- a/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-full.2.replicode
+++ b/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-full.2.replicode
@@ -1,0 +1,672 @@
+; ==== Entities and ontologies ====
+big_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+medium_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+small_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+left_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+center_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+right_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+size:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val big_block size 3 1)
+has_blocks:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val left_pole has_blocks [<blocks>] 1), order is bigger -> smaller
+pole:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+; "position" will be used as (mk.val big_block position left_pole 1)
+
+!dfn (move_block :); arg0: a block, arg1: target position (pole)
+
+
+; ==== Facts ====
+big_block_is_big:(mk.val big_block size 3 1) |[]
+(fact big_block_is_big 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_medium:(mk.val medium_block size 2 1) |[]
+(fact medium_block_is_medium 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+small_block_is_small:(mk.val small_block size 1 1) |[]
+(fact small_block_is_small 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+left_pole_is_a_pole:(mk.val left_pole essence pole 1) |[]
+(fact left_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+center_pole_is_a_pole:(mk.val center_pole essence pole 1) |[]
+(fact center_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+right_pole_is_a_pole:(mk.val right_pole essence pole 1) |[]
+(fact right_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+big_block_is_not_a_pole:(mk.val big_block essence pole 1) |[]
+(|fact big_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_not_a_pole:(mk.val medium_block essence pole 1) |[]
+(|fact medium_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+small_block_is_not_a_pole:(mk.val small_block essence pole 1) |[]
+(|fact small_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+
+; ==== CSTs ====
+; B1 is bigger than B2
+S_BlockIsBigger:(cst [] []
+    (fact (mk.val B1: size S1: :) T0: T1: : :)
+    (fact (mk.val B2: size S2: :) T0: T1: : :)
+[]
+    (> S1 S2)
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleIsEmpty:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [] :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasOneBlock:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B:] :) T0: T1: : :)
+    (|fact (mk.val B: essence pole :) T0: T1: : :)
+    (fact (mk.val B: size S: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasTwoBlocks:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B1: B2:] :) T0: T1: : :)
+    (fact (icst S_BlockIsBigger [] [B1: S1: B2: S2:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasThreeBlocks:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B1: B2: B3:] :) T0: T1: : :)
+    (fact (icst S_BlockIsBigger [] [B1: S1: B2: S2:] : :) T0: T1: : :)
+    (fact (icst S_BlockIsBigger [] [B2: S2: B3: S3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; ----------------------------------------------
+
+cst_592:(cst [] []
+   (|fact (mk.val B: essence pole :) v1: v2: : :)
+   (fact (icst S_BlockIsBigger [] [B: v3: B1: v5:] : :) v1: v2: : :)
+   (fact (icst S_PoleHasOneBlock [] [P1: B1: v5:] : :) v1: v2: : :)
+   (fact (icst S_PoleHasTwoBlocks [] [P2: B: B2: v3: v7:] : :) v1: v2: : :)
+   (fact (icst S_PoleIsEmpty [] [P3:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; cst_592_TopBlockBiggerThanSingle:(cst [] []
+;    (|fact (mk.val B: essence pole :) v1: v2: : :)
+;    (fact (icst S_BlockIsBigger [] [B: v3: B1: v5:] : :) v1: v2: : :)
+;    (fact (icst S_BlockIsBigger [] [B2: S2: B1: v5:] : :) v1: v2: : :)
+;    (fact (icst S_PoleHasOneBlock [] [P1: B1: v5:] : :) v1: v2: : :)
+;    (fact (icst S_PoleHasTwoBlocks [] [P2: B: B2: v3: S2:] : :) v1: v2: : :)
+;    (fact (icst S_PoleIsEmpty [] [P3:] : :) v1: v2: : :)
+; |[]
+; |[]
+; [stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_597:(cst [] []
+   (|fact (mk.val B2: essence pole :) v1: v2: : :)
+   (fact (icst S_BlockIsBigger [] [B2: v4: B1: v5:] : :) v1: v2: : :)
+   (fact (icst S_PoleIsEmpty [] [P1:] : :) v1: v2: : :)
+   (fact (icst S_PoleHasThreeBlocks [] [P: B2: B3: B1: v4: v9: v5:] : :) v1: v2: : :)
+   (fact (icst S_PoleIsEmpty [] [P2:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; B1 > B2, B1 > B3, B2 > B3 (B1: big, B2: medium, B3: small)
+; cst_676:(cst [] []
+;    (fact (icst S_BlockIsBigger [] [B1: v1: B2: v3:] : :) v4: v5: : :)
+;    (fact (icst S_BlockIsBigger [] [B1: v1: B3: v7:] : :) v4: v5: : :)
+;    (fact (icst S_BlockIsBigger [] [B2: v3: B3: v7:] : :) v4: v5: : :)
+;    (fact (icst S_PoleHasOneBlock [] [P1: B3: v7:] : :) v4: v5: : :)
+;    (fact (icst S_PoleHasOneBlock [] [P2: B1: v1:] : :) v4: v5: : :)
+; |[]
+; |[]
+; [stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; ----------------------------------------------
+
+; There are two poles P1 and P2 with one block each, block B1 is bigger than B2
+cst_TwoPolesWithOneBlock:(cst [] []
+   (|fact (mk.val B1: essence pole :) v1: v2: : :)
+   (|fact (mk.val B2: essence pole :) v1: v2: : :)
+   (fact (icst S_BlockIsBigger [] [B1: S1: B2: S2:] : :) v1: v2: : :)
+   (fact (icst S_PoleHasOneBlock [] [P1: B1: S1:] : :) v1: v2: : :)
+   (fact (icst S_PoleHasOneBlock [] [P2: B2: S2:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; There are two poles: P1 has one block B1 and P2 has two blocks B and B2; B1 is bigger than B2
+cst_PoleWithOneBlockAndPoleWithTwo:(cst [] []
+   (|fact (mk.val B1: essence pole :) v1: v2: : :)
+   (|fact (mk.val B2: essence pole :) v1: v2: : :)
+   (fact (icst S_BlockIsBigger [] [B1: S1: B2: S2:] : :) v1: v2: : :)
+   (fact (icst S_PoleHasOneBlock [] [P1: B1: S1:] : :) v1: v2: : :)
+   (fact (icst S_PoleHasTwoBlocks [] [P2: B: B2: S3: S2:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; There are two poles: P1 has one block B2 and P2 has two blocks B and B1; B1 is bigger than B2 (same as the other but here the lone block is smaller)
+cst_PoleWithOneBlockAndPoleWithTwo_bis:(cst [] []
+   (|fact (mk.val B1: essence pole :) v1: v2: : :)
+   (|fact (mk.val B2: essence pole :) v1: v2: : :)
+   (fact (icst S_BlockIsBigger [] [B1: S1: B2: S2:] : :) v1: v2: : :)
+   (fact (icst S_PoleHasOneBlock [] [P1: B2: S2:] : :) v1: v2: : :)
+   (fact (icst S_PoleHasTwoBlocks [] [P2: B: B1: S3: S1:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Models ====
+; After moving block B to pole P, another pole P1 will be empty
+mdl_204:(mdl [B: (ti v1: v2:)] []
+   (fact (cmd move_block [B: P:] :) v4: v5: : :)
+   (fact (mk.val P1: has_blocks [] :) v7: v8: : :)
+[]
+   v7:(add v1 100ms)
+   v8:(add v2 100ms)
+[]
+   v1:(sub v7 100ms)
+   v2:(sub v8 100ms)
+   v4:(sub v7 80ms)
+   v5:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If a pole has one block, the block can be moved and the pole will be empty
+mdl_205:(mdl [] []
+   (fact (icst S_PoleHasOneBlock [] [P: B: v2:] : :) v3: v4: : :)
+   (fact (imdl mdl_204 [B: (ti v3: v4:)] [v5: P: v6: v7:] : :) v3: v4: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Moving block B to pole P will make P have one block B
+; mdl_220
+mdl_208:(mdl [B: (ti v1: v2:)] []
+   (fact (cmd move_block [B: P:] :) v5: v6: : :)
+   (fact (mk.val P: has_blocks [B:] :) v7: v8: : :)
+[]
+   v7:(add v1 100ms)
+   v8:(add v2 100ms)
+[]
+   v1:(sub v7 100ms)
+   v2:(sub v8 100ms)
+   v5:(sub v7 80ms)
+   v6:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P is empty, a block can be moved to it
+mdl_209:(mdl [] []
+   (fact (icst S_PoleIsEmpty [] [P:] : :) v1: v2: : :)
+   (fact (imdl mdl_208 [B: (ti v1: v2:)] [P: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has one block B, moving B to another pole P1 will make P1 have B
+mdl_210:(mdl [] []
+   (fact (icst S_PoleHasOneBlock [] [P: B: v3:] : :) v5: v6: : :)
+   (fact (imdl mdl_208 [B: (ti v5: v6:)] [P1: v4: v5:] : :) v5: v6: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Moving block B to P will make P1 have one block B1
+mdl_249:(mdl [v0: (ti v1: v2:)] []
+   (fact (imdl mdl_208 [B: (ti v1: v2:)] [P: v5: v6:] : :) v7: v8: : :)
+   (fact (mk.val P1: has_blocks [B1:] :) v5: v6: : :)
+[]
+   v5:(add v1 100ms)
+   v6:(add v2 100ms)
+[]
+   v1:(sub v5 100ms)
+   v2:(sub v6 100ms)
+   v7:(sub v5 80ms)
+   v8:(sub v6 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P1 has blocks B1 and B, moving block B to P will make P1 have only block B1
+mdl_250:(mdl [] []
+   (fact (icst S_PoleHasTwoBlocks [] [P1: B1: B: v3: v4:] : :) v5: v6: : :)
+   (fact (imdl mdl_249 [[P: P1:] (ti v5: v6:)] [B: P: v8: v9: P1: B1:] : :) v5: v6: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Moving block B to pole P will make another pole P1 have one block B1 (similar to mdl_249 but as a command mdl)
+mdl_292:(mdl [v0: (ti v1: v2:)] []
+   (fact (cmd move_block [B: P:] :) v5: v6: : :)
+   (fact (mk.val P1: has_blocks [B1:] :) v9: v10: : :)
+[]
+   v9:(add v1 100ms)
+   v10:(add v2 100ms)
+[]
+   v1:(sub v9 100ms)
+   v2:(sub v10 100ms)
+   v5:(sub v9 80ms)
+   v6:(sub v10 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P1 has blocks B1 and B, moving block B to P will make P1 have only block B1 (similar to mdl_250 but without any pole receiving a block)
+mdl_293:(mdl [] []
+   (fact (icst S_PoleHasTwoBlocks [] [P1: B1: B: v3: v4:] : :) v5: v6: : :)
+   (fact (imdl mdl_292 [[P: P1:] (ti v5: v6:)] [B: P: P1: B1: v8: v9:] : :) v5: v6: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; After block B1 has been moved and pole P1 is empty, pole P will have two blocks B and B1
+mdl_294:(mdl [B: (ti v1: v2:)] []
+   (fact (imdl mdl_204 [B1: (ti v1: v2:)] [P: P1: v6: v7:] : :) v8: v9: : :)
+   (fact (mk.val P: has_blocks [B: B1:] :) v6: v7: : :)
+[]
+   v6:(add v1 100ms)
+   v7:(add v2 100ms)
+[]
+   v1:(sub v6 100ms)
+   v2:(sub v7 100ms)
+   v8:(sub v6 80ms)
+   v9:(sub v7 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has block B, block B1 can be moved to P so P will have blocks B and B1
+mdl_295:(mdl [] []
+   (fact (icst S_PoleHasOneBlock [] [P: B: v2:] : :) v3: v4: : :)
+   (fact (imdl mdl_294 [B: (ti v3: v4:)] [B1: P: P1: v7: v8:] : :) v3: v4: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Moving block B to pole P will make pole P have two blocks B1 and B
+mdl_296:(mdl [B1: (ti v1: v2:)] []
+   (fact (cmd move_block [B: P:] :) v5: v6: : :)
+   (fact (mk.val P: has_blocks [B1: B:] :) v7: v8: : :)
+[]
+   v7:(add v1 100ms)
+   v8:(add v2 100ms)
+[]
+   v1:(sub v7 100ms)
+   v2:(sub v8 100ms)
+   v5:(sub v7 80ms)
+   v6:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has one block B1, moving B to P will make P have two blocks B1 and B
+mdl_297:(mdl [] []
+   (fact (icst S_PoleHasOneBlock [] [P: B1: v2:] : :) v3: v4: : :)
+   (fact (imdl mdl_296 [B1: (ti v3: v4:)] [B: P: v6: v7:] : :) v3: v4: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; After moving block B to pole P, P will have three blocks B1, B2 and B (and pole P1 will be empty)
+mdl_497:(mdl [v0: (ti v1: v2:)] []
+   (fact (imdl mdl_204 [B: (ti v1: v2:)] [P: P1: v6: v7:] : :) v8: v9: : :)
+   (fact (mk.val P: has_blocks [B1: B2: B:] :) v6: v7: : :)
+[]
+   v6:(add v1 100ms)
+   v7:(add v2 100ms)
+[]
+   v1:(sub v6 100ms)
+   v2:(sub v7 100ms)
+   v8:(sub v6 80ms)
+   v9:(sub v7 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has two blocks B1 and B2, moving block B to P will make P have three blocks B1, B2 and B (and pole P1 will be empty)
+mdl_498:(mdl [] []
+   (fact (icst S_PoleHasTwoBlocks [] [P: B1: B2: v3: v4:] : :) v5: v6: : :)
+   (fact (imdl mdl_497 [[P: P1:] (ti v5: v6:)] [B: P: P1: v9: v10: B1: B2:] : :) v5: v6: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; After moving block B to pole P, P will have three blocks B1, B2 and B (similar to mdl_497 but as a command mdl, no pole remains empty)
+mdl_501:(mdl [[P: B1:] (ti v1: v2:)] []
+   (fact (cmd move_block [B: P:] :) v5: v6: : :)
+   (fact (mk.val P: has_blocks [B1: B2: B:] :) v9: v10: : :)
+[]
+   v9:(add v1 100ms)
+   v10:(add v2 100ms)
+[]
+   v1:(sub v9 100ms)
+   v2:(sub v10 100ms)
+   v5:(sub v9 80ms)
+   v6:(sub v10 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has two blocks B1 and B2, moving block B to P will make P have three blocks B1, B2 and B (similar to mdl_498 but no pole remains empty)
+mdl_502:(mdl [] []
+   (fact (icst S_PoleHasTwoBlocks [] [P: B1: B2: v3: v4:] : :) v5: v6: : :)
+   (fact (imdl mdl_501 [[P: B1:] (ti v5: v6:)] [B: P: B1: B2: v8: v9:] : :) v5: v6: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; After moving block B to pole P, another pole P1 will have two blocks B1 and B2 (and P will have one block B)
+mdl_547:(mdl [[P: P1: B1:] (ti v1: v2:)] []
+   (fact (imdl mdl_208 [B: (ti v1: v2:)] [P: v5: v6:] : :) v7: v8: : :)
+   (fact (mk.val P1: has_blocks [B1: B2:] :) v5: v6: : :)
+[]
+   v5:(add v1 100ms)
+   v6:(add v2 100ms)
+[]
+   v1:(sub v5 100ms)
+   v2:(sub v6 100ms)
+   v7:(sub v5 80ms)
+   v8:(sub v6 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P1 has three blocks B1, B2 and B, moving B to another pole P will make P1 have two blocks B1 and B2 and P will have one block B
+mdl_548:(mdl [] []
+   (fact (icst S_PoleHasThreeBlocks [] [P1: B1: B2: B: v4: v5: v6:] : :) v7: v8: : :)
+   (fact (imdl mdl_547 [[P: P1: B1:] (ti v7: v8:)] [B: P: v10: v11: P1: B1: B2:] : :) v7: v8: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; After moving block B to pole P, another pole P1 will have two blocks B1 and B2 (similar to mdl_547 but as a command model, no pole receives block)
+mdl_551:(mdl [[P: P1: B1:] (ti v1: v2:)] []
+   (fact (cmd move_block [B: P:] :) v5: v6: : :)
+   (fact (mk.val P1: has_blocks [B1: B2:] :) v10: v11: : :)
+[]
+   v10:(add v1 100ms)
+   v11:(add v2 100ms)
+[]
+   v1:(sub v10 100ms)
+   v2:(sub v11 100ms)
+   v5:(sub v10 80ms)
+   v6:(sub v11 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P1 has three blocks B1, B2 and B, moving B to another pole P will make P1 have two blocks B1 and B2 (similar to mdl_548 but no pole receives block)
+mdl_552:(mdl [] []
+   (fact (icst S_PoleHasThreeBlocks [] [P1: B1: B2: B: v4: v5: v6:] : :) v7: v8: : :)
+   (fact (imdl mdl_551 [[P: P1: B1:] (ti v7: v8:)] [B: B2: v10: v11:] : :) v7: v8: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; ---- Don't move block that is under another one ----
+
+; If pole P1 has one block B1, pole P2 has two blocks B and B2 (B > B2), pole P3 is emptyand B is bigger than B1, then it's not possible to move B to P1 (correct)
+mdl_593:(mdl [] []
+    (fact (icst cst_592 [] [B: v1: B1: v3: P1: P2: B2: v7: P3:] : :) v9: v10: : :)
+    ; (fact (icst cst_592_TopBlockBiggerThanSingle [] [B: v1: B1: v3: B2: S2: P1: P2: P3:] : :) v9: v10: : :)
+    ; (|fact (imdl mdl_296 [B1 (ti v9: v10:)] [B: P1: v13: v14:] : :) v9: v10: : :)
+    (|fact (imdl mdl_208 [B: (ti v9: v10:)] [P1: v13: v14:] : :) v9: v10: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P1 has one block B1, pole P2 has two blocks B and B2 (B > B2), pole P3 is empty and B is bigger than B1, then it's not possible to move B to P3
+; mdl_593_bis:(mdl [] []
+;     (fact (icst cst_592 [] [B: v1: B1: v3: P1: P2: B2: v7: P3:] : :) v9: v10: : :)
+;     (|fact (imdl mdl_208 [B: (ti v9: v10:)] [P3: v13: v14:] : :) v9: v10: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P1 has one block B1, pole P2 has two blocks B and B2 (B > B2), pole P3 is empty and B is bigger than B1,
+; B2 can be moved to P3 and P2 will be left with one block B
+; mdl_CanMoveTopBlockOfTwo:(mdl [] []
+;     (fact (icst cst_592 [] [B: v1: B1: v3: P1: P2: B2: v7: P3:] : :) v9: v10: : :)
+;     (fact (imdl mdl_249 [[] (ti v5: v6:)] [B2: P3: v8: v9: P2: B:] : :) v5: v6: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has three blocks B2, B3 and B1, poles P1 and P2 are empty and B2 is bigger than B1, then it's not possible to move B2 to P1 (correct)
+mdl_598:(mdl [] []
+    (fact (icst cst_597 [] [B2: v1: B1: v3: P1: P: B3: v7: P2:] : :) v9: v10: : :)
+    (|fact (imdl mdl_208 [B2: (ti v9: v10:)] [P1: v12: v13:] : :) v9: v10: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has three blocks B2, B3 and B1, poles P1 and P2 are empty and B2 is bigger than B1, then it's not possible to move B2 to P2
+mdl_598_bis:(mdl [] []
+    (fact (icst cst_597 [] [B2: v1: B1: v3: P1: P: B3: v7: P2:] : :) v9: v10: : :)
+    (|fact (imdl mdl_208 [B2: (ti v9: v10:)] [P2: v12: v13:] : :) v9: v10: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has three blocks B2, B3 and B1, poles P1 and P2 are empty and B2 is bigger than B1,
+; B1 can be moved to P1 and P will be left with two blocks B2 and B3
+; mdl_CanMoveTopBlockOfThree:(mdl [] []
+;     (fact (icst cst_597 [] [B2: v1: B1: v3: P1: P: B3: v7: P2:] : :) v9: v10: : :)
+;     ; (fact (imdl mdl_208 [B1: (ti v9: v10:)] [P1: v12: v13:] : :) v9: v10: : :)
+;     (fact (imdl mdl_547 [[] (ti v7: v8:)] [B1: P1: v10: v11: P: B2: B3:] : :) v7: v8: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has three blocks B2, B3 and B1, poles P1 and P2 are empty and B2 is bigger than B1,
+; B1 can be moved to P2 and P will be left with two blocks B2 and B3
+; mdl_CanMoveTopBlockOfThree_bis:(mdl [] []
+;     (fact (icst cst_597 [] [B2: v1: B1: v3: P1: P: B3: v7: P2:] : :) v9: v10: : :)
+;     ; (fact (imdl mdl_208 [B1: (ti v9: v10:)] [P2: v12: v13:] : :) v9: v10: : :)
+;     (fact (imdl mdl_547 [[] (ti v7: v8:)] [B1: P2: v10: v11: P: B2: B3:] : :) v7: v8: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P1 has one block B1, pole P2 has two blocks B and B2 (B > B2), pole P3 is empty and B is bigger than B1, B2 can be moved to P1
+; M_CanMoveTopBlockOfTwo:(mdl [] []
+;    (fact (icst cst_592 [] [B: v1: B1: v3: P1: P2: B2: v7: P3:] : :) v9: v10: : :)
+;    (fact (imdl mdl_296 [B1 (ti v11: v12:)] [B2: P1: v13: v14:] : :) v11: v12: : :)
+; []
+;    v11:(add v9 200ms)
+;    v12:(add v10 200ms)
+; []
+;    v9:(sub v11 200ms)
+;    v10:(sub v12 200ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has two blocks B and B1 and there are two empty poles P1 and P2, it's not possible to move B to pole P1
+; mdl_554:(mdl [] []
+;     (fact (icst cst_553 [] [B: P: B1: v3: v4: P1: P2:] : :) v7: v8: : :)
+;     ; (fact (icst cst_515 [] [B: B1: P: v3: v4: P1: P2:] : :) v7: v8: : :)
+;     (|fact (imdl mdl_208 [[] (ti v7: v8:)] [B: P1: v9: v10:] : :) v7: v8: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; If pole P has two blocks B and B1 and there are two empty poles P1 and P2, it's not possible to move B to pole P2
+; mdl_554_bis:(mdl [] []
+;     (fact (icst cst_553 [] [B: P: B1: v3: v4: P1: P2:] : :) v7: v8: : :)
+;     ; (fact (icst cst_515 [] [B: B1: P: v3: v4: P1: P2:] : :) v7: v8: : :)
+;     (|fact (imdl mdl_208 [[] (ti v7: v8:)] [B: P2: v9: v10:] : :) v7: v8: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; If pole P has two blocks B and B1 and there are two empty poles P1 and P2, B1 can be moved to P1
+; M_CanMoveAnotherBlock:(mdl [] []
+;     (fact (icst cst_553 [] [B: P: B1: v3: v4: P1: P2:] : :) v7: v8: : :)
+;     ; (fact (icst cst_515 [] [B: B1: P: v3: v4: P1: P2:] : :) v7: v8: : :)
+;     (fact (imdl mdl_208 [[] (ti v7: v8:)] [B1: P1: v9: v10:] : :) v7: v8: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; If pole P has two blocks B and B1 and there are two empty poles P1 and P2, B1 can be moved to P2
+; M_CanMoveAnotherBlock_bis:(mdl [] []
+;     (fact (icst cst_553 [] [B: P: B1: v3: v4: P1: P2:] : :) v7: v8: : :)
+;     ; (fact (icst cst_515 [] [B: B1: P: v3: v4: P1: P2:] : :) v7: v8: : :)
+;     (fact (imdl mdl_208 [[] (ti v7: v8:)] [B1: P2: v9: v10:] : :) v7: v8: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; ---- Don't move bigger block on smaller one ----
+
+; If pole P1 has block B1, pole P2 has block B2 and B1 is bigger than B2, then it's not possible to move B1 to P2
+; mdl_CannotMoveBiggerOnSmaller_1:(mdl [] []
+;    (fact (icst cst_TwoPolesWithOneBlock [] [B1: B2: S1: S2: P1: P2:] : :) v9: v10: : :)
+;    (|fact (imdl mdl_296 [B2 (ti v9: v10:)] [B1: P2: v13: v14:] : :) v9: v10: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; If pole P1 has block B1, pole P2 has two blocks B and B2 and B1 is bigger than B2, then it's not possible to move B1 to P2
+; mdl_CannotMoveBiggerOnSmaller_2:(mdl [] []
+;    (fact (icst cst_PoleWithOneBlockAndPoleWithTwo [] [B1: B2: S1: S2: P1: P2: B: S3:] : :) v9: v10: : :)
+;    (|fact (imdl mdl_296 [B2 (ti v9: v10:)] [B1: P2: v13: v14:] : :) v9: v10: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; If pole P1 has block B2, pole P2 has two blocks B and B1 and B1 is bigger than B2, then it's not possible to move B1 to P2
+; mdl_CannotMoveBiggerOnSmaller_3:(mdl [] []
+;    (fact (icst cst_PoleWithOneBlockAndPoleWithTwo_bis [] [B1: B2: S1: S2: P1: P2: B: S3:] : :) v9: v10: : :)
+;    (|fact (imdl mdl_296 [B2 (ti v9: v10:)] [B1: P2: v13: v14:] : :) v9: v10: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; mdl_667:(mdl [] []
+;    (fact (icst cst_666 [] [v0: v1: v2: v3: v4: v5: v6: v7: v8:] : :) v9: v10: : :)
+;    (|fact (imdl mdl_292 [v0: (ti v11: v12:)] [v1: v4: v5: v13: v14:] : :) v11: v12: : :)
+; []
+;    v11:(add v9 200ms)
+;    v12:(add v10 200ms)
+; []
+;    v9:(sub v11 200ms)
+;    v10:(sub v12 200ms)
+; [stdin] 0 1 1 1 1 ) []
+
+; If pole P1 has block B1, pole P2 has block B2, B1 is bigger than B2 and P3 is empty, then it's not possible to move B1 to P2 (correct!)
+; mdl_496:(mdl [] []
+;    (fact (icst cst_495 [] [B1: v1: B2: v3: P1: P2: P3:] : :) v7: v8: : :)
+;    (|fact (imdl mdl_204 [B1: (ti v9: v10:)] [P2: P1: v11: v12:] : :) v9: v10: : :)
+; []
+;    v9:(add v7 200ms)
+;    v10:(add v8 200ms)
+; []
+;    v7:(sub v9 200ms)
+;    v8:(sub v10 200ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; If pole P1 has block B1, pole P2 has block B2, B1 is bigger than B2 and P3 is empty, then
+; ; it's not possible that, after B1 has been moved to pole P2, P1 will be empty and P2 will have blocks B2 and B1 (correct)
+; mdl_511:(mdl [] []
+;    (fact (icst cst_495 [] [B1: v1: B2: v3: P1: P2: P3:] : :) v7: v8: : :)
+;    (|fact (imdl mdl_292 [B2: (ti v9: v10:)] [B1: P2: P1: v11: v12:] : :) v9: v10: : :)
+; []
+;    v9:(add v7 200ms)
+;    v10:(add v8 200ms)
+; []
+;    v7:(sub v9 200ms)
+;    v8:(sub v10 200ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; If pole P1 has block B1, pole P2 has block B2, B1 is bigger than B2 and pole P3 is empty, then
+; ; it's not possible that moving B1 to another pole P2 will make P2 have two blocks B2 and B1 (correct)
+; mdl_526:(mdl [] []
+;    (fact (icst cst_495 [] [B1: v1: B2: v3: P1: P2: P3:] : :) v7: v8: : :)
+;    (|fact (imdl mdl_296 [B2: (ti v9: v10:)] [B1: P2: v11: v12:] : :) v9: v10: : :)
+; []
+;    v9:(add v7 200ms)
+;    v10:(add v8 200ms)
+; []
+;    v7:(sub v9 200ms)
+;    v8:(sub v10 200ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; If pole P1 has two blocks B and B1 (B > B1), it's not possible that moving B to another pole P will make P have two blocks B1 and B (technically correct)
+; mdl_528:(mdl [] []
+;    (fact (icst S_PoleHasTwoBlocks [] [P1: B: B1: v3: v4:] : :) v5: v6: : :)
+;    (|fact (imdl mdl_296 [B1: (ti v6: v7:)] [B: P: v9: v10:] : :) v6: v7: : :)
+; []
+;    v6:(add v5 100ms)
+;    v7:(add v6 100ms)
+; []
+;    v5:(sub v6 100ms)
+;    v6:(sub v7 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; If pole P has two blocks B and B1 (B > B1) and other poles P1 and P2 are empty,
+; ; it's not possible that moving B1 to another pole P1 will make P1 have two blocks B1 and B (B1 > B) (correct)
+; mdl_531:(mdl [] []
+;    (fact (icst cst_515 [] [B: B1: P: v3: v4: P1: P2:] : :) v7: v8: : :)
+;    (|fact (imdl mdl_296 [B1: (ti v8: v9:)] [B: P1: v10: v11:] : :) v8: v9: : :)
+; []
+;    v8:(add v7 100ms)
+;    v9:(add v8 100ms)
+; []
+;    v7:(sub v8 100ms)
+;    v8:(sub v9 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; After block B has been moved to pole P and P has block B, another pole P1 will be empty
+; mdl_610:(mdl [B: (ti v1: v2:)] []
+;    (fact (imdl mdl_208 [[] (ti v1: v2:)] [B: P: v4: v5:] : :) v6: v7: : :)
+;    (fact (mk.val P1: has_blocks [] :) v4: v5: : :)
+; []
+;    v4:(add v1 100ms)
+;    v5:(add v2 100ms)
+; []
+;    v1:(sub v4 100ms)
+;    v2:(sub v5 100ms)
+;    v6:(sub v4 80ms)
+;    v7:(sub v5 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; If pole P1 has one block B, moving B to pole P will make P have block B and P1 will be empty
+; mdl_611:(mdl [] []
+;    (fact (icst S_PoleHasOneBlock [] [P1: B: v2:] : :) v3: v4: : :)
+;    (fact (imdl mdl_610 [B: (ti v3: v4:)] [P: v6: v7: P1:] : :) v3: v4: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Drive ====
+m_drive:(mdl [] []
+    ; The goal target timings are the same as the drive timings.
+    (fact (mk.val right_pole has_blocks [big_block medium_block small_block] :) T0: T1: : :)
+    ; (fact (icst S_PoleHasTwoBlocks [] [right_pole medium_block small_block 2 1] : :) T0: T1: : :)
+    ; (fact (icst S_Below [] [medium_block S1: right_pole small_block S2:] : :) T0: T1: : :)
+    (fact run T0: T1: ::)
+|[]
+|[]
+[stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+!def DRIVE_START 300ms
+
+pgm_inject_drive:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt DRIVE_START))
+[]
+   ; The end of the time interval will be used in m_drive as the end of the goal interval.
+   (inj [f_run:(fact run After (+ Before 1700ms) 1 1) []])
+   (inj [G:(goal f_run self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before injecting the drive.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected drive" []])
+1) |[]
+(ipgm pgm_inject_drive [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+
+; ==== Eject programs ====
+pgm_eject_cmd_move_block:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd move_block [B: P:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd move_block [B P] 1)
+1) |[]
+(ipgm pgm_eject_cmd_move_block [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]

--- a/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-full.replicode
+++ b/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-full.replicode
@@ -1,0 +1,628 @@
+; ==== Entities and ontologies ====
+; big_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+medium_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+small_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+left_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+center_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+right_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+size:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val big_block size 3 1)
+has_blocks:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val left_pole has_blocks [<blocks>] 1), order is bigger -> smaller
+pole:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+; "position" will be used as (mk.val big_block position left_pole 1)
+
+!dfn (move_block :); arg0: a block, arg1: target position (pole)
+
+
+; ==== Facts ====
+; big_block_is_big:(mk.val big_block size 3 1) |[]
+; (fact big_block_is_big 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_medium:(mk.val medium_block size 2 1) |[]
+(fact medium_block_is_medium 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+small_block_is_small:(mk.val small_block size 1 1) |[]
+(fact small_block_is_small 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+left_pole_is_a_pole:(mk.val left_pole essence pole 1) |[]
+(fact left_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+center_pole_is_a_pole:(mk.val center_pole essence pole 1) |[]
+(fact center_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+right_pole_is_a_pole:(mk.val right_pole essence pole 1) |[]
+(fact right_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+; big_block_is_not_a_pole:(mk.val big_block essence pole 1) |[]
+; (|fact big_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_not_a_pole:(mk.val medium_block essence pole 1) |[]
+(|fact medium_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+small_block_is_not_a_pole:(mk.val small_block essence pole 1) |[]
+(|fact small_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+
+; ==== CSTs ====
+; B1 is bigger than B2
+S_BlockIsBigger:(cst [] []
+    (fact (mk.val B1: size S1: :) T0: T1: : :)
+    (fact (mk.val B2: size S2: :) T0: T1: : :)
+[]
+    (> S1 S2)
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleIsEmpty:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [] :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasOneBlock:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B:] :) T0: T1: : :)
+    (|fact (mk.val B: essence pole :) T0: T1: : :)
+    (fact (mk.val B: size S: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasTwoBlocks:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B1: B2:] :) T0: T1: : :)
+    (fact (icst S_BlockIsBigger [] [B1: S1: B2: S2:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+;--------------------------------------------------------------------------
+
+cst_553:(cst [] []
+   (|fact (mk.val B: essence pole :) v1: v2: : :)
+   (fact (icst S_PoleHasTwoBlocks [] [P: B: B1: v5: v6:] : :) v1: v2: : :)
+   (fact (icst S_PoleIsEmpty [] [P1:] : :) v1: v2: : :)
+   (fact (icst S_PoleIsEmpty [] [P2:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+;--------------------------------------------------------------------------
+
+cst_495:(cst [] []
+   (fact (icst S_BlockIsBigger [] [B1: S1: B2: S2:] : :) v4: v5: : :)
+   (fact (icst S_PoleHasOneBlock [] [P1: B1: S1:] : :) v4: v5: : :)
+   (fact (icst S_PoleHasOneBlock [] [P2: B2: S2:] : :) v4: v5: : :)
+   (fact (icst S_PoleIsEmpty [] [P3:] : :) v4: v5: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_500:(cst [] []
+   (|fact (mk.val B: essence pole :) v1: v2: : :)
+   (fact (icst S_PoleHasTwoBlocks [] [P: B: B1: v5: v6:] : :) v1: v2: : :)
+   (fact (icst S_PoleIsEmpty [] [P1:] : :) v1: v2: : :)
+   (fact (icst S_PoleIsEmpty [] [P2:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_515:(cst [] []
+   (|fact (mk.val B: essence pole :) v1: v2: : :)
+   (|fact (mk.val B1: essence pole :) v1: v2: : :)
+   (fact (icst S_PoleHasTwoBlocks [] [P: B: B1: v5: v6:] : :) v1: v2: : :)
+   (fact (icst S_PoleIsEmpty [] [P1:] : :) v1: v2: : :)
+   (fact (icst S_PoleIsEmpty [] [P2:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Models ====
+; After moving block B to pole P, another pole P1 will be empty
+mdl_174:(mdl [B: (ti v1: v2:)] []
+   (fact (cmd move_block [B: P:] :) v4: v5: : :)
+   (fact (mk.val P1: has_blocks [] :) v7: v8: : :)
+[]
+   v7:(add v1 100ms)
+   v8:(add v2 100ms)
+[]
+   v1:(sub v7 100ms)
+   v2:(sub v8 100ms)
+   v4:(sub v7 80ms)
+   v5:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If a pole has one block, the block can be moved and the pole will be empty
+mdl_175:(mdl [] []
+   (fact (icst S_PoleHasOneBlock [] [P: B: v2:] : :) v3: v4: : :)
+   (fact (imdl mdl_174 [B: (ti v3: v4:)] [v5: P: v6: v7:] : :) v3: v4: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Moving a block to a pole will make the pole have the block
+mdl_178:(mdl [v0: (ti v1: v2:)] []
+   (fact (cmd move_block [B: P:] :) v5: v6: : :)
+   (fact (mk.val P: has_blocks [B:] :) v7: v8: : :)
+[]
+   v7:(add v1 100ms)
+   v8:(add v2 100ms)
+[]
+   v1:(sub v7 100ms)
+   v2:(sub v8 100ms)
+   v5:(sub v7 80ms)
+   v6:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P is empty, a block can be moved to it
+mdl_179:(mdl [] []
+   (fact (icst S_PoleIsEmpty [] [P:] : :) v1: v2: : :)
+   (fact (imdl mdl_178 [[] (ti v1: v2:)] [v3: P: v4: v5:] : :) v1: v2: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; After block B1 has been moved and pole P1 is empty, pole P will have two blocks B and B1
+mdl_253:(mdl [B: (ti v1: v2:)] []
+   (fact (imdl mdl_174 [B1: (ti v1: v2:)] [P: P1: v6: v7:] : :) v8: v9: : :)
+   (fact (mk.val P: has_blocks [B: B1:] :) v6: v7: : :)
+[]
+   v6:(add v1 100ms)
+   v7:(add v2 100ms)
+[]
+   v1:(sub v6 100ms)
+   v2:(sub v7 100ms)
+   v8:(sub v6 80ms)
+   v9:(sub v7 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has block B, block B1 can be moved to P so P will have blocks B and B1
+mdl_254:(mdl [] []
+   (fact (icst S_PoleHasOneBlock [] [P: B: v2:] : :) v3: v4: : :)
+   (fact (imdl mdl_253 [B: (ti v3: v4:)] [B1: P: P1: v7: v8:] : :) v3: v4: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Moving block B to pole P will make pole P have two blocks B1 and B
+mdl_257:(mdl [B1: (ti v1: v2:)] []
+   (fact (cmd move_block [B: P:] :) v5: v6: : :)
+   (fact (mk.val P: has_blocks [B1: B:] :) v7: v8: : :)
+[]
+   v7:(add v1 100ms)
+   v8:(add v2 100ms)
+[]
+   v1:(sub v7 100ms)
+   v2:(sub v8 100ms)
+   v5:(sub v7 80ms)
+   v6:(sub v8 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has one block B1, moving B to P will make P have two blocks B1 and B
+mdl_258:(mdl [] []
+   (fact (icst S_PoleHasOneBlock [] [P: B1: v2:] : :) v3: v4: : :)
+   (fact (imdl mdl_257 [B1: (ti v3: v4:)] [B: P: v6: v7:] : :) v3: v4: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Moving block B to P will make P1 have one block B1
+mdl_299:(mdl [v0: (ti v1: v2:)] []
+   (fact (imdl mdl_178 [[] (ti v1: v2:)] [B: P: v5: v6:] : :) v7: v8: : :)
+   (fact (mk.val P1: has_blocks [B1:] :) v5: v6: : :)
+[]
+   v5:(add v1 100ms)
+   v6:(add v2 100ms)
+[]
+   v1:(sub v5 100ms)
+   v2:(sub v6 100ms)
+   v7:(sub v5 80ms)
+   v8:(sub v6 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P1 has blocks B1 and B, moving block B to P will make P1 have only block B1
+mdl_300:(mdl [] []
+   (fact (icst S_PoleHasTwoBlocks [] [P1: B1: B: v3: v4:] : :) v5: v6: : :)
+   (fact (imdl mdl_299 [[P: P1:] (ti v5: v6:)] [B: P: v8: v9: P1: B1:] : :) v5: v6: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Moving block B to pole P will make another pole P1 have one block B1
+mdl_303:(mdl [v0: (ti v1: v2:)] []
+   (fact (cmd move_block [B: P:] :) v5: v6: : :)
+   (fact (mk.val P1: has_blocks [B1:] :) v9: v10: : :)
+[]
+   v9:(add v1 100ms)
+   v10:(add v2 100ms)
+[]
+   v1:(sub v9 100ms)
+   v2:(sub v10 100ms)
+   v5:(sub v9 80ms)
+   v6:(sub v10 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P1 has blocks B1 and B, moving block B to P will make P1 have only block B1
+mdl_304:(mdl [] []
+   (fact (icst S_PoleHasTwoBlocks [] [P1: B1: B: v3: v4:] : :) v5: v6: : :)
+   (fact (imdl mdl_303 [[P: P1:] (ti v5: v6:)] [B: P: P1: B1: v8: v9:] : :) v5: v6: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; ---- Don't move block that is under another one ----
+
+; If pole P has two blocks B and B1 and there are two empty poles P1 and P2, it's not possible to move B to pole P1
+mdl_554:(mdl [] []
+    (fact (icst cst_553 [] [B: P: B1: v3: v4: P1: P2:] : :) v7: v8: : :)
+    ; (fact (icst cst_515 [] [B: B1: P: v3: v4: P1: P2:] : :) v7: v8: : :)
+    (|fact (imdl mdl_178 [[] (ti v7: v8:)] [B: P1: v9: v10:] : :) v7: v8: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has two blocks B and B1 and there are two empty poles P1 and P2, it's not possible to move B to pole P2
+mdl_554_bis:(mdl [] []
+    (fact (icst cst_553 [] [B: P: B1: v3: v4: P1: P2:] : :) v7: v8: : :)
+    ; (fact (icst cst_515 [] [B: B1: P: v3: v4: P1: P2:] : :) v7: v8: : :)
+    (|fact (imdl mdl_178 [[] (ti v7: v8:)] [B: P2: v9: v10:] : :) v7: v8: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has two blocks B and B1 and there are two empty poles P1 and P2, B1 can be moved to P1
+M_CanMoveAnotherBlock:(mdl [] []
+    (fact (icst cst_553 [] [B: P: B1: v3: v4: P1: P2:] : :) v7: v8: : :)
+    ; (fact (icst cst_515 [] [B: B1: P: v3: v4: P1: P2:] : :) v7: v8: : :)
+    (fact (imdl mdl_178 [[] (ti v7: v8:)] [B1: P1: v9: v10:] : :) v7: v8: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has two blocks B and B1 and there are two empty poles P1 and P2, B1 can be moved to P2
+M_CanMoveAnotherBlock_bis:(mdl [] []
+    (fact (icst cst_553 [] [B: P: B1: v3: v4: P1: P2:] : :) v7: v8: : :)
+    ; (fact (icst cst_515 [] [B: B1: P: v3: v4: P1: P2:] : :) v7: v8: : :)
+    (fact (imdl mdl_178 [[] (ti v7: v8:)] [B1: P2: v9: v10:] : :) v7: v8: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; ---- Don't move bigger block on smaller one ----
+
+; If pole P1 has block B1, pole P2 has block B2, B1 is bigger than B2 and P3 is empty, then it's not possible to move B1 to P2 (correct!)
+; mdl_496:(mdl [] []
+;    (fact (icst cst_495 [] [B1: v1: B2: v3: P1: P2: P3:] : :) v7: v8: : :)
+;    (|fact (imdl mdl_174 [B1: (ti v9: v10:)] [P2: P1: v11: v12:] : :) v9: v10: : :)
+; []
+;    v9:(add v7 200ms)
+;    v10:(add v8 200ms)
+; []
+;    v7:(sub v9 200ms)
+;    v8:(sub v10 200ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; If pole P1 has block B1, pole P2 has block B2, B1 is bigger than B2 and P3 is empty, then
+; ; it's not possible that, after B1 has been moved to pole P2, P1 will be empty and P2 will have blocks B2 and B1 (correct)
+; mdl_511:(mdl [] []
+;    (fact (icst cst_495 [] [B1: v1: B2: v3: P1: P2: P3:] : :) v7: v8: : :)
+;    (|fact (imdl mdl_253 [B2: (ti v9: v10:)] [B1: P2: P1: v11: v12:] : :) v9: v10: : :)
+; []
+;    v9:(add v7 200ms)
+;    v10:(add v8 200ms)
+; []
+;    v7:(sub v9 200ms)
+;    v8:(sub v10 200ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; If pole P1 has block B1, pole P2 has block B2, B1 is bigger than B2 and pole P3 is empty, then
+; ; it's not possible that moving B1 to another pole P2 will make P2 have two blocks B2 and B1 (correct)
+; mdl_526:(mdl [] []
+;    (fact (icst cst_495 [] [B1: v1: B2: v3: P1: P2: P3:] : :) v7: v8: : :)
+;    (|fact (imdl mdl_257 [B2: (ti v9: v10:)] [B1: P2: v11: v12:] : :) v9: v10: : :)
+; []
+;    v9:(add v7 200ms)
+;    v10:(add v8 200ms)
+; []
+;    v7:(sub v9 200ms)
+;    v8:(sub v10 200ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; If pole P1 has two blocks B and B1 (B > B1), it's not possible that moving B to another pole P will make P have two blocks B1 and B (technically correct)
+; mdl_528:(mdl [] []
+;    (fact (icst S_PoleHasTwoBlocks [] [P1: B: B1: v3: v4:] : :) v5: v6: : :)
+;    (|fact (imdl mdl_257 [B1: (ti v6: v7:)] [B: P: v9: v10:] : :) v6: v7: : :)
+; []
+;    v6:(add v5 100ms)
+;    v7:(add v6 100ms)
+; []
+;    v5:(sub v6 100ms)
+;    v6:(sub v7 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; If pole P has two blocks B and B1 (B > B1) and other poles P1 and P2 are empty,
+; ; it's not possible that moving B1 to another pole P1 will make P1 have two blocks B1 and B (B1 > B) (correct)
+; mdl_531:(mdl [] []
+;    (fact (icst cst_515 [] [B: B1: P: v3: v4: P1: P2:] : :) v7: v8: : :)
+;    (|fact (imdl mdl_257 [B1: (ti v8: v9:)] [B: P1: v10: v11:] : :) v8: v9: : :)
+; []
+;    v8:(add v7 100ms)
+;    v9:(add v8 100ms)
+; []
+;    v7:(sub v8 100ms)
+;    v8:(sub v9 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; After block B has been moved to pole P and P has block B, another pole P1 will be empty
+; mdl_610:(mdl [B: (ti v1: v2:)] []
+;    (fact (imdl mdl_178 [[] (ti v1: v2:)] [B: P: v4: v5:] : :) v6: v7: : :)
+;    (fact (mk.val P1: has_blocks [] :) v4: v5: : :)
+; []
+;    v4:(add v1 100ms)
+;    v5:(add v2 100ms)
+; []
+;    v1:(sub v4 100ms)
+;    v2:(sub v5 100ms)
+;    v6:(sub v4 80ms)
+;    v7:(sub v5 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; If pole P1 has one block B, moving B to pole P will make P have block B and P1 will be empty
+; mdl_611:(mdl [] []
+;    (fact (icst S_PoleHasOneBlock [] [P1: B: v2:] : :) v3: v4: : :)
+;    (fact (imdl mdl_610 [B: (ti v3: v4:)] [P: v6: v7: P1:] : :) v3: v4: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Drive ====
+m_drive:(mdl [] []
+    ; The goal target timings are the same as the drive timings.
+    (fact (mk.val right_pole has_blocks [medium_block small_block] :) T0: T1: : :)
+    ; (fact (icst S_PoleHasTwoBlocks [] [right_pole medium_block small_block 2 1] : :) T0: T1: : :)
+    ; (fact (icst S_Below [] [medium_block S1: right_pole small_block S2:] : :) T0: T1: : :)
+    (fact run T0: T1: ::)
+|[]
+|[]
+[stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+!def DRIVE_START 300ms
+
+pgm_inject_drive:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt DRIVE_START))
+[]
+   ; The end of the time interval will be used in m_drive as the end of the goal interval.
+   (inj [f_run:(fact run After (+ Before 700ms) 1 1) []])
+   (inj [G:(goal f_run self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before injecting the drive.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected drive" []])
+1) |[]
+(ipgm pgm_inject_drive [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+
+; ==== Eject programs ====
+pgm_eject_cmd_move_block:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd move_block [B: P:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd move_block [B P] 1)
+1) |[]
+(ipgm pgm_eject_cmd_move_block [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+
+
+; ==== Duplicated or wrong CSTs and models ====
+; cst_505:(cst [] []
+;    (fact (icst S_BlockIsBigger [] [v0: v1: v2: v3:] : :) v4: v5: : :)
+;    (fact (icst S_PoleHasOneBlock [] [v6: v0: v1:] : :) v4: v5: : :)
+;    (fact (icst S_PoleHasOneBlock [] [v7: v2: v3:] : :) v4: v5: : :)
+;    (fact (icst S_PoleIsEmpty [] [v8:] : :) v4: v5: : :)
+; |[]
+; |[]
+; [stdin] 1 ) []
+;
+; cst_510:(cst [] []
+;    (fact (icst S_BlockIsBigger [] [v0: v1: v2: v3:] : :) v4: v5: : :)
+;    (fact (icst S_PoleHasOneBlock [] [v6: v0: v1:] : :) v4: v5: : :)
+;    (fact (icst S_PoleHasOneBlock [] [v7: v2: v3:] : :) v4: v5: : :)
+;    (fact (icst S_PoleIsEmpty [] [v8:] : :) v4: v5: : :)
+; |[]
+; |[]
+; [stdin] 1 ) []
+
+; cst_520:(cst [] []
+;    (fact (icst S_BlockIsBigger [] [v0: v1: v2: v3:] : :) v4: v5: : :)
+;    (fact (icst S_PoleHasOneBlock [] [v6: v0: v1:] : :) v4: v5: : :)
+;    (fact (icst S_PoleHasOneBlock [] [v7: v2: v3:] : :) v4: v5: : :)
+;    (fact (icst S_PoleIsEmpty [] [v8:] : :) v4: v5: : :)
+; |[]
+; |[]
+; [stdin] 1 ) []
+
+; cst_525:(cst [] []
+;    (fact (icst S_BlockIsBigger [] [v0: v1: v2: v3:] : :) v4: v5: : :)
+;    (fact (icst S_PoleHasOneBlock [] [v6: v0: v1:] : :) v4: v5: : :)
+;    (fact (icst S_PoleHasOneBlock [] [v7: v2: v3:] : :) v4: v5: : :)
+;    (fact (icst S_PoleIsEmpty [] [v8:] : :) v4: v5: : :)
+; |[]
+; |[]
+; [stdin] 1 ) []
+
+; cst_530:(cst [] []
+;    (|fact (mk.val v0: essence pole :) v1: v2: : :)
+;    (|fact (mk.val v3: essence pole :) v1: v2: : :)
+;    (fact (icst S_PoleHasTwoBlocks [] [v4: v0: v3: v5: v6:] : :) v1: v2: : :)
+;    (fact (icst S_PoleIsEmpty [] [v7:] : :) v1: v2: : :)
+;    (fact (icst S_PoleIsEmpty [] [v8:] : :) v1: v2: : :)
+; |[]
+; |[]
+; [stdin] 1 ) []
+
+; cst_535:(cst [] []
+;    (fact (icst S_BlockIsBigger [] [v0: v1: v2: v3:] : :) v4: v5: : :)
+;    (fact (icst S_PoleHasOneBlock [] [v6: v0: v1:] : :) v4: v5: : :)
+;    (fact (icst S_PoleHasOneBlock [] [v7: v2: v3:] : :) v4: v5: : :)
+;    (fact (icst S_PoleIsEmpty [] [v8:] : :) v4: v5: : :)
+; |[]
+; |[]
+; [stdin] 1 ) []
+
+
+; If pole P has two blocks B and B1, it's not possible to move B to another pole P1
+; mdl_541:(mdl [] []
+;    (fact (icst S_PoleHasTwoBlocks [] [P: B: B1: v3: v4:] : :) v5: v6: : :)
+;    (|fact (imdl mdl_178 [[] (ti v7: v8:)] [B: P1: v10: v11:] : :) v7: v8: : :)
+; []
+;    v7:(add v5 200ms)
+;    v8:(add v6 200ms)
+; []
+;    v5:(sub v7 200ms)
+;    v6:(sub v8 200ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has two blocks B and B1 and there are two empty poles P1 and P2, it's not possible to move B to pole P1
+; mdl_544:(mdl [] []
+;    (fact (icst cst_543 [] [B: P: B1: v3: v4: P1: P2:] : :) v7: v8: : :)
+;    (|fact (imdl mdl_178 [[] (ti v9: v10:)] [B: P1: v11: v12:] : :) v9: v10: : :)
+; []
+;    v9:(add v7 200ms)
+;    v10:(add v8 200ms)
+; []
+;    v7:(sub v9 200ms)
+;    v8:(sub v10 200ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has one block B, it's not possible to move B to pole P1 (wrong)
+; mdl_546:(mdl [] []
+;    (fact (icst S_PoleHasOneBlock [] [P: B: v2:] : :) v3: v4: : :)
+;    (|fact (imdl mdl_178 [[] (ti v4: v5:)] [B: P1: v7: v8:] : :) v4: v5: : :)
+; []
+;    v4:(add v3 100ms)
+;    v5:(add v4 100ms)
+; []
+;    v3:(sub v4 100ms)
+;    v4:(sub v5 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has one block B and B is bigger than B1 and pole P1 is empty, it's not possible to move B to pole P1 (wrong)
+; mdl_549:(mdl [] []
+;    (fact (icst cst_548 [] [B: v1: B1: v3: P: P1:] : :) v6: v7: : :)
+;    (|fact (imdl mdl_178 [[] (ti v7: v8:)] [B: P1: v9: v10:] : :) v7: v8: : :)
+; []
+;    v7:(add v6 100ms)
+;    v8:(add v7 100ms)
+; []
+;    v6:(sub v7 100ms)
+;    v7:(sub v8 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has two blocks B and B1, it's not possible to move B to another pole P1
+; mdl_551:(mdl [] []
+;     (fact (icst S_PoleHasTwoBlocks [] [P: B: B1: v3: v4:] : :) v5: v6: : :)
+;     (|fact (imdl mdl_178 [[] (ti v5: v6:)] [B: P1: v8: v9:] : :) v5: v6: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; If pole P has two blocks B1 and B2 (B1 > B2), moving B1 to another pole P1 will not make P be empty (useless?)
+; mdl_498:(mdl [] []
+;    (fact (icst S_PoleHasTwoBlocks [] [P: B1: B2: v3: v4:] : :) v5: v6: : :)
+;    (|fact (imdl mdl_174 [B1: (ti v6: v7:)] [P1: P: v9: v10:] : :) v6: v7: : :)
+; []
+;    v6:(add v5 100ms)
+;    v7:(add v6 100ms)
+; []
+;    v5:(sub v6 100ms)
+;    v6:(sub v7 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has two blocks B and B1 and poles P1 and P2 are empty, moving B to P1 will not make P empty (useless?)
+; mdl_501:(mdl [] []
+;    (fact (icst cst_500 [] [B: P: B1: v3: v4: P1: P2:] : :) v7: v8: : :)
+;    (|fact (imdl mdl_174 [B: (ti v8: v9:)] [P1: P: v10: v11:] : :) v8: v9: : :)
+; []
+;    v8:(add v7 100ms)
+;    v9:(add v8 100ms)
+; []
+;    v7:(sub v8 100ms)
+;    v8:(sub v9 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; mdl_506:(mdl [] []
+;    (fact (icst cst_505 [] [v0: v1: v2: v3: v4: v5: v6:] : :) v7: v8: : :)
+;    (|fact (imdl mdl_174 [v0: (ti v7: v8:)] [v5: v4: v9: v10:] : :) v7: v8: : :)
+; |[]
+; |[]
+; [stdin] 0 1 1 1 1 ) []
+
+; If pole P1 has one block B1, it's not possible that, after B1 has been moved to pole P, P1 will be empty and P will have blocks B and B1 (wrong)
+; mdl_508:(mdl [] []
+;    (fact (icst S_PoleHasOneBlock [] [P1: B1: v2:] : :) v3: v4: : :)
+;    (|fact (imdl mdl_253 [B: (ti v6: v7:)] [B1: P: P1: v9: v10:] : :) v6: v7: : :)
+; []
+;    v6:(add v3 200ms)
+;    v7:(add v4 200ms)
+; []
+;    v3:(sub v6 200ms)
+;    v4:(sub v7 200ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has two blocks B1 and B2, it's not possible that, after B1 has been moved to pole P1, P will be empty and P1 will have blocks B2 and B1 (useless?)
+; mdl_513:(mdl [] []
+;    (fact (icst S_PoleHasTwoBlocks [] [P: B1: B2: v3: v4:] : :) v5: v6: : :)
+;    (|fact (imdl mdl_253 [B2: (ti v6: v7:)] [B1: P1: P: v9: v10:] : :) v6: v7: : :)
+; []
+;    v6:(add v5 100ms)
+;    v7:(add v6 100ms)
+; []
+;    v5:(sub v6 100ms)
+;    v6:(sub v7 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; If pole P has two blocks B and B1 (B > B1) and other poles P1 and P2 are empty,
+; it's not possible that, after B has been moved to pole P1, P will be empty and P1 will have blocks B1 and B (already known?)
+; mdl_516:(mdl [] []
+;    (fact (icst cst_515 [] [B: B1: P: v3: v4: P1: P2:] : :) v7: v8: : :)
+;    (|fact (imdl mdl_253 [B1: (ti v8: v9:)] [B: P1: P: v10: v11:] : :) v8: v9: : :)
+; []
+;    v8:(add v7 100ms)
+;    v9:(add v8 100ms)
+; []
+;    v7:(sub v8 100ms)
+;    v8:(sub v9 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; mdl_521:(mdl [] []
+;    (fact (icst cst_520 [] [v0: v1: v2: v3: v4: v5: v6:] : :) v7: v8: : :)
+;    (|fact (imdl mdl_253 [v2: (ti v7: v8:)] [v0: v5: v4: v9: v10:] : :) v7: v8: : :)
+; |[]
+; |[]
+; [stdin] 0 1 1 1 1 ) []
+
+; If pole P1 has one block B, it's not possible that moving B to another pole P will make P have two blocks B1 and B (B1 > B) (wrong)
+; mdl_523:(mdl [] []
+;    (fact (icst S_PoleHasOneBlock [] [P1: B: v2:] : :) v3: v4: : :)
+;    (|fact (imdl mdl_257 [B1: (ti v6: v7:)] [B: P: v9: v10:] : :) v6: v7: : :)
+; []
+;    v6:(add v3 200ms)
+;    v7:(add v4 200ms)
+; []
+;    v3:(sub v6 200ms)
+;    v4:(sub v7 200ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; mdl_536:(mdl [] []
+;    (fact (icst cst_535 [] [v0: v1: v2: v3: v4: v5: v6:] : :) v7: v8: : :)
+;    (|fact (imdl mdl_257 [v2: (ti v7: v8:)] [v0: v5: v9: v10:] : :) v7: v8: : :)
+; |[]
+; |[]
+; [stdin] 0 1 1 1 1 ) []

--- a/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-learn-2-bigger-than.replicode
+++ b/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-learn-2-bigger-than.replicode
@@ -1,0 +1,658 @@
+; ==== Entities and ontologies ====
+big_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+medium_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+small_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+left_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+center_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+right_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+bigger_than:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val big_block bigger_than small_block 1)
+has_blocks:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val left_pole has_blocks [medium_block small_block] 1) or (mk.val left_pole has_blocks [] 1) order is bigger -> smaller
+pole:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+
+!dfn (move_block :); arg0: a block, arg1: target pole, arg2: source pole
+
+
+; ==== Facts ====
+big_block_is_bigger_than_medium:(mk.val big_block bigger_than medium_block 1) |[]
+(fact big_block_is_bigger_than_medium 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+big_block_is_bigger_than_small:(mk.val big_block bigger_than small_block 1) |[]
+(fact big_block_is_bigger_than_small 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_bigger_than_small:(mk.val medium_block bigger_than small_block 1) |[]
+(fact medium_block_is_bigger_than_small 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+left_pole_is_a_pole:(mk.val left_pole essence pole 1) |[]
+(fact left_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+center_pole_is_a_pole:(mk.val center_pole essence pole 1) |[]
+(fact center_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+right_pole_is_a_pole:(mk.val right_pole essence pole 1) |[]
+(fact right_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+big_block_is_not_a_pole:(mk.val big_block essence pole 1) |[]
+(|fact big_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_not_a_pole:(mk.val medium_block essence pole 1) |[]
+(|fact medium_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+small_block_is_not_a_pole:(mk.val small_block essence pole 1) |[]
+(|fact small_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+
+; ==== CSTs ====
+S_PoleIsEmpty:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [] :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasOneBlock:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B:] :) T0: T1: : :)
+    (|fact (mk.val B: essence pole :) T0: T1: : :)
+    ; (fact (mk.val B: size S: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasTwoBlocks:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B1: B2:] :) T0: T1: : :)
+    (fact (mk.val B1: bigger_than B2: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasThreeBlocks:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B1: B2: B3:] :) T0: T1: : :)
+    (fact (mk.val B1: bigger_than B2: :) T0: T1: : :)
+    (fact (mk.val B2: bigger_than B3: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Drive ====
+m_drive:(mdl [] []
+    ; The goal target timings are the same as the drive timings.
+    (fact (mk.val right_pole has_blocks [big_block medium_block small_block] :) T0: T1: : :)
+    (fact run T0: T1: ::)
+|[]
+|[]
+[stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+!def DRIVE_START 2400ms
+
+pgm_inject_drive:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt DRIVE_START))
+[]
+   ; The end of the time interval will be used in m_drive as the end of the goal interval.
+   (inj [f_run:(fact run After (+ Before 700ms) 1 1) []])
+   (inj [G:(goal f_run self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before injecting the drive.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected drive" []])
+1) |[]
+(ipgm pgm_inject_drive [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+; ==== Babble programs ====
+; Initial state is left_pole:[small_block], center_pole:[big_block medium_block], right_pole:empty
+
+pgm_babbleA_1:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 100ms))
+[]
+    ; Move the medium block to the right pole
+    (inj [Command:(cmd move_block [small_block right_pole left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_1 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_2:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 200ms))
+[]
+    ; Move the big block to the center pole
+    (inj [Command:(cmd move_block [medium_block left_pole center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_2 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_3:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 300ms))
+[]
+    ; Move the small block on the medium one (right pole)
+    (inj [Command:(cmd move_block [small_block left_pole right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_3 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_4:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 400ms))
+[]
+    ; Move the small block back to the center pole
+    (inj [Command:(cmd move_block [big_block right_pole center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [big_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_4 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_5:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 500ms))
+[]
+    ; Move the small block back to the center pole
+    (inj [Command:(cmd move_block [small_block center_pole left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_5 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_6:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 600ms))
+[]
+    ; Move the medium block to the left pole
+    (inj [Command:(cmd move_block [medium_block right_pole left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_6 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_7:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 700ms))
+[]
+    ; Move the small block on the medium one (left pole)
+    (inj [Command:(cmd move_block [small_block right_pole center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_7 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_8:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 800ms))
+[]
+    ; Move the small block back to the center pole
+    (inj [Command:(cmd move_block [small_block left_pole right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_8 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_9fail:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 900ms))
+[]
+    ; Move the big block to the center pole (fails because there is medium on top)
+    (inj [Command:(cmd move_block [big_block center_pole right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [big_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_9fail [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_10:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1000ms))
+[]
+    ; Move the medium block to the center
+    (inj [Command:(cmd move_block [medium_block center_pole right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_10 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_11:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1100ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block right_pole left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_11 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_12:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1200ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [medium_block left_pole center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_12 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_13:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1300ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block left_pole right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_13 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_14fail:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1400ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [medium_block center_pole left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_14fail [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_15:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1500ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block center_pole left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_15 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_16:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1600ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block right_pole center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_16 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_17:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1700ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [medium_block center_pole left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_17 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_18:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1800ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block left_pole right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_18 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_19:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1900ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [medium_block right_pole center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_19 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_20:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 2000ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block right_pole left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_20 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_21:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 2100ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block left_pole right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_21 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_22:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 2200ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [medium_block center_pole right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_22 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_23:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 2300ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block right_pole left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_23 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+; pgm_babbleA_24fail:(pgm [] []
+;     ; This fact repeats periodically. We use it as a "heartbeat".
+;     (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+; []
+;     (>= After (+ this.vw.ijt 2400ms))
+; []
+;     ; Move the small block to the right pole
+;     (inj [Command:(cmd move_block [medium_block right_pole] 1) []])
+;     (inj [F_Command:(fact Command After Before 1 1) []])
+;     (inj [G:(goal F_Command self nil 1) []])
+;     (inj []
+;         ; Delay a little to allow predictions for this sampling period before processing.
+;         (fact G T0:(+ After 10ms) T0 1 1)
+;         [SYNC_ONCE T0 1 forever primary nil]
+;     )
+;     (prb [1 "print" "injected (cmd move_block [medium_block right_pole])" []])
+; 1) |[]
+; (ipgm pgm_babbleA_24fail [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+;    [SYNC_ONCE now 0 forever primary nil 1]
+;
+; pgm_babbleA_25:(pgm [] []
+;     ; This fact repeats periodically. We use it as a "heartbeat".
+;     (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+; []
+;     (>= After (+ this.vw.ijt 2500ms))
+; []
+;     ; Move the small block to the right pole
+;     (inj [Command:(cmd move_block [small_block right_pole] 1) []])
+;     (inj [F_Command:(fact Command After Before 1 1) []])
+;     (inj [G:(goal F_Command self nil 1) []])
+;     (inj []
+;         ; Delay a little to allow predictions for this sampling period before processing.
+;         (fact G T0:(+ After 10ms) T0 1 1)
+;         [SYNC_ONCE T0 1 forever primary nil]
+;     )
+;     (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+; 1) |[]
+; (ipgm pgm_babbleA_25 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+;    [SYNC_ONCE now 0 forever primary nil 1]
+; ;
+; pgm_babbleA_26:(pgm [] []
+;     ; This fact repeats periodically. We use it as a "heartbeat".
+;     (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+; []
+;     (>= After (+ this.vw.ijt 2600ms))
+; []
+;     ; Move the small block to the right pole
+;     (inj [Command:(cmd move_block [medium_block left_pole] 1) []])
+;     (inj [F_Command:(fact Command After Before 1 1) []])
+;     (inj [G:(goal F_Command self nil 1) []])
+;     (inj []
+;         ; Delay a little to allow predictions for this sampling period before processing.
+;         (fact G T0:(+ After 10ms) T0 1 1)
+;         [SYNC_ONCE T0 1 forever primary nil]
+;     )
+;     (prb [1 "print" "injected (cmd move_block [medium_block left_pole])" []])
+; 1) |[]
+; (ipgm pgm_babbleA_26 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+;    [SYNC_ONCE now 0 forever primary nil 1]
+;
+; pgm_babbleA_27:(pgm [] []
+;     ; This fact repeats periodically. We use it as a "heartbeat".
+;     (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+; []
+;     (>= After (+ this.vw.ijt 2700ms))
+; []
+;     ; Move the small block to the right pole
+;     (inj [Command:(cmd move_block [small_block left_pole] 1) []])
+;     (inj [F_Command:(fact Command After Before 1 1) []])
+;     (inj [G:(goal F_Command self nil 1) []])
+;     (inj []
+;         ; Delay a little to allow predictions for this sampling period before processing.
+;         (fact G T0:(+ After 10ms) T0 1 1)
+;         [SYNC_ONCE T0 1 forever primary nil]
+;     )
+;     (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+; 1) |[]
+; (ipgm pgm_babbleA_27 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+;    [SYNC_ONCE now 0 forever primary nil 1]
+
+
+; ==== Eject programs ====
+pgm_eject_cmd_move_block:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd move_block [B: To: From:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd move_block [B To From] 1)
+1) |[]
+(ipgm pgm_eject_cmd_move_block [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]

--- a/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-learn-bigger-than.replicode
+++ b/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-learn-bigger-than.replicode
@@ -1,0 +1,682 @@
+; ==== Entities and ontologies ====
+big_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+medium_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+small_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+left_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+center_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+right_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+bigger_than:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val big_block bigger_than small_block 1)
+has_blocks:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val left_pole has_blocks [medium_block small_block] 1) or (mk.val left_pole has_blocks [] 1) order is bigger -> smaller
+pole:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+
+!dfn (move_block :); arg0: a block, arg1: target position (pole)
+
+
+; ==== Facts ====
+big_block_is_bigger_than_medium:(mk.val big_block bigger_than medium_block 1) |[]
+(fact big_block_is_bigger_than_medium 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+big_block_is_bigger_than_small:(mk.val big_block bigger_than small_block 1) |[]
+(fact big_block_is_bigger_than_small 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_bigger_than_small:(mk.val medium_block bigger_than small_block 1) |[]
+(fact medium_block_is_bigger_than_small 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+left_pole_is_a_pole:(mk.val left_pole essence pole 1) |[]
+(fact left_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+center_pole_is_a_pole:(mk.val center_pole essence pole 1) |[]
+(fact center_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+right_pole_is_a_pole:(mk.val right_pole essence pole 1) |[]
+(fact right_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+big_block_is_not_a_pole:(mk.val big_block essence pole 1) |[]
+(|fact big_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_not_a_pole:(mk.val medium_block essence pole 1) |[]
+(|fact medium_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+small_block_is_not_a_pole:(mk.val small_block essence pole 1) |[]
+(|fact small_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+
+; ==== CSTs ====
+S_PoleIsEmpty:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [] :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasOneBlock:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B:] :) T0: T1: : :)
+    (|fact (mk.val B: essence pole :) T0: T1: : :)
+    ; (fact (mk.val B: size S: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasTwoBlocks:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B1: B2:] :) T0: T1: : :)
+    (fact (mk.val B1: bigger_than B2: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasThreeBlocks:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B1: B2: B3:] :) T0: T1: : :)
+    (fact (mk.val B1: bigger_than B2: :) T0: T1: : :)
+    (fact (mk.val B2: bigger_than B3: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Drive ====
+m_drive:(mdl [] []
+    ; The goal target timings are the same as the drive timings.
+    (fact (mk.val right_pole has_blocks [big_block medium_block small_block] :) T0: T1: : :)
+    (fact run T0: T1: ::)
+|[]
+|[]
+[stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+anti_position_drive:(ent 1) [[SYNC_ONCE now 0 forever root nil]]
+; Goal will be to not have two blocks in the right pole
+m_anti_position_drive:(mdl [P: B1: B2:] []
+   (|fact (mk.val P: has_blocks [B1: B2:] 1) T0: T1: 1 1)
+   (fact anti_position_drive T0: T1: ::)
+|[]
+|[]
+[stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+!def DRIVE_START 2800ms
+
+pgm_inject_drive:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt DRIVE_START))
+[]
+   ; The end of the time interval will be used in m_drive as the end of the goal interval.
+   (inj [f_run:(fact run After (+ Before 700ms) 1 1) []])
+   (inj [G:(goal f_run self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before injecting the drive.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected drive" []])
+1) |[]
+(ipgm pgm_inject_drive [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+; ==== Babble programs ====
+; Initial state is left_pole:[small_block], center_pole:[big_block medium_block], right_pole:empty
+
+pgm_babbleA_1:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 100ms))
+[]
+    ; Move the medium block to the right pole
+    (inj [Command:(cmd move_block [small_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_1 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_2:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 200ms))
+[]
+    ; Move the big block to the center pole
+    (inj [Command:(cmd move_block [medium_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_2 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_3:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 300ms))
+[]
+    ; Move the small block on the medium one (right pole)
+    (inj [Command:(cmd move_block [small_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_3 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_4:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 400ms))
+[]
+    ; Move the small block back to the center pole
+    (inj [Command:(cmd move_block [big_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [big_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_4 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_5:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 500ms))
+[]
+    ; Move the small block back to the center pole
+    (inj [Command:(cmd move_block [small_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_5 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_6:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 600ms))
+[]
+    ; Move the medium block to the left pole
+    (inj [Command:(cmd move_block [medium_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_6 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_7:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 700ms))
+[]
+    ; Move the small block on the medium one (left pole)
+    (inj [Command:(cmd move_block [small_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_7 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_8:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 800ms))
+[]
+    ; Move the small block back to the center pole
+    (inj [Command:(cmd move_block [small_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_8 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_9fail:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 900ms))
+[]
+    ; Move the big block to the center pole (fails because there is medium on top)
+    (inj [Command:(cmd move_block [big_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [big_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_9fail [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_10:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1000ms))
+[]
+    ; (inj [Drive:(imdl m_anti_position_drive [right_pole big_block medium_block] [] false 1) []])
+    ; (inj [F_Drive:(fact Drive (+ After 100ms) (+ Before 100ms) 1 1) []])
+    ; (inj [G_F_Drive:(goal F_Drive self nil 1) []])
+    ; (inj []
+    ;     (fact G_F_Drive T0:(+ After 10ms) T0 1 1)
+    ;     [SYNC_ONCE T0 1 forever primary nil]
+    ; )
+    ; Move the medium block to the center
+    (inj [Command:(cmd move_block [medium_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_10 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_11:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1100ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_11 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_12:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1200ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [medium_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_12 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_13:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1300ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_13 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_14fail:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1400ms))
+[]
+    (inj [Drive:(imdl m_anti_position_drive [left_pole medium_block small_block] [] false 1) []])
+    (inj [F_Drive:(fact Drive (+ After 100ms) (+ Before 300ms) 1 1) []])
+    (inj [G_F_Drive:(goal F_Drive self nil 1) []])
+    (inj []
+        (fact G_F_Drive T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [medium_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_14fail [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_15:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1500ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_15 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_16:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1600ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_16 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_17:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1700ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [medium_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_17 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_18:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1800ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_18 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_19:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1900ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [medium_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_19 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_20:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 2000ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_20 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_21:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 2100ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_21 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_22:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 2200ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [medium_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_22 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_23:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 2300ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_23 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_24fail:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 2400ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [medium_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_24fail [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_25:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 2500ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_25 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+;
+pgm_babbleA_26:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 2600ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [medium_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_26 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+;
+pgm_babbleA_27:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 2700ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_27 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+
+; ==== Eject programs ====
+pgm_eject_cmd_move_block:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd move_block [B: P:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd move_block [B P] 1)
+1) |[]
+(ipgm pgm_eject_cmd_move_block [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]

--- a/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-learn.2.replicode
+++ b/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-learn.2.replicode
@@ -1,0 +1,560 @@
+; ==== Entities and ontologies ====
+; big_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+medium_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+small_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+left_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+center_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+right_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+size:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val big_block size 3 1)
+has_blocks:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val left_pole has_blocks [medium_block small_block] 1) or (mk.val left_pole has_blocks [] 1) order is bigger -> smaller
+pole:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+; "position" will be used as (mk.val big_block position left_pole 1)
+
+!dfn (move_block :); arg0: a block, arg1: target position (pole)
+
+
+; ==== Facts ====
+; big_block_is_big:(mk.val big_block size 3 1) |[]
+; (fact big_block_is_big 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_medium:(mk.val medium_block size 2 1) |[]
+(fact medium_block_is_medium 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+small_block_is_small:(mk.val small_block size 1 1) |[]
+(fact small_block_is_small 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+left_pole_is_a_pole:(mk.val left_pole essence pole 1) |[]
+(fact left_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+center_pole_is_a_pole:(mk.val center_pole essence pole 1) |[]
+(fact center_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+right_pole_is_a_pole:(mk.val right_pole essence pole 1) |[]
+(fact right_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+; big_block_is_not_a_pole:(mk.val big_block essence pole 1) |[]
+; (|fact big_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_not_a_pole:(mk.val medium_block essence pole 1) |[]
+(|fact medium_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+small_block_is_not_a_pole:(mk.val small_block essence pole 1) |[]
+(|fact small_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+
+; ==== CSTs ====
+; S_BlockPosition:(cst [] []
+;     (fact (mk.val B: size S: :) T0: T1: : :)
+;     (fact (mk.val B: position P: :) T0: T1: : :)
+;     (fact (mk.val P: essence pole :) T0: T1: : :)
+; |[]
+; |[]
+; [stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; B1 is bigger than B2
+S_BlockIsBigger:(cst [] []
+    (fact (mk.val B1: size S1: :) T0: T1: : :)
+    (fact (mk.val B2: size S2: :) T0: T1: : :)
+[]
+    (> S1 S2)
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; B1 is below B2
+; S_Below:(cst [] []
+;     (fact (icst S_BlockIsBigger [] [B1: S1: B2: S2:] : :) T0: T1: : :)
+;     (fact (icst S_BlockPosition [] [B1: S1: P:] : :) T0: T1: : :)
+;     (fact (icst S_BlockPosition [] [B2: S2: P:] : :) T0: T1: : :)
+; |[]
+; |[]
+; [stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleIsEmpty:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [] :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasOneBlock:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B:] :) T0: T1: : :)
+    (|fact (mk.val B: essence pole :) T0: T1: : :)
+    (fact (mk.val B: size S: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasTwoBlocks:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B1: B2:] :) T0: T1: : :)
+    (fact (icst S_BlockIsBigger [] [B1: S1: B2: S2:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Models ====
+; After a move a pole will have no blocks
+; M_MoveEmptiesPole:(mdl [v0: (ti v1: v2:)] []
+;   (fact (cmd move_block [v0: v3:]) v4: v5:)
+;   (fact (mk.val v6: has_blocks []) v7: v8:)
+; []
+;   v7:(+ v1 100ms)
+;   v8:(+ v2 100ms)
+; []
+;   v1:(- v7 100ms)
+;   v2:(- v8 100ms)
+;   v4:(- v7 80ms)
+;   v5:(- v8 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; After move the block position will be updated
+; M_MoveChangesPosition:(mdl [v0: (ti v1: v2:)] []
+;     (fact (cmd move_block [v3: v4:] :) v5: v6: : :)
+;     (fact (mk.val v3: position v4: :) v7: v8: : :)
+; []
+;     v7:(+ v1 100ms)
+;     v8:(+ v2 100ms)
+; []
+;     v1:(- v7 100ms)
+;     v2:(- v8 100ms)
+;     v5:(- v7 80ms)
+;     v6:(- v8 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; M_PoleHasOneBlockAfterMove:(mdl [v0: (ti v1: v2:)] []
+;     ; (fact (imdl M_MoveChangesPosition [v3: (ti v1: v2:)] [v4: v5: v6: v7:] : :) v8: v9: : :)
+;     (fact (cmd move_block [v3: v4:] :) v5: v6: : :)
+;     (fact (mk.val v4: has_blocks [v3:] :) v7: v8: : :)
+; []
+;     v7:(+ v1 100ms)
+;     v8:(+ v2 100ms)
+; []
+;     v1:(- v7 100ms)
+;     v2:(- v8 100ms)
+;     v5:(- v7 80ms)
+;     v6:(- v8 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; After move the destination pole will have two blocks
+; M_PoleHasTwoBlocksAfterMove:(mdl [v0: (ti v1: v2:)] []
+;     ; (fact (imdl M_MoveChangesPosition [v3: (ti v1: v2:)] [v4: v5: v6: v7:] : :) v8: v9: : :)
+;     (fact (cmd move_block [v3: v4:] :) v5: v6: : :)
+;     ; (fact (mk.val v4: has_blocks [v0: v3:] :) v7: v8: : :)
+;     (fact (icst S_PoleHasTwoBlocks [] [v4: v0: v3:] : :) v7: v8: : :)
+; []
+;     v7:(+ v1 100ms)
+;     v8:(+ v2 100ms)
+; []
+;     v1:(- v7 100ms)
+;     v2:(- v8 100ms)
+;     v5:(- v7 80ms)
+;     v6:(- v8 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; M_CannotPutBiggerBlockOnTop:(mdl [B1: (ti T0: T1:)] []
+;     (fact (icst S_BlockIsBigger [] [B1: S1: B2: S2:] : :) T0: T1: : :)
+;     (|fact (imdl M_PoleHasTwoBlocksAfterMove [B1: (ti T0: T1:)] [B2: P:] : :) T0: T1: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Drive ====
+m_drive:(mdl [] []
+    ; The goal target timings are the same as the drive timings.
+    (fact (mk.val right_pole has_blocks [medium_block small_block] :) T0: T1: : :)
+    ; (fact (icst S_PoleHasTwoBlocks [] [right_pole medium_block small_block 2 1] : :) T0: T1: : :)
+    ; (fact (icst S_Below [] [medium_block S1: right_pole small_block S2:] : :) T0: T1: : :)
+    (fact run T0: T1: ::)
+|[]
+|[]
+[stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+!def DRIVE_START 1700ms
+
+pgm_inject_drive:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt DRIVE_START))
+[]
+   ; The end of the time interval will be used in m_drive as the end of the goal interval.
+   (inj [f_run:(fact run After (+ Before 700ms) 1 1) []])
+   (inj [G:(goal f_run self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before injecting the drive.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected drive" []])
+1) |[]
+(ipgm pgm_inject_drive [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+; ==== Babble programs ====
+; Initial state is left_pole:[big_block], center_pole:[medium_block], right_pole:empty
+
+pgm_babbleA_1:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 100ms))
+[]
+    ; Move the medium block to the right pole
+    (inj [Command:(cmd move_block [medium_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_1 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_2:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 200ms))
+[]
+    ; Move the big block to the center pole
+    (inj [Command:(cmd move_block [small_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_2 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_3:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 300ms))
+[]
+    ; Move the small block on the medium one (right pole)
+    (inj [Command:(cmd move_block [small_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_3 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_4:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 400ms))
+[]
+    ; Move the small block back to the center pole
+    (inj [Command:(cmd move_block [small_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_4 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_6:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 500ms))
+[]
+    ; Move the medium block to the left pole
+    (inj [Command:(cmd move_block [medium_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_6 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_7:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 600ms))
+[]
+    ; Move the small block on the medium one (left pole)
+    (inj [Command:(cmd move_block [small_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_7 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_8:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 700ms))
+[]
+    ; Move the small block back to the center pole
+    (inj [Command:(cmd move_block [small_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_8 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_9:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 800ms))
+[]
+    ; Move the small block to the left pole
+    (inj [Command:(cmd move_block [small_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_9 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_10fail:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 900ms))
+[]
+    ; Moving the medium block to the right will fail because it's below the small one
+    (inj [Command:(cmd move_block [medium_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_10fail [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_11:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1000ms))
+[]
+    ; Move the small block to the center pole
+    (inj [Command:(cmd move_block [small_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_11 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_13:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1100ms))
+[]
+    (inj [Command:(cmd move_block [medium_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_13 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_14:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1200ms))
+[]
+    (inj [Command:(cmd move_block [small_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_14 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_15fail:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1300ms))
+[]
+    ; Moving will fail because the medium block is under the small one
+    (inj [Command:(cmd move_block [medium_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_15fail [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_16:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1400ms))
+[]
+    (inj [Command:(cmd move_block [small_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_16 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_17fail:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1500ms))
+[]
+    ; Moving will fail because the medium block is under the small one
+    (inj [Command:(cmd move_block [medium_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_17fail [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_18fail:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1600ms))
+[]
+    ; Moving will fail because the medium block is under the small one
+    (inj [Command:(cmd move_block [medium_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_18fail [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+; pgm_babbleA_17:(pgm [] []
+;     ; This fact repeats periodically. We use it as a "heartbeat".
+;     (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+; []
+;     (>= After (+ this.vw.ijt 1500ms))
+; []
+;     (inj [Command:(cmd move_block [medium_block center_pole] 1) []])
+;     (inj [F_Command:(fact Command After Before 1 1) []])
+;     (inj [G:(goal F_Command self nil 1) []])
+;     (inj []
+;         ; Delay a little to allow predictions for this sampling period before processing.
+;         (fact G T0:(+ After 10ms) T0 1 1)
+;         [SYNC_ONCE T0 1 forever primary nil]
+;     )
+;     (prb [1 "print" "injected (cmd move_block [medium_block center_pole])" []])
+; 1) |[]
+; (ipgm pgm_babbleA_17 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+;    [SYNC_ONCE now 0 forever primary nil 1]
+;
+; pgm_babbleA_18:(pgm [] []
+;     ; This fact repeats periodically. We use it as a "heartbeat".
+;     (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+; []
+;     (>= After (+ this.vw.ijt 1600ms))
+; []
+;     (inj [Command:(cmd move_block [small_block center_pole] 1) []])
+;     (inj [F_Command:(fact Command After Before 1 1) []])
+;     (inj [G:(goal F_Command self nil 1) []])
+;     (inj []
+;         ; Delay a little to allow predictions for this sampling period before processing.
+;         (fact G T0:(+ After 10ms) T0 1 1)
+;         [SYNC_ONCE T0 1 forever primary nil]
+;     )
+;     (prb [1 "print" "injected (cmd move_block [small_block center_pole])" []])
+; 1) |[]
+; (ipgm pgm_babbleA_18 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+;    [SYNC_ONCE now 0 forever primary nil 1]
+
+
+; ==== Eject programs ====
+pgm_eject_cmd_move_block:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd move_block [B: P:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd move_block [B P] 1)
+1) |[]
+(ipgm pgm_eject_cmd_move_block [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]

--- a/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-learn.replicode
+++ b/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-learn.replicode
@@ -1,0 +1,681 @@
+; ==== Entities and ontologies ====
+big_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+medium_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+small_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+left_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+center_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+right_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+size:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val big_block size 3 1)
+has_blocks:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val left_pole has_blocks [medium_block small_block] 1) or (mk.val left_pole has_blocks [] 1) order is bigger -> smaller
+pole:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+
+
+; ==== Facts ====
+big_block_is_big:(mk.val big_block size 3 1) |[]
+(fact big_block_is_big 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_medium:(mk.val medium_block size 2 1) |[]
+(fact medium_block_is_medium 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+small_block_is_small:(mk.val small_block size 1 1) |[]
+(fact small_block_is_small 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+left_pole_is_a_pole:(mk.val left_pole essence pole 1) |[]
+(fact left_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+center_pole_is_a_pole:(mk.val center_pole essence pole 1) |[]
+(fact center_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+right_pole_is_a_pole:(mk.val right_pole essence pole 1) |[]
+(fact right_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+big_block_is_not_a_pole:(mk.val big_block essence pole 1) |[]
+(|fact big_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_not_a_pole:(mk.val medium_block essence pole 1) |[]
+(|fact medium_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+small_block_is_not_a_pole:(mk.val small_block essence pole 1) |[]
+(|fact small_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+
+; ==== CSTs ====
+; B1 is bigger than B2
+S_BlockIsBigger:(cst [] []
+    (fact (mk.val B1: size S1: :) T0: T1: : :)
+    (fact (mk.val B2: size S2: :) T0: T1: : :)
+[]
+    (> S1 S2)
+[]
+    (> S1 S2)
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleIsEmpty:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [] :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasOneBlock:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B:] :) T0: T1: : :)
+    (|fact (mk.val B: essence pole :) T0: T1: : :)
+    (fact (mk.val B: size S: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasTwoBlocks:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B1: B2:] :) T0: T1: : :)
+    (fact (icst S_BlockIsBigger [] [B1: S1: B2: S2:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasThreeBlocks:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B1: B2: B3:] :) T0: T1: : :)
+    (fact (icst S_BlockIsBigger [] [B1: S1: B2: S2:] : :) T0: T1: : :)
+    (fact (icst S_BlockIsBigger [] [B2: S2: B3: S3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; mdl_Size:(mdl [] []
+;    (fact (mk.val B: size S: :) v4: v5: : :)
+;    (fact (mk.val B: size S: :) v7: v8: : :)
+; []
+;    v7:(add v4 100ms)
+;    v8:(add v5 100ms)
+; []
+;    v4:(sub v7 100ms)
+;    v5:(sub v8 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Drive ====
+m_drive:(mdl [] []
+    ; The goal target timings are the same as the drive timings.
+    (fact (mk.val right_pole has_blocks [big_block medium_block small_block] :) T0: T1: : :)
+    (fact run T0: T1: ::)
+|[]
+|[]
+[stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; anti_position_drive:(ent 1) [[SYNC_ONCE now 0 forever root nil]]
+; ; Goal will be to not have two blocks in the right pole
+; m_anti_position_drive:(mdl [P: B1: B2:] []
+;    (|fact (mk.val P: has_blocks [B1: B2:] 1) T0: T1: 1 1)
+;    (fact anti_position_drive T0: T1: ::)
+; |[]
+; |[]
+; [stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; m_yes_position_drive:(mdl [P: B1:] []
+;    (fact (mk.val P: has_blocks [B1:] 1) T0: T1: 1 1)
+;    (fact anti_position_drive T0: T1: ::)
+; |[]
+; |[]
+; [stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+!def DRIVE_START 2400ms
+
+pgm_inject_drive:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt DRIVE_START))
+[]
+   ; The end of the time interval will be used in m_drive as the end of the goal interval.
+   (inj [f_run:(fact run After (+ Before 700ms) 1 1) []])
+   (inj [G:(goal f_run self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before injecting the drive.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected drive" []])
+1) |[]
+(ipgm pgm_inject_drive [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+; ==== Babble programs ====
+; Initial state is left_pole:[small_block], center_pole:[big_block medium_block], right_pole:empty
+
+pgm_babbleA_1:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 100ms))
+[]
+    ; Move the medium block to the right pole
+    (inj [Command:(cmd move_block [small_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_1 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_2:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 200ms))
+[]
+    ; Move the big block to the center pole
+    (inj [Command:(cmd move_block [medium_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_2 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_3:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 300ms))
+[]
+    ; Move the small block on the medium one (right pole)
+    (inj [Command:(cmd move_block [small_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_3 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_4:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 400ms))
+[]
+    ; Move the small block back to the center pole
+    (inj [Command:(cmd move_block [big_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [big_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_4 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_5:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 500ms))
+[]
+    ; Move the small block back to the center pole
+    (inj [Command:(cmd move_block [small_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_5 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_6:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 600ms))
+[]
+    ; Move the medium block to the left pole
+    (inj [Command:(cmd move_block [medium_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_6 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_7:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 700ms))
+[]
+    ; Move the small block on the medium one (left pole)
+    (inj [Command:(cmd move_block [small_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_7 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_8:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 800ms))
+[]
+    ; Move the small block back to the center pole
+    (inj [Command:(cmd move_block [small_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_8 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_9fail:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 900ms))
+[]
+    ; Move the big block to the center pole (fails because there is medium on top)
+    (inj [Command:(cmd move_block [big_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [big_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_9fail [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_10:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1000ms))
+[]
+    ; (inj [Drive:(imdl m_anti_position_drive [right_pole big_block medium_block] [] false 1) []])
+    ; (inj [F_Drive:(fact Drive (+ After 100ms) (+ Before 100ms) 1 1) []])
+    ; (inj [G_F_Drive:(goal F_Drive self nil 1) []])
+    ; (inj []
+    ;     (fact G_F_Drive T0:(+ After 10ms) T0 1 1)
+    ;     [SYNC_ONCE T0 1 forever primary nil]
+    ; )
+    ; Move the medium block to the center
+    (inj [Command:(cmd move_block [medium_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_10 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_11:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1100ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_11 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_12:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1200ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [medium_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_12 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_13:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1300ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_13 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_14fail:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1400ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [medium_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_14fail [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_15:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1500ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_15 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_16:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1600ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_16 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_17:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1700ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [medium_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_17 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_18:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1800ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_18 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_19:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1900ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [medium_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_19 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_20:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 2000ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_20 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_21:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 2100ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_21 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_22:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 2200ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [medium_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_22 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_23:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 2300ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_23 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+; pgm_babbleA_24:(pgm [] []
+;     ; This fact repeats periodically. We use it as a "heartbeat".
+;     (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+; []
+;     (>= After (+ this.vw.ijt 2400ms))
+; []
+;     ; Move the small block to the right pole
+;     (inj [Command:(cmd move_block [small_block left_pole] 1) []])
+;     (inj [F_Command:(fact Command After Before 1 1) []])
+;     (inj [G:(goal F_Command self nil 1) []])
+;     (inj []
+;         ; Delay a little to allow predictions for this sampling period before processing.
+;         (fact G T0:(+ After 10ms) T0 1 1)
+;         [SYNC_ONCE T0 1 forever primary nil]
+;     )
+;     (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+; 1) |[]
+; (ipgm pgm_babbleA_24 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+;    [SYNC_ONCE now 0 forever primary nil 1]
+;
+; pgm_babbleA_25:(pgm [] []
+;     ; This fact repeats periodically. We use it as a "heartbeat".
+;     (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+; []
+;     (>= After (+ this.vw.ijt 2500ms))
+; []
+;     ; Move the small block to the right pole
+;     (inj [Command:(cmd move_block [medium_block right_pole] 1) []])
+;     (inj [F_Command:(fact Command After Before 1 1) []])
+;     (inj [G:(goal F_Command self nil 1) []])
+;     (inj []
+;         ; Delay a little to allow predictions for this sampling period before processing.
+;         (fact G T0:(+ After 10ms) T0 1 1)
+;         [SYNC_ONCE T0 1 forever primary nil]
+;     )
+;     (prb [1 "print" "injected (cmd move_block [medium_block right_pole])" []])
+; 1) |[]
+; (ipgm pgm_babbleA_25 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+;    [SYNC_ONCE now 0 forever primary nil 1]
+;
+; pgm_babbleA_26:(pgm [] []
+;     ; This fact repeats periodically. We use it as a "heartbeat".
+;     (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+; []
+;     (>= After (+ this.vw.ijt 2600ms))
+; []
+;     ; Move the small block to the right pole
+;     (inj [Command:(cmd move_block [small_block right_pole] 1) []])
+;     (inj [F_Command:(fact Command After Before 1 1) []])
+;     (inj [G:(goal F_Command self nil 1) []])
+;     (inj []
+;         ; Delay a little to allow predictions for this sampling period before processing.
+;         (fact G T0:(+ After 10ms) T0 1 1)
+;         [SYNC_ONCE T0 1 forever primary nil]
+;     )
+;     (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+; 1) |[]
+; (ipgm pgm_babbleA_26 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+;    [SYNC_ONCE now 0 forever primary nil 1]
+
+
+; ==== Eject programs ====
+pgm_eject_cmd_move_block:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd move_block [B: P:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd move_block [B P] 1)
+1) |[]
+(ipgm pgm_eject_cmd_move_block [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]

--- a/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-learn.working.replicode
+++ b/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi-learn.working.replicode
@@ -1,0 +1,339 @@
+; ==== Entities and ontologies ====
+; big_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+medium_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+small_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+left_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+center_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+right_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+size:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val big_block size 3 1)
+has_blocks:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val left_pole has_blocks [medium_block small_block] 1) or (mk.val left_pole has_blocks [] 1) order is bigger -> smaller
+pole:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+; "position" will be used as (mk.val big_block position left_pole 1)
+
+!dfn (move_block :); arg0: a block, arg1: target position (pole)
+
+
+; ==== Facts ====
+; big_block_is_big:(mk.val big_block size 3 1) |[]
+; (fact big_block_is_big 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_medium:(mk.val medium_block size 2 1) |[]
+(fact medium_block_is_medium 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+small_block_is_small:(mk.val small_block size 1 1) |[]
+(fact small_block_is_small 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+left_pole_is_a_pole:(mk.val left_pole essence pole 1) |[]
+(fact left_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+center_pole_is_a_pole:(mk.val center_pole essence pole 1) |[]
+(fact center_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+right_pole_is_a_pole:(mk.val right_pole essence pole 1) |[]
+(fact right_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+; big_block_is_not_a_pole:(mk.val big_block essence pole 1) |[]
+; (|fact big_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_not_a_pole:(mk.val medium_block essence pole 1) |[]
+(|fact medium_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+small_block_is_not_a_pole:(mk.val small_block essence pole 1) |[]
+(|fact small_block_is_not_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+
+; ==== CSTs ====
+; B1 is bigger than B2
+S_BlockIsBigger:(cst [] []
+    (fact (mk.val B1: size S1: :) T0: T1: : :)
+    (fact (mk.val B2: size S2: :) T0: T1: : :)
+[]
+    (> S1 S2)
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleIsEmpty:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [] :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasOneBlock:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B:] :) T0: T1: : :)
+    (|fact (mk.val B: essence pole :) T0: T1: : :)
+    (fact (mk.val B: size S: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasTwoBlocks:(cst [] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B1: B2:] :) T0: T1: : :)
+    (fact (icst S_BlockIsBigger [] [B1: S1: B2: S2:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Drive ====
+m_drive:(mdl [] []
+    ; The goal target timings are the same as the drive timings.
+    (fact (mk.val right_pole has_blocks [medium_block small_block] :) T0: T1: : :)
+    (fact run T0: T1: ::)
+|[]
+|[]
+[stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+!def DRIVE_START 1200ms
+
+pgm_inject_drive:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt DRIVE_START))
+[]
+   ; The end of the time interval will be used in m_drive as the end of the goal interval.
+   (inj [f_run:(fact run After (+ Before 700ms) 1 1) []])
+   (inj [G:(goal f_run self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before injecting the drive.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected drive" []])
+1) |[]
+(ipgm pgm_inject_drive [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+; ==== Babble programs ====
+; Initial state is left_pole:[small_block], center_pole:[medium_block], right_pole:empty
+
+pgm_babbleA_1:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 100ms))
+[]
+    ; Move the medium block to the right pole
+    (inj [Command:(cmd move_block [medium_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_1 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_2:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 200ms))
+[]
+    ; Move the big block to the center pole
+    (inj [Command:(cmd move_block [small_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_2 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_3:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 300ms))
+[]
+    ; Move the small block on the medium one (right pole)
+    (inj [Command:(cmd move_block [small_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_3 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_4:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 400ms))
+[]
+    ; Move the small block back to the center pole
+    (inj [Command:(cmd move_block [small_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_4 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_6:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 500ms))
+[]
+    ; Move the medium block to the left pole
+    (inj [Command:(cmd move_block [medium_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_6 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_7:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 600ms))
+[]
+    ; Move the small block on the medium one (left pole)
+    (inj [Command:(cmd move_block [small_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_7 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_8:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 700ms))
+[]
+    ; Move the small block back to the center pole
+    (inj [Command:(cmd move_block [small_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_8 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_fail2:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 800ms))
+[]
+    ; Moving the medium block on the small one will fail
+    (inj [Command:(cmd move_block [medium_block center_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [medium_block center_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_fail2 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_9:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 900ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_9 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_10:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1000ms))
+[]
+    ; Move the small block on the medium one (left)
+    (inj [Command:(cmd move_block [small_block left_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block left_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_10 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_babbleA_11:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+    (>= After (+ this.vw.ijt 1100ms))
+[]
+    ; Move the small block to the right pole
+    (inj [Command:(cmd move_block [small_block right_pole] 1) []])
+    (inj [F_Command:(fact Command After Before 1 1) []])
+    (inj [G:(goal F_Command self nil 1) []])
+    (inj []
+        ; Delay a little to allow predictions for this sampling period before processing.
+        (fact G T0:(+ After 10ms) T0 1 1)
+        [SYNC_ONCE T0 1 forever primary nil]
+    )
+    (prb [1 "print" "injected (cmd move_block [small_block right_pole])" []])
+1) |[]
+(ipgm pgm_babbleA_11 [] RUN_ONCE MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+
+; ==== Eject programs ====
+pgm_eject_cmd_move_block:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd move_block [B: P:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd move_block [B P] 1)
+1) |[]
+(ipgm pgm_eject_cmd_move_block [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]

--- a/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi.replicode
+++ b/AERA/replicode_v1.2/tower-of-hanoi/tower-of-hanoi.replicode
@@ -1,0 +1,307 @@
+; ==== Entities and ontologies ====
+big_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+medium_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+small_block:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+left_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+center_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+right_pole:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+size:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val big_block size 3 1)
+has_blocks:(ont 1) [[SYNC_ONCE now 1 forever root nil]] ; Usage: (mk.val left_pole has_blocks [medium_block small_block] 1) or (mk.val left_pole has_blocks [] 1) order is bigger -> smaller
+pole:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+; "position" will be used as (mk.val big_block position left_pole 1)
+
+
+; ==== Facts ====
+big_block_is_big:(mk.val big_block size 3 1) |[]
+(fact big_block_is_big 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+medium_block_is_medium:(mk.val medium_block size 2 1) |[]
+(fact medium_block_is_medium 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+small_block_is_small:(mk.val small_block size 1 1) |[]
+(fact small_block_is_small 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+left_pole_is_a_pole:(mk.val left_pole essence pole 1) |[]
+(fact left_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+center_pole_is_a_pole:(mk.val center_pole essence pole 1) |[]
+(fact center_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+right_pole_is_a_pole:(mk.val right_pole essence pole 1) |[]
+(fact right_pole_is_a_pole 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+
+; ==== CSTs ====
+S_PoleIsEmpty:(cst [P:] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [] :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasOneBlock:(cst [P:] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B:] :) T0: T1: : :)
+    (fact (mk.val B: size S: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasTwoBlocks:(cst [P:] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B1: B2:] :) T0: T1: : :)
+    (fact (mk.val B1: size S1: :) T0: T1: : :)
+    (fact (mk.val B2: size S2: :) T0: T1: : :)
+[]
+    (< S2 S1)
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+S_PoleHasThreeBlocks:(cst [P:] []
+    (fact (mk.val P: essence pole :) T0: T1: : :)
+    (fact (mk.val P: has_blocks [B1: B2: B3:] :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; P1 has a block and P2 is empty
+S_OneEmpty:(cst [P1: P2:] []
+    (fact (icst S_PoleHasOneBlock [P1:] [] : :) T0: T1: : :)
+    (fact (icst S_PoleIsEmpty [P2:] [] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; P1 has two blocks and P2 is empty
+S_TwoEmpty:(cst [P1: P2:] []
+    (fact (icst S_PoleHasTwoBlocks [P1:] [] : :) T0: T1: : :)
+    (fact (icst S_PoleIsEmpty [P2:] [] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; P1 and P2 have one block each, the block in P2 is smaller
+S_OneOne:(cst [P1: P2:] []
+    (fact (icst S_PoleHasOneBlock [P1:] [B1: S1:] : :) T0: T1: : :)
+    (fact (icst S_PoleHasOneBlock [P2:] [B2: S2:] : :) T0: T1: : :)
+[]
+    (< S2 S1)
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; P1 has two blocks and P2 has one
+S_TwoOne:(cst [P1: P2:] []
+    (fact (icst S_PoleHasTwoBlocks [P1:] [B1: B2: S1: S2:] : :) T0: T1: : :)
+    (fact (icst S_PoleHasOneBlock [P2:] [B3: S3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; P1 has two blocks and P2 has one, the block in P2 is smaller than the top block in P1
+S_TwoOneOrdered:(cst [P1: P2:] []
+    (fact (icst S_PoleHasTwoBlocks [P1:] [B1: B2: S1: S2:] : :) T0: T1: : :)
+    (fact (icst S_PoleHasOneBlock [P2:] [B3: S3:] : :) T0: T1: : :)
+[]
+    (< S3 S2)
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; P1 has three blocks and P2 is empty
+S_ThreeEmpty:(cst [P1: P2:] []
+    (fact (icst S_PoleHasThreeBlocks [P1:] [] : :) T0: T1: : :)
+    (fact (icst S_PoleIsEmpty [P2:] [] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Models ====
+; Move block from a pole with one block to an empty pole, after this P_to will have one block and P_from will be empty
+M_MoveFromOneToEmpty:(mdl [P_from: P_to: (ti T0: T1:)] []
+    (fact (cmd move [P_from: P_to:] :) T2: T1_cmd: : :)
+    (fact (icst S_OneEmpty [P_to: P_from:] [] : :) T1_RHS: T3: : :)
+[]
+    T1_RHS:(+ T0 100ms)
+    T3:(+ T1 100ms)
+[]
+    T2:(- T1_RHS 80ms)
+    T1_cmd:(- T3 100ms)
+    T0:(- T1_RHS 100ms)
+    T1:(- T3 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Move block from a pole with one block to a pole with one, after this P_to will have two blocks and P_from will be empty
+M_MoveFromOneToOne:(mdl [P_from: P_to: (ti T0: T1:)] []
+    (fact (cmd move [P_from: P_to:] :) T2: T1_cmd: : :)
+    (fact (icst S_TwoEmpty [P_to: P_from:] [] : :) T1_RHS: T3: : :)
+[]
+    T1_RHS:(+ T0 100ms)
+    T3:(+ T1 100ms)
+[]
+    T2:(- T1_RHS 80ms)
+    T1_cmd:(- T3 100ms)
+    T0:(- T1_RHS 100ms)
+    T1:(- T3 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Move block from a pole with one block to a pole with two, after this P_to will have three blocks and P_from will be empty
+M_MoveFromOneToTwo:(mdl [P_from: P_to: (ti T0: T1:)] []
+    (fact (cmd move [P_from: P_to:] :) T2: T1_cmd: : :)
+    (fact (icst S_ThreeEmpty [P_to: P_from:] [] : :) T1_RHS: T3: : :)
+[]
+    T1_RHS:(+ T0 100ms)
+    T3:(+ T1 100ms)
+[]
+    T2:(- T1_RHS 80ms)
+    T1_cmd:(- T3 100ms)
+    T0:(- T1_RHS 100ms)
+    T1:(- T3 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Move block from a pole with two blocks to an empty pole, after this both P_from and P_to will have one block
+M_MoveFromTwoToEmpty:(mdl [P_from: P_to: (ti T0: T1:)] []
+    (fact (cmd move [P_from: P_to:] :) T2: T1_cmd: : :)
+    (fact (icst S_OneOne [P_to: P_from:] [] : :) T1_RHS: T3: : :)
+[]
+    T1_RHS:(+ T0 100ms)
+    T3:(+ T1 100ms)
+[]
+    T2:(- T1_RHS 80ms)
+    T1_cmd:(- T3 100ms)
+    T0:(- T1_RHS 100ms)
+    T1:(- T3 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; Move block from a pole with two blocks to a pole with one, after this P_to will have two blocks and P_from will have one
+M_MoveFromTwoToOne:(mdl [P_from: P_to: (ti T0: T1:)] []
+    (fact (cmd move [P_from: P_to:] :) T2: T1_cmd: : :)
+    (fact (icst S_TwoOne [P_to: P_from:] [] : :) T1_RHS: T3: : :)
+[]
+    T1_RHS:(+ T0 100ms)
+    T3:(+ T1 100ms)
+[]
+    T2:(- T1_RHS 80ms)
+    T1_cmd:(- T3 100ms)
+    T0:(- T1_RHS 100ms)
+    T1:(- T3 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+M_MoveFromOneToOne_req:(mdl [P1: P2:] []
+    (fact (icst S_OneOne [P2: P1:] [] : :) T0: T1: : :)
+    (fact (imdl M_MoveFromOneToOne [P1: P2: (ti T0: T1:)] [T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+M_MoveFromTwoToOne_req:(mdl [P1: P2:] []
+    (fact (icst S_TwoOneOrdered [P1: P2:] [] : :) T0: T1: : :)
+    (fact (imdl M_MoveFromTwoToOne [P1: P2: (ti T0: T1:)] [T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; ; If pole is empty then M_MoveBlock will be successful
+; M_MoveBlock_req1:(mdl [P:] []
+;     (fact (icst S_PoleIsEmpty [P:] [] : :) T0: T1: : :)
+;     (fact (imdl M_MoveBlock [B: P: (ti T0: T1:)] [T1_RHS: T3:] : :) T0: T1: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; If pole P has block B_P that is smaller than B then movement will fail
+; M_MoveBlock_req2:(mdl [P:] []
+;     (fact (icst S_OneBlockPoleIsForbidden [P: B_P:] [S_P: B: S: P1:] : :) T0: T1: : :)
+;     (|fact (imdl M_MoveBlock [B: P: (ti T0: T1:)] [T1_RHS: T3:] : :) T0: T1: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; ; If pole P has two blocks and the top one B_P2 is smaller than B then movement will fail
+; M_MoveBlock_req3:(mdl [P: B_P1: B_P2:] []
+;     (fact (icst S_TwoBlockPoleIsForbidden [P: B_P1: B_P2:] [S_P2: B: S: P1:] : :) T0: T1: : :)
+;     (|fact (imdl M_MoveBlock [B: P: (ti T0: T1:)] [T1_RHS: T3:] : :) T0: T1: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; M_PoleHasOneBlockAfterMove:(mdl [B: New_p: (ti T0: T1:)] []
+;     (fact (imdl M_MoveBlock [B: New_p: (ti T0: T1:)] [T1_RHS: T3:] : :) T0_cmd: T1_cmd: : :)
+;     ; (fact (mk.val New_p: has_blocks [B:] :) T1_RHS: T3: : :)
+;     (fact (icst S_PoleHasOneBlock [New_p: B:] [] : :) T1_RHS: T3: : :)
+; []
+;     T1_RHS:(+ T0 100ms)
+;     T3:(+ T1 100ms)
+; []
+;     T0_cmd:(- T1_RHS 80ms)
+;     T1_cmd:(- T3 100ms)
+;     T0:(- T1_RHS 100ms)
+;     T1:(- T3 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; M_PoleHasTwoBlocksAfterMove:(mdl [B: New_p: (ti T0: T1:)] []
+;     (fact (imdl M_MoveBlock [B: New_p: (ti T0: T1:)] [T1_RHS: T3:] : :) T0_cmd: T1_cmd: : :)
+;     ; (fact (mk.val New_p: has_blocks [B1: B:] :) T1_RHS: T3: : :)
+;     (fact (icst S_PoleHasTwoBlocks [New_p: B1: B:] [] : :) T1_RHS: T3: : :)
+; []
+;     T1_RHS:(+ T0 100ms)
+;     T3:(+ T1 100ms)
+; []
+;     T0_cmd:(- T1_RHS 80ms)
+;     T1_cmd:(- T3 100ms)
+;     T0:(- T1_RHS 100ms)
+;     T1:(- T3 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+;
+; M_PoleHasThreeBlocksAfterMove:(mdl [B: New_p: (ti T0: T1:)] []
+;     (fact (imdl M_MoveBlock [B: New_p: (ti T0: T1:)] [T1_RHS: T3:] : :) T0_cmd: T1_cmd: : :)
+;     ; (fact (mk.val New_p: has_blocks [B1: B2: B:] :) T1_RHS: T3: : :)
+;     (fact (icst S_PoleHasThreeBlocks [New_p: B1: B2: B:] [] : :) T1_RHS: T3: : :)
+; []
+;     T1_RHS:(+ T0 100ms)
+;     T3:(+ T1 100ms)
+; []
+;     T0_cmd:(- T1_RHS 80ms)
+;     T1_cmd:(- T3 100ms)
+;     T0:(- T1_RHS 100ms)
+;     T1:(- T3 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Drive ====
+!def DRIVE_START 300ms
+
+m_drive:(mdl [] []
+    ; The goal target timings are the same as the drive timings.
+    ; (fact (mk.val right_pole has_blocks all_blocks :) T0: T1: : :)
+    (fact (icst S_PoleHasThreeBlocks [right_pole] [] : :) T0: T1: : :)
+    (fact run T0: T1: ::)
+|[]
+|[]
+[stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+pgm_inject_drive:(pgm [] []
+   ; This fact repeats periodically. We use it as a "heartbeat".
+   (ptn (fact (mk.val left_pole essence pole :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt DRIVE_START))
+[]
+   ; The end of the time interval will be used in m_drive as the end of the goal interval.
+   (inj [f_run:(fact run After (+ Before 2500ms) 1 1) []])
+   (inj [G:(goal f_run self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before injecting the drive.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected drive" []])
+1) |[]
+(ipgm pgm_inject_drive [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_eject_cmd_move:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd move [P1: P2:] :) ::) ::) ::) [])
+[]
+   (= (is_sim G) false)
+[]
+   (cmd move [P1 P2] 1)
+1) |[]
+(ipgm pgm_eject_cmd_move [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]

--- a/AERA/replicode_v1.2/travel-to-place.replicode
+++ b/AERA/replicode_v1.2/travel-to-place.replicode
@@ -1,0 +1,473 @@
+; ==== Entities and ontologies ====
+you:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+car:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+garage_door:(ent 1) [[SYNC_ONCE now 1 forever root nil]]
+
+home:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+bus_stop_1:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+bus_stop_2:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+bus_stop_3:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+gas_station:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+destination:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+
+location:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+in_car:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+oil_checked:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+started:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+opened:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+
+in_bus:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+; on_foot:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+
+e_car:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+e_door:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+yourself:(ont 1) [[SYNC_ONCE now 0 forever root nil]]
+
+you_is_yourself:(mk.val you essence yourself 1) |[]
+(fact you_is_yourself 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+car_is_car:(mk.val car essence e_car 1) |[]
+(fact car_is_car 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+garage_door_is_door:(mk.val garage_door essence e_door 1) |[]
+(fact garage_door_is_door 0s:0ms:0us GIGASEC 1 1) [[SYNC_AXIOM now 1 forever stdin nil]]
+
+
+; ==== CSTs ====
+; cst_ReadyToDrive:(cst [] []
+;    (fact (mk.val C: essence e_car :) T0: T1: : :)
+;    (fact (mk.val C: oil_checked true :) T0: T1: : :)
+;    (fact (mk.val C: started true :) T0: T1: : :)
+;    (fact (mk.val Y: in_car [C:] :) T0: T1: : :)
+;    (fact (mk.val G: essence e_door :) T0: T1: : :)
+;    (fact (mk.val G: opened true :) T0: T1: : :)
+; |[]
+; |[]
+; [stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_YouPosition:(cst [] []
+   (fact (mk.val Y: essence yourself :) T0: T1: : :)
+   (fact (mk.val Y: position P: :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_YouHome:(cst [] []
+   (fact (mk.val Y: essence yourself :) T0: T1: : :)
+   (fact (mk.val Y: position home :) T0: T1: : :)
+   (fact (mk.val C: essence e_car :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_OilChecked:(cst [] []
+   (fact (mk.val C: essence e_car :) T0: T1: : :)
+   (fact (mk.val C: oil_checked true :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_EngineStarted:(cst [] []
+   (fact (mk.val C: essence e_car :) T0: T1: : :)
+   (fact (mk.val C: started true :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_InCar:(cst [] []
+   (fact (mk.val C: essence e_car :) T0: T1: : :)
+   (fact (mk.val Y: essence yourself :) T0: T1: : :)
+   (fact (mk.val Y: in_car [C:] :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_InBus:(cst [] []
+   (fact (mk.val Y: essence yourself :) T0: T1: : :)
+   (fact (mk.val Y: in_bus true :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+cst_GarageDoorOpened:(cst [] []
+   (fact (mk.val G: essence e_door :) T0: T1: : :)
+   (fact (mk.val G: opened true :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+; ==== Models ====
+mdl_CheckOil:(mdl [C: (ti T0: T1:)] []
+   (fact (cmd check_oil [C:] :) T2: T1_cmd: : :)
+   (fact (mk.val C: oil_checked true :) T1_RHS: T3: : :)
+[]
+   T1_RHS:(+ T0 100ms)
+   T3:(+ T1 100ms)
+[]
+   T2:(- T1_RHS 80ms)
+   T1_cmd:(- T3 100ms)
+   T0:(- T1_RHS 100ms)
+   T1:(- T3 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_CheckOil_req:(mdl [] []
+   (fact (icst cst_YouHome [] [Y: C:] : :) T0: T1: : :)
+   (fact (imdl mdl_CheckOil [C: (ti T0: T1:)] [T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; mdl_CheckOil_anti1:(mdl [] []
+;    (fact (mk.val Y: in_bus true :) T0: T1: : :)
+;    (|fact (imdl mdl_CheckOil [C: (ti T0: T1:)] [T1_RHS: T3:] : :) T0: T1: : :)
+; |[]
+; |[]
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_EnterCar:(mdl [C: (ti T0: T1:)] []
+   (fact (cmd enter_car [C:] :) T2: T1_cmd: : :)
+   (fact (mk.val Y: in_car [C:] :) T1_RHS: T3: : :)
+[]
+   T1_RHS:(+ T0 100ms)
+   T3:(+ T1 100ms)
+[]
+   T2:(- T1_RHS 80ms)
+   T1_cmd:(- T3 100ms)
+   T0:(- T1_RHS 100ms)
+   T1:(- T3 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_EnterCar_req:(mdl [] []
+   (fact (icst cst_OilChecked [] [C:] : :) T0: T1: : :)
+   (fact (imdl mdl_EnterCar [C: (ti T0: T1:)] [Y: T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_OpenGarage:(mdl [G: (ti T0: T1:)] []
+   (fact (cmd open_garage [G:] :) T2: T1_cmd: : :)
+   (fact (mk.val G: opened true :) T1_RHS: T3: : :)
+[]
+   T1_RHS:(+ T0 100ms)
+   T3:(+ T1 100ms)
+[]
+   T2:(- T1_RHS 80ms)
+   T1_cmd:(- T3 100ms)
+   T0:(- T1_RHS 100ms)
+   T1:(- T3 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_OpenGarage_req:(mdl [] []
+   (fact (icst cst_InCar [] [Y: C:] : :) T0: T1: : :)
+   (fact (imdl mdl_OpenGarage [G: (ti T0: T1:)] [T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_StartEngine:(mdl [C: (ti T0: T1:)] []
+   (fact (cmd start_engine [C:] :) T2: T1_cmd: : :)
+   (fact (mk.val C: started true :) T1_RHS: T3: : :)
+[]
+   T1_RHS:(+ T0 100ms)
+   T3:(+ T1 100ms)
+[]
+   T2:(- T1_RHS 80ms)
+   T1_cmd:(- T3 100ms)
+   T0:(- T1_RHS 100ms)
+   T1:(- T3 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_StartEngine_req:(mdl [] []
+   (fact (icst cst_GarageDoorOpened [] [G:] : :) T0: T1: : :)
+   (fact (imdl mdl_StartEngine [C: (ti T0: T1:)] [T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_Drive:(mdl [C: Dest: (ti T0: T1:)] []
+   (fact (cmd drive [C: Dest:] :) T2: T1_cmd: : :)
+   (fact (mk.val Y: position Dest: :) T1_RHS: T3: : :)
+[]
+   T1_RHS:(+ T0 300ms)
+   T3:(+ T1 300ms)
+[]
+   T2:(- T1_RHS 280ms)
+   T1_cmd:(- T3 300ms)
+   T0:(- T1_RHS 300ms)
+   T1:(- T3 300ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_Drive_req:(mdl [] []
+   (fact (icst cst_EngineStarted [] [C:] : :) T0: T1: : :)
+   (fact (imdl mdl_Drive [C: Dest: (ti T0: T1:)] [Y: T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_Drive_anti1:(mdl [] []
+   (fact (icst cst_InBus [] [Y:] : :) T0: T1: : :)
+   (|fact (imdl mdl_Drive [C: Dest: (ti T0: T1:)] [Y: T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+mdl_Walk:(mdl [Dest: (ti T0: T1:)] []
+   (fact (cmd walk [Dest:] :) T2: T1_cmd: : :)
+   (fact (mk.val Y: position Dest: :) T1_RHS: T3: : :)
+[]
+   T1_RHS:(+ T0 300ms)
+   T3:(+ T1 300ms)
+[]
+   T2:(- T1_RHS 280ms)
+   T1_cmd:(- T3 300ms)
+   T0:(- T1_RHS 300ms)
+   T1:(- T3 300ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_Walk_req1:(mdl [] []
+   (fact (icst cst_YouPosition [] [Y: home] : :) T0: T1: : :)
+   (fact (imdl mdl_Walk [bus_stop_1 (ti T0: T1:)] [Y: T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_Walk_req2:(mdl [] []
+   (fact (icst cst_YouPosition [] [Y: bus_stop_1] : :) T0: T1: : :)
+   (fact (imdl mdl_Walk [bus_stop_2 (ti T0: T1:)] [Y: T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_Walk_req3:(mdl [] []
+   (fact (icst cst_YouPosition [] [Y: bus_stop_2] : :) T0: T1: : :)
+   (fact (imdl mdl_Walk [bus_stop_3 (ti T0: T1:)] [Y: T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_Walk_req4:(mdl [] []
+   (fact (icst cst_YouPosition [] [Y: bus_stop_3] : :) T0: T1: : :)
+   (fact (imdl mdl_Walk [destination (ti T0: T1:)] [Y: T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_Walk_anti1:(mdl [] []
+   (fact (icst cst_InCar [] [Y: C:] : :) T0: T1: : :)
+   (|fact (imdl mdl_Walk [Dest: (ti T0: T1:)] [Y: T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_Walk_anti2:(mdl [] []
+   (fact (icst cst_InBus [] [Y:] : :) T0: T1: : :)
+   (|fact (imdl mdl_Walk [Dest: (ti T0: T1:)] [Y: T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+; mdl_Walk_reuse1:(mdl [Dest: (ti T0: T1:)] []
+;    (fact (imdl mdl_Walk [Dest: (ti T0: T1:)] [Y: T1_RHS: T3:] : :) T0_cmd: T1_cmd: : :)
+;    (fact (mk.val Y: on_foot true :) T1_RHS: T3: : :)
+; []
+;    T1_RHS:(+ T0 100ms)
+;    T3:(+ T1 100ms)
+; []
+;    T0_cmd:(- T1_RHS 80ms)
+;    T1_cmd:(- T3 100ms)
+;    T0:(- T1_RHS 100ms)
+;    T1:(- T3 100ms)
+; [stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+mdl_TakeBus:(mdl [Dest: (ti T0: T1:)] []
+   (fact (cmd take_bus [Dest:] :) T2: T1_cmd: : :)
+   (fact (mk.val Y: position Dest: :) T1_RHS: T3: : :)
+[]
+   T1_RHS:(+ T0 200ms)
+   T3:(+ T1 200ms)
+[]
+   T2:(- T1_RHS 180ms)
+   T1_cmd:(- T3 200ms)
+   T0:(- T1_RHS 200ms)
+   T1:(- T3 200ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_TakeBus_req1:(mdl [] []
+   (fact (icst cst_YouPosition [] [Y: home] : :) T0: T1: : :)
+   (fact (imdl mdl_TakeBus [bus_stop_1 (ti T0: T1:)] [Y: T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_TakeBus_req2:(mdl [] []
+   (fact (icst cst_YouPosition [] [Y: bus_stop_1] : :) T0: T1: : :)
+   (fact (imdl mdl_TakeBus [bus_stop_2 (ti T0: T1:)] [Y: T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_TakeBus_req3:(mdl [] []
+   (fact (icst cst_YouPosition [] [Y: bus_stop_2] : :) T0: T1: : :)
+   (fact (imdl mdl_TakeBus [bus_stop_3 (ti T0: T1:)] [Y: T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_TakeBus_req4:(mdl [] []
+   (fact (icst cst_YouPosition [] [Y: bus_stop_3] : :) T0: T1: : :)
+   (fact (imdl mdl_TakeBus [destination (ti T0: T1:)] [Y: T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_TakeBus_anti1:(mdl [] []
+   (fact (icst cst_InCar [] [Y: C:] : :) T0: T1: : :)
+   (|fact (imdl mdl_TakeBus [Dest: (ti T0: T1:)] [Y: T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_TakeBus_anti2:(mdl [] []
+   (fact (icst cst_InBus [] [Y:] : :) T0: T1: : :)
+   (|fact (imdl mdl_TakeBus [Dest: (ti T0: T1:)] [Y: T1_RHS: T3:] : :) T0: T1: : :)
+|[]
+|[]
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+mdl_TakeBus_reuse1:(mdl [Dest: (ti T0: T1:)] []
+   (fact (imdl mdl_TakeBus [Dest: (ti T0: T1:)] [Y: T2_RHS: T3_RHS:] : :) T0_cmd: T1_cmd: : :)
+   (fact (mk.val Y: in_bus true :) T1_RHS: T3: : :)
+[]
+   T1_RHS:(+ T0 100ms)
+   T3:(+ T1 100ms)
+[]
+   T0_cmd:(- T1_RHS 80ms)
+   T1_cmd:(- T3 100ms)
+   T0:(- T1_RHS 100ms)
+   T1:(- T3 100ms)
+[stdin] 1 1 1 1 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+
+
+; ==== Drive ====
+m_drive:(mdl [] []
+    ; The goal target timings are the same as the drive timings.
+    (fact (mk.val you position destination :) T0: T1: : :)
+    (fact run T0: T1: ::)
+|[]
+|[]
+[stdin drives] 1 1 1 0 1) [[SYNC_ONCE now 0 forever primary nil 1]]
+
+!def DRIVE_START 300ms
+!def DRIVE_START2 600ms
+
+pgm_inject_drive:(pgm [] []
+    ; This fact repeats periodically. We use it as a "heartbeat".
+    (ptn (fact (mk.val you essence yourself :) After: Before: ::) [])
+[]
+   (>= After (+ this.vw.ijt DRIVE_START))
+[]
+   ; The end of the time interval will be used in m_drive as the end of the goal interval.
+   (inj [f_run:(fact run After (+ Before 1600ms) 1 1) []])
+   (inj [G:(goal f_run self nil 1) []])
+   (inj []
+      ; Delay a little to allow predictions for this sampling period before injecting the drive.
+      (fact G T0:(+ After 10ms) T0 1 1)
+      [SYNC_ONCE T0 1 forever primary nil]
+   )
+   (prb [1 "print" "injected drive" []])
+1) |[]
+(ipgm pgm_inject_drive [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+; pgm_inject_drive2:(pgm [] []
+;     ; This fact repeats periodically. We use it as a "heartbeat".
+;     (ptn (fact (mk.val you essence yourself :) After: Before: ::) [])
+; []
+;    (= After (+ this.vw.ijt DRIVE_START2))
+; []
+;    ; The end of the time interval will be used in m_drive as the end of the goal interval.
+;    (inj [f_run:(fact run After (+ Before 1100ms) 1 1) []])
+;    (inj [G:(goal f_run self nil 1) []])
+;    (inj []
+;       ; Delay a little to allow predictions for this sampling period before injecting the drive.
+;       (fact G T0:(+ After 10ms) T0 1 1)
+;       [SYNC_ONCE T0 1 forever primary nil]
+;    )
+;    (prb [1 "print" "injected drive" []])
+; 1) |[]
+; (ipgm pgm_inject_drive2 [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+;    [SYNC_ONCE now 0 forever primary nil 1]
+
+
+; ==== Eject programs ====
+pgm_eject_cmd_check_oil:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd check_oil [C:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd check_oil [C] 1)
+1) |[]
+(ipgm pgm_eject_cmd_check_oil [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_eject_cmd_enter_car:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd enter_car [C:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd enter_car [C] 1)
+1) |[]
+(ipgm pgm_eject_cmd_enter_car [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_eject_cmd_open_garage:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd open_garage [Ga:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd open_garage [Ga] 1)
+1) |[]
+(ipgm pgm_eject_cmd_open_garage [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_eject_cmd_start_engine:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd start_engine [C:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd start_engine [C] 1)
+1) |[]
+(ipgm pgm_eject_cmd_start_engine [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_eject_cmd_drive:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd drive [C: Dest:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd drive [C Dest] 1)
+1) |[]
+(ipgm pgm_eject_cmd_drive [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_eject_cmd_walk:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd walk [Dest:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd walk [Dest] 1)
+1) |[]
+(ipgm pgm_eject_cmd_walk [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]
+
+pgm_eject_cmd_take_bus:(pgm [] []
+    (ptn (fact G:(goal (fact (cmd take_bus [Dest:] :) ::) ::) ::) [])
+[]
+    (= (is_sim G) false)
+[]
+    (cmd take_bus [Dest] 1)
+1) |[]
+(ipgm pgm_eject_cmd_take_bus [] RUN_ALWAYS MAX_TIME VOLATILE NOTIFY 1) []
+   [SYNC_ONCE now 0 forever primary nil 1]

--- a/AERA/take_vehicles_io_device.cpp
+++ b/AERA/take_vehicles_io_device.cpp
@@ -1,0 +1,161 @@
+#include "take_vehicles_io_device.h"
+
+using namespace std;
+using namespace std::chrono;
+using namespace r_code;
+using namespace r_exec;
+
+namespace take_vehicles {
+
+TakeVehiclesIODevice::TakeVehiclesIODevice() {
+	oil_checked_ = false;
+	in_car_ = false;
+	garage_opened_ = false;
+	engine_started_ = false;
+	in_bus_ = false;
+
+	start_moving_time_ = NULL;
+	destination_ = NULL;
+}
+
+bool TakeVehiclesIODevice::load(const std::vector<r_code::Code*>* objects, uint32 stdin_oid, uint32 stdout_oid, uint32 self_oid) {
+	if (!MemExec::load(objects, stdin_oid, stdout_oid, self_oid))
+		return false;
+
+	check_oil_opcode_ = r_exec::GetOpcode("check_oil");
+	enter_car_opcode_ = r_exec::GetOpcode("enter_car");
+	open_garage_opcode_ = r_exec::GetOpcode("open_garage");
+	start_engine_opcode_ = r_exec::GetOpcode("start_engine");
+	drive_opcode_ = r_exec::GetOpcode("drive");
+	walk_opcode_ = r_exec::GetOpcode("walk");
+	take_bus_opcode_ = r_exec::GetOpcode("take_bus");
+
+	you_object_ = MemStatic::find_object(objects, "you");
+	car_object_ = MemStatic::find_object(objects, "car");
+	garage_door_object_ = MemStatic::find_object(objects, "garage_door");
+
+	position_property_ = MemStatic::find_object(objects, "position");
+	oil_checked_property_ = MemStatic::find_object(objects, "oil_checked");
+	in_car_property_ = MemStatic::find_object(objects, "in_car");
+	started_property_ = MemStatic::find_object(objects, "started");
+	opened_property_ = MemStatic::find_object(objects, "opened");
+	in_bus_property_ = MemStatic::find_object(objects, "in_bus");
+
+	home_position_ = MemStatic::find_object(objects, "home");
+	destination_position_ = MemStatic::find_object(objects, "destination");
+
+	position_ = home_position_;
+
+	//on_vehicle_property_ = MemStatic::find_object(objects, "on_vehicle");
+	//bus_object_ = MemStatic::find_object(objects, "bus");
+	//foot_object_ = MemStatic::find_object(objects, "foot");
+	//vehicle_ = car_object_;
+}
+
+Code* TakeVehiclesIODevice::eject(r_code::Code* command) {
+	uint16 function = (command->code(CMD_FUNCTION).atom_ >> 8) & 0x000000FF;
+
+	if (function == check_oil_opcode_) {
+		uint16 args_set_index = command->code(CMD_ARGS).asIndex();
+		Code* car = command->get_reference(command->code(args_set_index + 1).asIndex());
+
+		oil_checked_ = true;
+		return command;
+	}
+	else if (function == enter_car_opcode_) {
+		uint16 args_set_index = command->code(CMD_ARGS).asIndex();
+		Code* car = command->get_reference(command->code(args_set_index + 1).asIndex());
+
+		in_car_ = true;
+		return command;
+	}
+	else if (function == open_garage_opcode_) {
+		uint16 args_set_index = command->code(CMD_ARGS).asIndex();
+		Code* garage = command->get_reference(command->code(args_set_index + 1).asIndex());
+
+		garage_opened_ = true;
+		return command;
+	}
+	else if (function == start_engine_opcode_) {
+		uint16 args_set_index = command->code(CMD_ARGS).asIndex();
+		Code* car = command->get_reference(command->code(args_set_index + 1).asIndex());
+
+		engine_started_ = true;
+		return command;
+	}
+	else if (function == drive_opcode_) {
+		uint16 args_set_index = command->code(CMD_ARGS).asIndex();
+		Code* car = command->get_reference(command->code(args_set_index + 1).asIndex());
+		Code* destination = command->get_reference(command->code(args_set_index + 2).asIndex());
+		
+		if (!oil_checked_ || !in_car_ || !garage_opened_ || !engine_started_)
+			return command;
+
+		destination_ = destination;
+		start_moving_time_ = &r_exec::Now();
+		return command;
+	}
+	else if (function == walk_opcode_) {
+		uint16 args_set_index = command->code(CMD_ARGS).asIndex();
+		Code* destination = command->get_reference(command->code(args_set_index + 1).asIndex());
+
+		if (in_car_)
+			return command;
+
+		destination_ = destination;
+		start_moving_time_ = &r_exec::Now();
+		return command;
+	}
+	else if (function == take_bus_opcode_) {
+		uint16 args_set_index = command->code(CMD_ARGS).asIndex();
+		Code* destination = command->get_reference(command->code(args_set_index + 1).asIndex());
+
+		if (in_car_)
+			return command;
+
+		destination_ = destination;
+		in_bus_ = true;
+		start_moving_time_ = &r_exec::Now();
+		return command;
+	}
+
+	return NULL;
+}
+
+void TakeVehiclesIODevice::on_time_tick() {
+	auto now = r_exec::Now();
+
+	if (in_car_ && duration_cast<milliseconds>(now - *start_moving_time_).count() >= 300) {
+		position_ = destination_;
+		destination_ = NULL;
+		start_moving_time_ = NULL;
+	}
+	else if (in_bus_ && duration_cast<milliseconds>(now - *start_moving_time_).count() >= 200) {
+		position_ = destination_;
+		destination_ = NULL;
+		start_moving_time_ = NULL;
+	}
+
+	MemStatic::inject_marker_value_from_io_device(you_object_, position_property_, position_,
+		now, now + MemStatic::get_sampling_period(), r_exec::View::SYNC_HOLD);
+
+	MemStatic::inject_marker_value_from_io_device(car_object_, oil_checked_property_, Atom::Boolean(oil_checked_),
+		now, now + MemStatic::get_sampling_period(), r_exec::View::SYNC_HOLD);
+
+	MemStatic::inject_marker_value_from_io_device(car_object_, started_property_, Atom::Boolean(engine_started_),
+		now, now + MemStatic::get_sampling_period(), r_exec::View::SYNC_HOLD);
+
+	auto vehicle = std::vector<Code*>();
+	if (in_car_)
+		vehicle.push_back(car_object_);
+	MemStatic::inject_marker_value_from_io_device(you_object_, in_car_property_, vehicle,
+		now, now + MemStatic::get_sampling_period(), r_exec::View::SYNC_HOLD);
+
+	MemStatic::inject_marker_value_from_io_device(garage_door_object_, opened_property_, Atom::Boolean(garage_opened_),
+		now, now + MemStatic::get_sampling_period(), r_exec::View::SYNC_HOLD);
+
+	MemStatic::inject_marker_value_from_io_device(you_object_, in_bus_property_, Atom::Boolean(in_bus_),
+		now, now + MemStatic::get_sampling_period(), r_exec::View::SYNC_HOLD);
+}
+
+}

--- a/AERA/take_vehicles_io_device.h
+++ b/AERA/take_vehicles_io_device.h
@@ -1,0 +1,75 @@
+#ifndef take_vehicles_io_device_h
+#define take_vehicles_io_device_h
+
+#include "../r_exec/mem.h"
+#include <map>
+
+namespace take_vehicles {
+
+class TakeVehiclesIODevice : public r_exec::MemExec<r_exec::LObject, r_exec::MemStatic> {
+
+public:
+  TakeVehiclesIODevice();
+
+  // Called in main.cpp
+  bool load(const std::vector<r_code::Code*>* objects, uint32 stdin_oid, uint32 stdout_oid, uint32 self_oid) override;
+
+  /**
+  * Receive a command from AERA.
+  *
+  * \return The given command if it is executed as-is, or a new command object of the command
+  * that is actually executed. The program controller will make a fact from the command and
+  * inject it as the efferent copy. However, if the command is not executed, then return NULL
+  * and the program controller will put an anti-fact of the command in the mk.rdx reduction.
+  */
+  r_code::Code* eject(r_code::Code* command) override;
+
+  // Called in DiagnosticTimeState::step()
+  void on_diagnostic_time_tick() override { on_time_tick(); }
+
+protected:
+  // Objects can be injected into the working memory from here (use injection functions from _Mem)
+  void on_time_tick();
+
+  uint16 check_oil_opcode_;
+  uint16 enter_car_opcode_;
+  uint16 open_garage_opcode_;
+  uint16 start_engine_opcode_;
+  uint16 drive_opcode_;
+  uint16 walk_opcode_;
+  uint16 take_bus_opcode_;
+
+  r_code::Code* you_object_;
+  r_code::Code* car_object_;
+  r_code::Code* garage_door_object_;
+  
+  r_code::Code* position_property_;
+  r_code::Code* oil_checked_property_;
+  r_code::Code* in_car_property_;
+  r_code::Code* started_property_;
+  r_code::Code* opened_property_;
+  r_code::Code* in_bus_property_;
+
+  r_code::Code* home_position_;
+  r_code::Code* destination_position_;
+
+  bool oil_checked_;
+  bool in_car_;
+  bool garage_opened_;
+  bool engine_started_;
+  bool in_bus_;
+  r_code::Code* position_;
+  r_code::Code* destination_;
+
+  Timestamp* start_moving_time_;
+
+
+  //r_code::Code* on_vehicle_property_;
+  //r_code::Code* bus_object_;
+  //r_code::Code* foot_object_;
+
+  //r_code::Code* vehicle_;
+};
+}
+
+#endif

--- a/AERA/tower_of_hanoi_io_device.cpp
+++ b/AERA/tower_of_hanoi_io_device.cpp
@@ -1,0 +1,93 @@
+#include "tower_of_hanoi_io_device.h"
+
+using namespace r_code;
+using namespace r_exec;
+
+namespace tower_of_hanoi {
+
+TowerOfHanoiIODevice::TowerOfHanoiIODevice(std::string source_file_name) : poles_(), positions_() {
+	move_opcode_ = 0xFFFF;
+	left_pole_object_ = NULL;
+	center_pole_object_ = NULL;
+	right_pole_object_ = NULL;
+
+	source_file_name_ = source_file_name;
+}
+
+bool TowerOfHanoiIODevice::load(const std::vector<r_code::Code*>* objects, uint32 stdin_oid, uint32 stdout_oid, uint32 self_oid) {
+	if (!MemExec::load(objects, stdin_oid, stdout_oid, self_oid))
+		return false;
+
+	move_opcode_ = r_exec::GetOpcode("move");
+	move_block_opcode_ = r_exec::GetOpcode("move_block");
+	position_property_ = MemStatic::find_object(objects, "position");
+	has_blocks_property_ = MemStatic::find_object(objects, "has_blocks");
+	left_pole_object_ = MemStatic::find_object(objects, "left_pole");
+	center_pole_object_ = MemStatic::find_object(objects, "center_pole");
+	right_pole_object_ = MemStatic::find_object(objects, "right_pole");
+	big_block_object_ = MemStatic::find_object(objects, "big_block");
+	medium_block_object_ = MemStatic::find_object(objects, "medium_block");
+	small_block_object_ = MemStatic::find_object(objects, "small_block");
+
+	if (source_file_name_.find("learn") != std::string::npos) {
+		positions_[2] = 1; // Big (2) at center (1)
+		positions_[1] = 1; // Medium (1) at center (1)
+		positions_[0] = 0; // Small (0) at left (0)
+
+		poles_[1].push_back(big_block_object_); // Big at center (1)
+		poles_[1].push_back(medium_block_object_); // Medium at center (1)
+		poles_[0].push_back(small_block_object_); // Small at left (0)
+	}
+	else if (source_file_name_.find("full") != std::string::npos) {
+		//positions_[2] = 2; // Big (2) at right (2)
+		//positions_[1] = 1; // Medium (1) at center (1)
+		//positions_[0] = 2; // Small (0) at right (2)
+
+		//poles_[2].push_back(big_block_object_); // Big at right (2)
+		//poles_[1].push_back(medium_block_object_); // Medium at center (1)
+		//poles_[2].push_back(small_block_object_); // Small at right (2)
+
+		positions_[2] = 2; // Big (2) at right (2)
+		positions_[1] = 0; // Medium (1) at left (0)
+		positions_[0] = 0; // Small (0) at left (0)
+
+		poles_[2].push_back(big_block_object_); // Big at right (2)
+		poles_[0].push_back(medium_block_object_); // Medium at left (0)
+		poles_[0].push_back(small_block_object_); // Small at left (0)
+	}
+
+	return true;
+}
+
+Code* TowerOfHanoiIODevice::eject(Code* command) {
+	uint16 function = (command->code(CMD_FUNCTION).atom_ >> 8) & 0x000000FF;
+
+	if (function == move_block_opcode_) {
+		uint16 args_set_index = command->code(CMD_ARGS).asIndex();
+
+		Code* block = command->get_reference(command->code(args_set_index + 1).asIndex());
+		Code* pole = command->get_reference(command->code(args_set_index + 2).asIndex());
+
+		if (!move_block(block_object_to_index(block), pole_object_to_index(pole)))
+			return command;
+
+		return command;
+	}
+
+	return NULL;
+}
+
+void TowerOfHanoiIODevice::on_time_tick() {
+	auto now = r_exec::Now();
+
+	MemStatic::inject_marker_value_from_io_device(left_pole_object_, has_blocks_property_, poles_[0],
+		now, now + MemStatic::get_sampling_period());
+
+	MemStatic::inject_marker_value_from_io_device(center_pole_object_, has_blocks_property_, poles_[1],
+		now, now + MemStatic::get_sampling_period());
+
+	MemStatic::inject_marker_value_from_io_device(right_pole_object_, has_blocks_property_, poles_[2],
+		now, now + MemStatic::get_sampling_period());
+}
+
+}

--- a/AERA/tower_of_hanoi_io_device.h
+++ b/AERA/tower_of_hanoi_io_device.h
@@ -1,0 +1,138 @@
+#ifndef tower_of_hanoi_io_device_h
+#define tower_of_hanoi_io_device_h
+
+#include <stack>
+#include <array>
+#include "../r_exec/mem.h"
+
+namespace tower_of_hanoi {
+
+class TowerOfHanoiIODevice : public r_exec::MemExec<r_exec::LObject, r_exec::MemStatic> {
+
+public:
+  TowerOfHanoiIODevice(std::string source_file_name);
+
+  //~TowerOfHanoiIODevice();
+
+  // Called in main.cpp
+  bool load(const std::vector<r_code::Code*>* objects, uint32 stdin_oid, uint32 stdout_oid, uint32 self_oid) override;
+
+  /**
+  * Receive a command from AERA.
+  *
+  * \return The given command if it is executed as-is, or a new command object of the command
+  * that is actually executed. The program controller will make a fact from the command and
+  * inject it as the efferent copy. However, if the command is not executed, then return NULL
+  * and the program controller will put an anti-fact of the command in the mk.rdx reduction.
+  */
+  r_code::Code* eject(r_code::Code* command) override;
+
+  // Called in DiagnosticTimeState::step()
+  void on_diagnostic_time_tick() override { on_time_tick(); }
+
+protected:
+  // Objects can be injected into the working memory from here (use injection functions from _Mem)
+  void on_time_tick();
+
+  bool move(int from, int to) {
+    if (from > 2 || from < 0 || to < 0 || to > 2)
+      return false;
+
+    r_code::Code* from_block = poles_[from].back();
+    if (!poles_[to].empty() && is_smaller(poles_[to].back(), from_block)) {
+      // Cannot move if destination has a smaller block
+      return false;
+    }
+
+    poles_[from].pop_back();
+    poles_[to].push_back(from_block);
+    return true;
+  }
+
+  bool move_block(int block, int pole) {
+    int from = positions_[block];
+
+    if (!isTopBlock(block))
+      return false;
+
+    if (!move(from, pole))
+      return false;
+
+    //for (int d = block; d < 2; ++d) {
+    //  if (positions_[d] == pole)
+    //    return false;
+    //}
+
+    positions_[block] = pole;
+    return true;
+  }
+
+  // Returns true if block b1 is smaller than block b2
+  bool is_smaller(r_code::Code* b1, r_code::Code* b2) {
+    if (b1 == small_block_object_)
+      return true;
+    if (b1 == big_block_object_)
+      return false;
+    if (b1 == medium_block_object_)
+      return b2 == big_block_object_;
+  }
+
+  bool isTopBlock(int block) const {
+    int pole = positions_[block];
+
+    for (int d = 0; d < block; ++d) {
+      if (positions_[d] == pole) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  int pole_object_to_index(r_code::Code* pole_object) {
+    if (pole_object == left_pole_object_)
+      return 0;
+    if (pole_object == center_pole_object_)
+      return 1;
+    if (pole_object == right_pole_object_)
+      return 2;
+  }
+
+  r_code::Code* index_to_pole_object(int index) {
+    if (index == 0)
+      return left_pole_object_;
+    if (index == 1)
+      return center_pole_object_;
+    if (index == 2)
+      return right_pole_object_;
+  }
+
+  int block_object_to_index(r_code::Code* block_object) {
+    if (block_object == small_block_object_)
+      return 0;
+    if (block_object == medium_block_object_)
+      return 1;
+    if (block_object == big_block_object_)
+      return 2;
+  }
+
+  uint16 move_opcode_;
+  uint16 move_block_opcode_;
+  r_code::Code* position_property_;
+  r_code::Code* has_blocks_property_;
+  r_code::Code* left_pole_object_;
+  r_code::Code* center_pole_object_;
+  r_code::Code* right_pole_object_;
+  r_code::Code* big_block_object_;
+  r_code::Code* medium_block_object_;
+  r_code::Code* small_block_object_;
+
+  // 0: small, 1: medium, 2: big -- values are same as poles_ array
+  std::array<int, 3> positions_;
+  // 0: left, 1: center, 2: right
+  std::array<std::vector<r_code::Code*>, 3> poles_;
+
+  std::string source_file_name_;
+};
+}
+
+#endif

--- a/r_exec/binding_map.cpp
+++ b/r_exec/binding_map.cpp
@@ -330,6 +330,11 @@ void ObjectValue::valuate(Code *destination, uint16 write_index, uint16& /* exte
 }
 
 bool ObjectValue::match(const Code *object, uint16 index) {
+  uint16 object_index = object->code(index).asIndex();
+  if (object_index >= object->references_size()) {
+    // Object at "index" is probably an I_PTR to a set
+    return map_->match_object(object->get_reference(object->code(object_index + 1).asIndex()), object_);
+  }
 
   return map_->match_object(object->get_reference(object->code(index).asIndex()), object_);
 }

--- a/r_exec/binding_map.h
+++ b/r_exec/binding_map.h
@@ -342,7 +342,9 @@ public:
 
   Atom *get_value_code(uint16 id) const;
   uint16 get_value_code_size(uint16 id) const;
-  uint16 get_first_index() const { return first_index_;  }
+  uint16 get_first_index() const { return first_index_; }
+
+  uint32 get_unbound_values() const { return unbound_values_; }
 
   /**
    * Check if any value in bm matches any value in this BindingMap

--- a/r_exec/cst_controller.cpp
+++ b/r_exec/cst_controller.cpp
@@ -188,6 +188,10 @@ _Fact* CSTOverlay::inject_production(View* input) {
       // Propagate the accumulated of DefeasibleValidity from all the inputs to the new prediction.
       prediction->defeasible_validities_ = defeasible_validities_;
     Fact *f_p_f_icst = new Fact(prediction, now, now, 1, 1);
+    MkRdx* mk_rdx = new MkRdx(f_icst, input->object_, f_p_f_icst, 1, bindings_);
+    CSTController* controller = (CSTController*)controller_;
+    controller->inject_notification_into_out_groups(controller->get_host(), mk_rdx);
+    simulations_copy[0]->solution_graph_[f_p_f_icst] = mk_rdx;
     if (!((HLPController *)controller_)->inject_prediction(f_p_f_icst, lowest_cfd_)) // inject a simulated prediction in the main group.
       return NULL;
     OUTPUT_LINE(CST_OUT, Utils::RelativeTime(Now()) << " cst " << get_object()->get_oid() << ": fact " <<
@@ -368,6 +372,13 @@ bool CSTOverlay::reduce(View *input, CSTOverlay *&offspring) {
 
         Pred* p_promoted_fact = new Pred(promoted_fact, prediction, 1);
         Fact* f_p_promoted_fact = new Fact(p_promoted_fact, now, now, 1, 1);
+        if (is_simulation) {
+          Fact* f_icst = ((CSTController*)controller_)->get_f_icst(bindings_, &axiom_inputs_, &non_axiom_inputs_);
+          MkRdx* mk_rdx = new MkRdx(f_icst, input->object_, f_p_promoted_fact, 1, bindings_);
+          CSTController* controller = (CSTController*)controller_;
+          controller->inject_notification_into_out_groups(controller->get_host(), mk_rdx);
+          predictionSimulation->solution_graph_[f_p_promoted_fact] = mk_rdx;
+        }
 
         // The promoted fact may be defeated by a predicted fact for the same time interval, so make it defeasible.
         P<DefeasibleValidity> defeasible_validity = new DefeasibleValidity();

--- a/r_exec/cst_controller.cpp
+++ b/r_exec/cst_controller.cpp
@@ -191,7 +191,7 @@ _Fact* CSTOverlay::inject_production(View* input) {
     MkRdx* mk_rdx = new MkRdx(f_icst, input->object_, f_p_f_icst, 1, bindings_);
     CSTController* controller = (CSTController*)controller_;
     controller->inject_notification_into_out_groups(controller->get_host(), mk_rdx);
-    simulations_copy[0]->solution_graph_[f_p_f_icst] = mk_rdx;
+    simulations_copy[0]->solution_->add_mk_rdx(mk_rdx);
     if (!((HLPController *)controller_)->inject_prediction(f_p_f_icst, lowest_cfd_)) // inject a simulated prediction in the main group.
       return NULL;
     OUTPUT_LINE(CST_OUT, Utils::RelativeTime(Now()) << " cst " << get_object()->get_oid() << ": fact " <<
@@ -377,7 +377,7 @@ bool CSTOverlay::reduce(View *input, CSTOverlay *&offspring) {
           MkRdx* mk_rdx = new MkRdx(f_icst, input->object_, f_p_promoted_fact, 1, bindings_);
           CSTController* controller = (CSTController*)controller_;
           controller->inject_notification_into_out_groups(controller->get_host(), mk_rdx);
-          predictionSimulation->solution_graph_[f_p_promoted_fact] = mk_rdx;
+          predictionSimulation->solution_->add_mk_rdx(mk_rdx);
         }
 
         // The promoted fact may be defeated by a predicted fact for the same time interval, so make it defeasible.

--- a/r_exec/factory.cpp
+++ b/r_exec/factory.cpp
@@ -770,6 +770,28 @@ bool Sim::is_invalidated() {
   return false;
 }
 
+uint32 Sim::count_super_goal_chain() const {
+  Sim* super_goal_sim = get_f_super_goal()->get_goal()->get_sim();
+  if (super_goal_sim == NULL)
+    return 0;
+
+  return super_goal_sim->count_super_goal_chain() + 1;
+}
+
+float32 Sim::get_solution_mdl_count(Success* success) {
+  uint32 counter = 0;
+  auto found_mk_rdx = solution_graph_.find(success->get_evidence());
+  while (found_mk_rdx != solution_graph_.end()) {
+    P<MkRdx> mk_rdx = found_mk_rdx->second;
+    _Fact* code = (_Fact*)mk_rdx->get_reference(0);
+    auto is_imdl = code->get_reference(0)->code(0).asOpcode() == Opcodes::IMdl;
+    if (is_imdl)
+      counter++;
+    found_mk_rdx = solution_graph_.find(mk_rdx->get_first_input());
+  }
+  return counter;
+}
+
 Sim* Sim::get_root_sim()
 {
   Sim* result = this;

--- a/r_exec/factory.cpp
+++ b/r_exec/factory.cpp
@@ -429,6 +429,8 @@ bool _Fact::CounterEvidence(const Code *lhs, const Code *rhs) {
     if (((ICST*)lhs)->components_.size() != ((ICST*)rhs)->components_.size())
       return false;
 
+    if (((ICST*)rhs)->components_.empty())
+      return false;
     for (uint32 i = 0; i < ((ICST *)lhs)->components_.size(); ++i) { // compare all components 2 by 2.
 
       // JTNote: This assumes that the components_ in the lhs and rhs are in the same order.
@@ -978,7 +980,7 @@ Mdl::Mdl(SysObject* source) : LObject(source) {
 
 ////////////////////////////////////////////////////////////////
 
-Solution::Solution(_Fact* source_goal) : solution_graph_(), imdl_chain_() {
+Solution::Solution(_Fact* source_goal) : solution_graph_() {
   source_goal_ = source_goal;
 }
 
@@ -1035,21 +1037,74 @@ std::pair<uint16, uint16> Solution::get_complexity(_Fact* f_success) {
 
   milliseconds duration = duration_cast<milliseconds>(before - after);
   float32 strength_avg = strength_sum / mdl_counter;
-  //auto d_before = Utils::RelativeTime(before);
-  //auto d_after = Utils::RelativeTime(after);
+
   return std::pair<uint16, uint16>(args_counter, mdl_counter);
 }
 
-void Solution::build_imdl_chain(_Fact* success_evidence) {
+float32 Solution::get_imdl_complexity(_Fact* f_success) {
+  //build_imdl_chain(f_success);
+
+  float32 score = 0.0f;
+  milliseconds total_duration = duration_cast<milliseconds>(before_ - after_);
+
+  //std::vector<P<MkRdx>>::const_reverse_iterator r_iter;
+  //for (r_iter = imdl_chain_.rbegin(); r_iter != imdl_chain_.rend(); r_iter++) {
+  //  //P<MkRdx> mk_rdx = (*r_iter);
+  //  _Fact* production = (_Fact*)(*r_iter)->get_first_production();
+  //  _Fact* target = production->get_pred()->get_target();
+  //  Mdl* mdl = target->get_imdl()->get_mdl();
+
+  //  Atom args_set = mdl->code(mdl->code(MDL_TPL_ARGS).asIndex());
+  //  uint16 args_count = args_set.getAtomCount() + 1; // + 1 is counting the model itself
+
+  //  milliseconds time_progress = duration_cast<milliseconds>(target->get_before() - after_);
+  //  auto time_weight = duration<float32>(time_progress).count() / duration<float32>(total_duration).count();
+
+  //  score += (args_count * time_weight) / mdl->code(MDL_STRENGTH).asFloat();
+  //}
+
+  _Fact* success_evidence = f_success->get_success()->get_evidence();
   auto found_mk_rdx = solution_graph_.find(success_evidence);
   while (found_mk_rdx != solution_graph_.end()) {
-  	P<MkRdx> mk_rdx = found_mk_rdx->second;
-  	_Fact* production = (_Fact*)mk_rdx->get_first_production();
-  	auto is_imdl = production->get_reference(0)->get_reference(0)->get_reference(0)->code(0).asOpcode() == Opcodes::IMdl;
-    if (is_imdl)
-      imdl_chain_.push_back(mk_rdx);
-  	found_mk_rdx = solution_graph_.find(mk_rdx->get_first_input());
+    P<MkRdx> mk_rdx = found_mk_rdx->second;
+    auto next_item = solution_graph_.find(mk_rdx->get_first_input());
+    
+    _Fact* production = (_Fact*)mk_rdx->get_first_production();
+    _Fact* target = production->get_pred()->get_target();
+    IMdl* imdl = target->get_imdl();
+
+    if (imdl) {
+      Mdl* mdl = imdl->get_mdl();
+      
+      if (mdl->get_lhs_cmd()) {
+        // It's a command model
+        Atom args_set = mdl->code(mdl->code(MDL_TPL_ARGS).asIndex());
+        uint16 args_count = args_set.getAtomCount() + 1; // + 1 is counting the model itself
+
+        milliseconds time_progress = duration_cast<milliseconds>(target->get_before() - after_);
+        auto time_weight = 1 - (duration<float32>(time_progress).count() / duration<float32>(total_duration).count());
+
+        score += (args_count * time_weight) / mdl->code(MDL_SR).asFloat();
+      }
+    }
+    else if (next_item == solution_graph_.end()) {
+      // This is the first prediction of the chain but wasn't an imdl, it's a cmd so get the imdl from 
+      // the "code" field of the mk.rdx
+      _Fact* f_imdl = (_Fact*)mk_rdx->get_reference(0);
+      Mdl* mdl = f_imdl->get_imdl()->get_mdl();
+
+      Atom args_set = mdl->code(mdl->code(MDL_TPL_ARGS).asIndex());
+      uint16 args_count = args_set.getAtomCount() + 1; // + 1 is counting the model itself
+
+      //milliseconds time_progress = duration_cast<milliseconds>(target->get_before() - after_);
+      //auto time_weight = 1 - (duration<float32>(time_progress).count() / duration<float32>(total_duration).count());
+
+      score += (args_count * 1) / mdl->code(MDL_SR).asFloat();
+    }
+    found_mk_rdx = next_item;
   }
+
+  return score;
 }
 
 }

--- a/r_exec/factory.cpp
+++ b/r_exec/factory.cpp
@@ -980,88 +980,14 @@ Mdl::Mdl(SysObject* source) : LObject(source) {
 
 ////////////////////////////////////////////////////////////////
 
-Solution::Solution(_Fact* source_goal) : solution_graph_() {
+Solution::Solution(_Fact* source_goal) : solution_graph_(), unique_mdls_ids_() {
   source_goal_ = source_goal;
 }
 
-std::pair<uint16, uint16> Solution::get_complexity(_Fact* f_success) {
-  uint16 args_counter = 0;
-  uint16 mdl_counter = 0;
-  uint32 unbound_values = 0;
-  float32 strength_sum = 0.0f;
-  Timestamp before = f_success->get_before();
-  Timestamp after = f_success->get_after();
-
-  auto found_mk_rdx = solution_graph_.find(f_success->get_success()->get_evidence());
-  while (found_mk_rdx != solution_graph_.end()) {
-    P<MkRdx> mk_rdx = found_mk_rdx->second;
-    _Fact* f_imdl = (_Fact*)mk_rdx->get_reference(0); // Reduction source (imdl or icst)
-    auto is_imdl = f_imdl->get_reference(0)->code(0).asOpcode() == Opcodes::IMdl;
-    if (is_imdl)
-    {
-      mdl_counter++;
-
-      Mdl* mdl = (Mdl*)f_imdl->get_reference(0)->get_reference(0);
-      BindingMap bm = mk_rdx->bindings_;
-      unbound_values += bm.get_unbound_values();
-
-      if (Mdl* lhs_mdl = mdl->get_lhs_mdl()) {
-        //Atom tpl_args = lhs_mdl->code(MDL_TPL_ARGS);
-        Atom patterns = lhs_mdl->code(MDL_OBJS);
-        //Atom fwd_guards = lhs_mdl->code(MDL_FWD_GUARDS);
-        //Atom strength = lhs_mdl->code(MDL_STRENGTH);
-
-        Atom inner_lhs = lhs_mdl->code(lhs_mdl->code(patterns.asIndex() + 1).asIndex() + 1);
-        auto debug = 0;
-      }
-
-      if (Code* lhs_cmd = mdl->get_lhs_cmd()) {
-        auto d = 0;
-      }
-
-      if (ICST* lhs_icst = mdl->get_lhs_icst()) {
-        auto d = 0;
-      }
-
-      Atom args_set = mdl->code(mdl->code(MDL_TPL_ARGS).asIndex());
-      args_counter += args_set.getAtomCount();
-
-      strength_sum += mdl->code(MDL_STRENGTH).asFloat();
-    }
-
-    _Fact* prod_f = (_Fact*)mk_rdx->get_first_production();
-    after = prod_f->get_pred()->get_target()->get_after();
-
-    found_mk_rdx = solution_graph_.find(mk_rdx->get_first_input());
-  }
-
-  milliseconds duration = duration_cast<milliseconds>(before - after);
-  float32 strength_avg = strength_sum / mdl_counter;
-
-  return std::pair<uint16, uint16>(args_counter, mdl_counter);
-}
-
-float32 Solution::get_imdl_complexity(_Fact* f_success) {
-  //build_imdl_chain(f_success);
-
+float32 Solution::get_solution_score(_Fact* f_success) {
+  unique_mdls_ids_.clear(); // Clear in case multiple successes were predicted in different branches of the same Sim
   float32 score = 0.0f;
-  milliseconds total_duration = duration_cast<milliseconds>(before_ - after_);
-
-  //std::vector<P<MkRdx>>::const_reverse_iterator r_iter;
-  //for (r_iter = imdl_chain_.rbegin(); r_iter != imdl_chain_.rend(); r_iter++) {
-  //  //P<MkRdx> mk_rdx = (*r_iter);
-  //  _Fact* production = (_Fact*)(*r_iter)->get_first_production();
-  //  _Fact* target = production->get_pred()->get_target();
-  //  Mdl* mdl = target->get_imdl()->get_mdl();
-
-  //  Atom args_set = mdl->code(mdl->code(MDL_TPL_ARGS).asIndex());
-  //  uint16 args_count = args_set.getAtomCount() + 1; // + 1 is counting the model itself
-
-  //  milliseconds time_progress = duration_cast<milliseconds>(target->get_before() - after_);
-  //  auto time_weight = duration<float32>(time_progress).count() / duration<float32>(total_duration).count();
-
-  //  score += (args_count * time_weight) / mdl->code(MDL_STRENGTH).asFloat();
-  //}
+  milliseconds total_duration = duration_cast<milliseconds>(f_success->get_before() - after_);
 
   _Fact* success_evidence = f_success->get_success()->get_evidence();
   auto found_mk_rdx = solution_graph_.find(success_evidence);
@@ -1071,40 +997,75 @@ float32 Solution::get_imdl_complexity(_Fact* f_success) {
     
     _Fact* production = (_Fact*)mk_rdx->get_first_production();
     _Fact* target = production->get_pred()->get_target();
-    IMdl* imdl = target->get_imdl();
 
+    IMdl* imdl = target->get_imdl();
     if (imdl) {
       Mdl* mdl = imdl->get_mdl();
-      
-      if (mdl->get_lhs_cmd()) {
-        // It's a command model
-        Atom args_set = mdl->code(mdl->code(MDL_TPL_ARGS).asIndex());
-        uint16 args_count = args_set.getAtomCount() + 1; // + 1 is counting the model itself
-
-        milliseconds time_progress = duration_cast<milliseconds>(target->get_before() - after_);
-        auto time_weight = 1 - (duration<float32>(time_progress).count() / duration<float32>(total_duration).count());
-
-        score += (args_count * time_weight) / mdl->code(MDL_SR).asFloat();
+      if (mdl->get_lhs()->code(0).asOpcode() == Opcodes::MkVal && mdl->get_rhs()->code(0).asOpcode() == Opcodes::MkVal) {
+        // This model describes something "automatic" that is happening, so don't count it
+        found_mk_rdx = next_item;
+        continue;
       }
+
+      unique_mdls_ids_.insert(mdl->get_oid());
+      
+      Atom args_set = imdl->code(imdl->code(I_HLP_TPL_ARGS).asIndex());
+      Atom exp_args_set = imdl->code(imdl->code(I_HLP_EXPOSED_ARGS).asIndex());
+
+      uint32 args_count = args_set.getAtomCount();
+      args_count += exp_args_set.getAtomCount();
+      //args_count += imdl->count_unbound_args(); // Unbound variables are counted twice
+
+      milliseconds time_progress = duration_cast<milliseconds>(target->get_before() - after_);
+      auto time_weight = 1 - (duration<float32>(time_progress).count() / duration<float32>(total_duration).count());
+
+      score += (args_count * time_weight) / mdl->code(MDL_SR).asFloat();
     }
-    else if (next_item == solution_graph_.end()) {
-      // This is the first prediction of the chain but wasn't an imdl, it's a cmd so get the imdl from 
-      // the "code" field of the mk.rdx
-      _Fact* f_imdl = (_Fact*)mk_rdx->get_reference(0);
-      Mdl* mdl = f_imdl->get_imdl()->get_mdl();
+    else if (imdl = ((_Fact*)mk_rdx->get_reference(0))->get_imdl()) {
+     // Sometimes imdls are not produced as facts but they are only used to make a prediction
+      Mdl* mdl = imdl->get_mdl();
+      if (mdl->get_lhs()->code(0).asOpcode() == Opcodes::MkVal && mdl->get_rhs()->code(0).asOpcode() == Opcodes::MkVal) {
+        // This model describes something "automatic" that is happening, so don't count it
+        found_mk_rdx = next_item;
+        continue;
+      }
 
-      Atom args_set = mdl->code(mdl->code(MDL_TPL_ARGS).asIndex());
-      uint16 args_count = args_set.getAtomCount() + 1; // + 1 is counting the model itself
+      unique_mdls_ids_.insert(mdl->get_oid());
 
-      //milliseconds time_progress = duration_cast<milliseconds>(target->get_before() - after_);
-      //auto time_weight = 1 - (duration<float32>(time_progress).count() / duration<float32>(total_duration).count());
+      Atom args_set = imdl->code(imdl->code(I_HLP_TPL_ARGS).asIndex());
+      Atom exp_args_set = imdl->code(imdl->code(I_HLP_EXPOSED_ARGS).asIndex());
 
-      score += (args_count * 1) / mdl->code(MDL_SR).asFloat();
+      uint32 args_count = args_set.getAtomCount();
+      args_count += exp_args_set.getAtomCount();
+      //args_count += imdl->count_unbound_args(); // Unbound variables are counted twice
+
+      milliseconds time_progress = duration_cast<milliseconds>(target->get_before() - after_);
+      auto time_weight = 1 - (duration<float32>(time_progress).count() / duration<float32>(total_duration).count());
+
+      score += (args_count * time_weight) / mdl->code(MDL_SR).asFloat();
     }
+  //  else if (next_item == solution_graph_.end()) {
+  //    // This is the first prediction of the chain but wasn't an imdl, it's a cmd so get the imdl from 
+  //    // the "code" field of the mk.rdx
+  //    _Fact* f_imdl = (_Fact*)mk_rdx->get_reference(0);
+  //    imdl = f_imdl->get_imdl();
+  //    Mdl* mdl = imdl->get_mdl();
+  //    unique_mdls_ids_.insert(mdl->get_oid());
+
+  //    Atom args_set = imdl->code(imdl->code(I_HLP_TPL_ARGS).asIndex());
+  //    Atom exp_args_set = imdl->code(imdl->code(I_HLP_EXPOSED_ARGS).asIndex());
+
+  //    uint32 args_count = args_set.getAtomCount();
+  //    args_count += exp_args_set.getAtomCount();
+  //    //args_count += imdl->count_unbound_args(); // Unbound variables are counted twice
+
+  //    score += (args_count * 1) / mdl->code(MDL_SR).asFloat();
+  //    score += imdl->count_unbound_args() * 1000; // Workaround to prevent executing commands with unbound variables
+  //  }
     found_mk_rdx = next_item;
   }
 
-  return score;
+  return score + unique_mdls_ids_.size();
 }
 
 }

--- a/r_exec/factory.cpp
+++ b/r_exec/factory.cpp
@@ -713,6 +713,8 @@ Sim::Sim(Sim *s) : root_(s->root_), solution_controller_(s->solution_controller_
     code(i) = s->code(i);
   for (uint16 i = 0; i < s->references_size(); ++i)
     add_reference(s->get_reference(i));
+
+  solution_ = NULL;
 }
 
 Sim::Sim(SimMode mode, microseconds thz, Fact *super_goal, bool opposite, Controller *root, float32 psln_thr, Controller *solution_controller,
@@ -746,6 +748,8 @@ Sim::Sim(SimMode mode, microseconds thz, Fact *super_goal, bool opposite, Contro
 
   Utils::SetDuration<Code>(this, SIM_THZ, thz);
   Utils::SetTimestamp<Code>(this, SIM_SOLUTION_BEFORE, solution_before);
+  
+  solution_ = NULL;
 }
 
 bool Sim::invalidate() {
@@ -768,68 +772,6 @@ bool Sim::is_invalidated() {
     return true;
   }
   return false;
-}
-
-uint32 Sim::count_super_goal_chain() const {
-  Sim* super_goal_sim = get_f_super_goal()->get_goal()->get_sim();
-  if (super_goal_sim == NULL)
-    return 0;
-
-  return super_goal_sim->count_super_goal_chain() + 1;
-}
-
-std::pair<uint16, uint16> Sim::get_solution_mdl_count(_Fact* f_success) {
-  uint16 args_counter = 0;
-  uint16 mdl_counter = 0;
-  uint32 unbound_values = 0;
-  Timestamp before = f_success->get_before();
-  Timestamp after = f_success->get_after();
-
-  auto found_mk_rdx = solution_graph_.find(f_success->get_success()->get_evidence());
-  while (found_mk_rdx != solution_graph_.end()) {
-    P<MkRdx> mk_rdx = found_mk_rdx->second;
-    _Fact* f_imdl = (_Fact*)mk_rdx->get_reference(0); // Reduction source (imdl or icst)
-    auto is_imdl = f_imdl->get_reference(0)->code(0).asOpcode() == Opcodes::IMdl;
-    if (is_imdl)
-    {
-      mdl_counter++;
-
-      Mdl* mdl = (Mdl*)f_imdl->get_reference(0)->get_reference(0);
-      BindingMap bm = mk_rdx->bindings_;
-      unbound_values += bm.get_unbound_values();
-      
-      if (Mdl* lhs_mdl = mdl->get_lhs_mdl()) {
-        //Atom tpl_args = lhs_mdl->code(MDL_TPL_ARGS);
-        Atom patterns = lhs_mdl->code(MDL_OBJS);
-        //Atom fwd_guards = lhs_mdl->code(MDL_FWD_GUARDS);
-        //Atom strength = lhs_mdl->code(MDL_STRENGTH);
-
-        Atom inner_lhs = lhs_mdl->code(lhs_mdl->code(patterns.asIndex() + 1).asIndex() + 1);
-        auto debug = 0;
-      }
-
-      if (Code* lhs_cmd = mdl->get_lhs_cmd()) {
-        auto d = 0;
-      }
-
-      if (ICST* lhs_icst = mdl->get_lhs_icst()) {
-        auto d = 0;
-      }
-
-      Atom args_set = mdl->code(mdl->code(MDL_TPL_ARGS).asIndex());
-      args_counter += args_set.getAtomCount();
-    }
-
-    _Fact* prod_f = (_Fact*)mk_rdx->get_first_production();
-    after = prod_f->get_pred()->get_target()->get_after();
-
-    found_mk_rdx = solution_graph_.find(mk_rdx->get_first_input());
-  }
-
-  milliseconds duration = duration_cast<milliseconds>(before - after);
-  //auto d_before = Utils::RelativeTime(before);
-  //auto d_after = Utils::RelativeTime(after);
-  return std::pair<uint16, uint16>(args_counter, mdl_counter);
 }
 
 Sim* Sim::get_root_sim()
@@ -1028,9 +970,86 @@ IMdl::IMdl(SysObject* source) : LObject(source) {
 }
 
 Mdl::Mdl() : LObject() {
+  code(0) = Atom::Model(Opcodes::Mdl, MDL_ARITY);
 }
 
 Mdl::Mdl(SysObject* source) : LObject(source) {
+}
+
+////////////////////////////////////////////////////////////////
+
+Solution::Solution(_Fact* source_goal) : solution_graph_(), imdl_chain_() {
+  source_goal_ = source_goal;
+}
+
+std::pair<uint16, uint16> Solution::get_complexity(_Fact* f_success) {
+  uint16 args_counter = 0;
+  uint16 mdl_counter = 0;
+  uint32 unbound_values = 0;
+  float32 strength_sum = 0.0f;
+  Timestamp before = f_success->get_before();
+  Timestamp after = f_success->get_after();
+
+  auto found_mk_rdx = solution_graph_.find(f_success->get_success()->get_evidence());
+  while (found_mk_rdx != solution_graph_.end()) {
+    P<MkRdx> mk_rdx = found_mk_rdx->second;
+    _Fact* f_imdl = (_Fact*)mk_rdx->get_reference(0); // Reduction source (imdl or icst)
+    auto is_imdl = f_imdl->get_reference(0)->code(0).asOpcode() == Opcodes::IMdl;
+    if (is_imdl)
+    {
+      mdl_counter++;
+
+      Mdl* mdl = (Mdl*)f_imdl->get_reference(0)->get_reference(0);
+      BindingMap bm = mk_rdx->bindings_;
+      unbound_values += bm.get_unbound_values();
+
+      if (Mdl* lhs_mdl = mdl->get_lhs_mdl()) {
+        //Atom tpl_args = lhs_mdl->code(MDL_TPL_ARGS);
+        Atom patterns = lhs_mdl->code(MDL_OBJS);
+        //Atom fwd_guards = lhs_mdl->code(MDL_FWD_GUARDS);
+        //Atom strength = lhs_mdl->code(MDL_STRENGTH);
+
+        Atom inner_lhs = lhs_mdl->code(lhs_mdl->code(patterns.asIndex() + 1).asIndex() + 1);
+        auto debug = 0;
+      }
+
+      if (Code* lhs_cmd = mdl->get_lhs_cmd()) {
+        auto d = 0;
+      }
+
+      if (ICST* lhs_icst = mdl->get_lhs_icst()) {
+        auto d = 0;
+      }
+
+      Atom args_set = mdl->code(mdl->code(MDL_TPL_ARGS).asIndex());
+      args_counter += args_set.getAtomCount();
+
+      strength_sum += mdl->code(MDL_STRENGTH).asFloat();
+    }
+
+    _Fact* prod_f = (_Fact*)mk_rdx->get_first_production();
+    after = prod_f->get_pred()->get_target()->get_after();
+
+    found_mk_rdx = solution_graph_.find(mk_rdx->get_first_input());
+  }
+
+  milliseconds duration = duration_cast<milliseconds>(before - after);
+  float32 strength_avg = strength_sum / mdl_counter;
+  //auto d_before = Utils::RelativeTime(before);
+  //auto d_after = Utils::RelativeTime(after);
+  return std::pair<uint16, uint16>(args_counter, mdl_counter);
+}
+
+void Solution::build_imdl_chain(_Fact* success_evidence) {
+  auto found_mk_rdx = solution_graph_.find(success_evidence);
+  while (found_mk_rdx != solution_graph_.end()) {
+  	P<MkRdx> mk_rdx = found_mk_rdx->second;
+  	_Fact* production = (_Fact*)mk_rdx->get_first_production();
+  	auto is_imdl = production->get_reference(0)->get_reference(0)->get_reference(0)->code(0).asOpcode() == Opcodes::IMdl;
+    if (is_imdl)
+      imdl_chain_.push_back(mk_rdx);
+  	found_mk_rdx = solution_graph_.find(mk_rdx->get_first_input());
+  }
 }
 
 }

--- a/r_exec/factory.cpp
+++ b/r_exec/factory.cpp
@@ -778,18 +778,58 @@ uint32 Sim::count_super_goal_chain() const {
   return super_goal_sim->count_super_goal_chain() + 1;
 }
 
-float32 Sim::get_solution_mdl_count(Success* success) {
-  uint32 counter = 0;
-  auto found_mk_rdx = solution_graph_.find(success->get_evidence());
+std::pair<uint16, uint16> Sim::get_solution_mdl_count(_Fact* f_success) {
+  uint16 args_counter = 0;
+  uint16 mdl_counter = 0;
+  uint32 unbound_values = 0;
+  Timestamp before = f_success->get_before();
+  Timestamp after = f_success->get_after();
+
+  auto found_mk_rdx = solution_graph_.find(f_success->get_success()->get_evidence());
   while (found_mk_rdx != solution_graph_.end()) {
     P<MkRdx> mk_rdx = found_mk_rdx->second;
-    _Fact* code = (_Fact*)mk_rdx->get_reference(0);
-    auto is_imdl = code->get_reference(0)->code(0).asOpcode() == Opcodes::IMdl;
+    _Fact* f_imdl = (_Fact*)mk_rdx->get_reference(0); // Reduction source (imdl or icst)
+    auto is_imdl = f_imdl->get_reference(0)->code(0).asOpcode() == Opcodes::IMdl;
     if (is_imdl)
-      counter++;
+    {
+      mdl_counter++;
+
+      Mdl* mdl = (Mdl*)f_imdl->get_reference(0)->get_reference(0);
+      BindingMap bm = mk_rdx->bindings_;
+      unbound_values += bm.get_unbound_values();
+      
+      if (Mdl* lhs_mdl = mdl->get_lhs_mdl()) {
+        //Atom tpl_args = lhs_mdl->code(MDL_TPL_ARGS);
+        Atom patterns = lhs_mdl->code(MDL_OBJS);
+        //Atom fwd_guards = lhs_mdl->code(MDL_FWD_GUARDS);
+        //Atom strength = lhs_mdl->code(MDL_STRENGTH);
+
+        Atom inner_lhs = lhs_mdl->code(lhs_mdl->code(patterns.asIndex() + 1).asIndex() + 1);
+        auto debug = 0;
+      }
+
+      if (Code* lhs_cmd = mdl->get_lhs_cmd()) {
+        auto d = 0;
+      }
+
+      if (ICST* lhs_icst = mdl->get_lhs_icst()) {
+        auto d = 0;
+      }
+
+      Atom args_set = mdl->code(mdl->code(MDL_TPL_ARGS).asIndex());
+      args_counter += args_set.getAtomCount();
+    }
+
+    _Fact* prod_f = (_Fact*)mk_rdx->get_first_production();
+    after = prod_f->get_pred()->get_target()->get_after();
+
     found_mk_rdx = solution_graph_.find(mk_rdx->get_first_input());
   }
-  return counter;
+
+  milliseconds duration = duration_cast<milliseconds>(before - after);
+  //auto d_before = Utils::RelativeTime(before);
+  //auto d_after = Utils::RelativeTime(after);
+  return std::pair<uint16, uint16>(args_counter, mdl_counter);
 }
 
 Sim* Sim::get_root_sim()
@@ -977,6 +1017,20 @@ bool ICST::r_contains(const _Fact* component) const {
   }
 
   return false;
+}
+
+////////////////////////////////////////////////////////////////
+
+IMdl::IMdl() : LObject() {
+}
+
+IMdl::IMdl(SysObject* source) : LObject(source) {
+}
+
+Mdl::Mdl() : LObject() {
+}
+
+Mdl::Mdl(SysObject* source) : LObject(source) {
 }
 
 }

--- a/r_exec/factory.h
+++ b/r_exec/factory.h
@@ -278,14 +278,6 @@ public:
   float32 get_solution_cfd() const { return code(SIM_SOLUTION_CFD).asFloat(); }
 
   /**
-  * Counts how long is the backward chain that led to this simulation by tracing back
-  * super goals up to the drive.
-  */
-  uint32 count_super_goal_chain() const;
-
-  std::pair<uint16, uint16> get_solution_mdl_count(_Fact* f_success);
-
-  /**
    * Get the  deadline of the solution goal.
    */
   Timestamp get_solution_before() const { return r_code::Utils::GetTimestamp<Code>(this, SIM_SOLUTION_BEFORE); }
@@ -358,9 +350,7 @@ public:
   // A list of (fact (pred (fact (cmd ::)))) to check if a command has already been signalled in this sim.
   std::vector<P<_Fact> > already_signalled_;
 
-  // The graph of predictions made in this simulation, referenced by their reduction markers.
-  // A reduction rdx1 is stored at key rdx1.out (the first production), the previous object in the chain is at rdx1.in (the first input).
-  std::unordered_map<r_code::Code*, P<MkRdx>> solution_graph_;
+  Solution* solution_;
 
 private:
   std::vector<P<_Fact> > goalTargets_;
@@ -705,10 +695,17 @@ public:
     return NULL;
   }
 
-  Code* get_lhs_cmd() const { // TODO: Create Cmd class
+  Code* get_lhs_cmd() const {
     Code* lhs = get_reference(0);
     if (lhs->code(0).asOpcode() == Opcodes::Cmd)
       return lhs;
+
+    // Get unpacked model
+    lhs = get_reference(references_size() - MDL_HIDDEN_REFS)->get_reference(0);
+    if (lhs->code(0).asOpcode() == Opcodes::Fact 
+      && lhs->get_reference(0)->code(0).asOpcode() == Opcodes::Cmd)
+      return lhs->get_reference(0);
+    
     return NULL;
   }
 
@@ -725,6 +722,48 @@ class r_exec_dll IMdl :
 public:
   IMdl();
   IMdl(r_code::SysObject* source);
+
+  Mdl* get_mdl() const {
+    Code* mdl = get_reference(0); // Could use code(I_HLP_OBJ).asIndex()
+    if (mdl->code(0).asOpcode() == Opcodes::Mdl)
+      return (Mdl*)mdl;
+    return NULL;
+  }
+};
+
+
+class r_exec_dll Solution {
+public:
+  Solution(_Fact* source_goal);
+
+  void add_mk_rdx(P<MkRdx> mk_rdx) {
+    solution_graph_[mk_rdx->get_first_production()] = mk_rdx;
+  }
+
+  /**
+  * Returns the drive goal of this solution by following the chain from the source goal.
+  */
+  _Fact* get_drive() const {
+    _Fact* drive = source_goal_;
+    while (drive->get_goal()->get_super_goal()->get_goal()->has_sim()) {
+      drive = drive->get_goal()->get_super_goal();
+    }
+    return drive;
+  }
+
+  std::pair<uint16, uint16> get_complexity(_Fact* f_success);
+
+  void build_imdl_chain(_Fact* success_evidence);
+
+  // The sub-goal that started the forward chain for this solution (structured as f->g->f->obj).
+  _Fact* source_goal_;
+
+  // The graph of predictions that make up the solution, referenced by their reduction markers.
+  // A marker rdx1 is stored at key rdx1.out (the first production), the previous object in the chain is at rdx1.in (the first input).
+  std::unordered_map<r_code::Code*, P<MkRdx>> solution_graph_;
+
+  std::vector<P<MkRdx>> imdl_chain_;
+};
 };
 }
 

--- a/r_exec/factory.h
+++ b/r_exec/factory.h
@@ -151,6 +151,8 @@ class Pred;
 class Goal;
 class Success;
 class MkRdx;
+class Solution;
+class IMdl;
 
 class r_exec_dll _Fact :
   public LObject {
@@ -233,6 +235,12 @@ public:
     Code *success = get_reference(0);
     if (success->code(0).asOpcode() == Opcodes::Success)
       return (Success *)success;
+    return NULL;
+  }
+  IMdl* get_imdl() const {
+    Code* imdl = get_reference(0);
+    if (imdl->code(0).asOpcode() == Opcodes::IMdl)
+      return (IMdl*)imdl;
     return NULL;
   }
 
@@ -752,8 +760,7 @@ public:
   }
 
   std::pair<uint16, uint16> get_complexity(_Fact* f_success);
-
-  void build_imdl_chain(_Fact* success_evidence);
+  float32 get_imdl_complexity(_Fact* f_success);
 
   // The sub-goal that started the forward chain for this solution (structured as f->g->f->obj).
   _Fact* source_goal_;
@@ -762,8 +769,10 @@ public:
   // A marker rdx1 is stored at key rdx1.out (the first production), the previous object in the chain is at rdx1.in (the first input).
   std::unordered_map<r_code::Code*, P<MkRdx>> solution_graph_;
 
-  std::vector<P<MkRdx>> imdl_chain_;
-};
+  // Set when the first prediction is added.
+  Timestamp after_;
+  // Set when a success is created.
+  Timestamp before_;
 };
 }
 

--- a/r_exec/factory.h
+++ b/r_exec/factory.h
@@ -283,7 +283,7 @@ public:
   */
   uint32 count_super_goal_chain() const;
 
-  float32 get_solution_mdl_count(Success* success);
+  std::pair<uint16, uint16> get_solution_mdl_count(_Fact* f_success);
 
   /**
    * Get the  deadline of the solution goal.
@@ -359,7 +359,7 @@ public:
   std::vector<P<_Fact> > already_signalled_;
 
   // The graph of predictions made in this simulation, referenced by their reduction markers.
-  // Keys are the outputs of the reductions, for tracing back from the success object.
+  // A reduction rdx1 is stored at key rdx1.out (the first production), the previous object in the chain is at rdx1.in (the first input).
   std::unordered_map<r_code::Code*, P<MkRdx>> solution_graph_;
 
 private:
@@ -690,6 +690,41 @@ public:
 
   P<BindingMap> bindings_;
   std::vector<P<_Fact> > components_; // the inputs that triggered the building of the icst.
+};
+
+class r_exec_dll Mdl :
+  public LObject {
+public:
+  Mdl();
+  Mdl(r_code::SysObject* source);
+
+  Mdl* get_lhs_mdl() const {
+    Code* lhs = get_reference(0);
+    if (lhs->code(0).asOpcode() == Opcodes::Mdl)
+      return (Mdl*)lhs;
+    return NULL;
+  }
+
+  Code* get_lhs_cmd() const { // TODO: Create Cmd class
+    Code* lhs = get_reference(0);
+    if (lhs->code(0).asOpcode() == Opcodes::Cmd)
+      return lhs;
+    return NULL;
+  }
+
+  ICST* get_lhs_icst() const {
+    Code* lhs = get_reference(0);
+    if (lhs->code(0).asOpcode() == Opcodes::ICst)
+      return (ICST*)lhs;
+    return NULL;
+  }
+};
+
+class r_exec_dll IMdl :
+  public LObject {
+public:
+  IMdl();
+  IMdl(r_code::SysObject* source);
 };
 }
 

--- a/r_exec/factory.h
+++ b/r_exec/factory.h
@@ -150,6 +150,7 @@ public:
 class Pred;
 class Goal;
 class Success;
+class MkRdx;
 
 class r_exec_dll _Fact :
   public LObject {
@@ -277,6 +278,14 @@ public:
   float32 get_solution_cfd() const { return code(SIM_SOLUTION_CFD).asFloat(); }
 
   /**
+  * Counts how long is the backward chain that led to this simulation by tracing back
+  * super goals up to the drive.
+  */
+  uint32 count_super_goal_chain() const;
+
+  float32 get_solution_mdl_count(Success* success);
+
+  /**
    * Get the  deadline of the solution goal.
    */
   Timestamp get_solution_before() const { return r_code::Utils::GetTimestamp<Code>(this, SIM_SOLUTION_BEFORE); }
@@ -348,6 +357,10 @@ public:
 
   // A list of (fact (pred (fact (cmd ::)))) to check if a command has already been signalled in this sim.
   std::vector<P<_Fact> > already_signalled_;
+
+  // The graph of predictions made in this simulation, referenced by their reduction markers.
+  // Keys are the outputs of the reductions, for tracing back from the success object.
+  std::unordered_map<r_code::Code*, P<MkRdx>> solution_graph_;
 
 private:
   std::vector<P<_Fact> > goalTargets_;

--- a/r_exec/factory.h
+++ b/r_exec/factory.h
@@ -696,15 +696,41 @@ public:
   Mdl();
   Mdl(r_code::SysObject* source);
 
+  Code* get_lhs() const {
+    Code* unpacked_mdl = get_reference(references_size() - MDL_HIDDEN_REFS);
+    
+    if (unpacked_mdl->code(0).asOpcode() == Opcodes::Mdl) {
+      uint16 patterns_set_index = unpacked_mdl->code(MDL_OBJS).asIndex();
+      return unpacked_mdl->get_reference(unpacked_mdl->code(patterns_set_index + 1).asIndex());
+    }
+    else {
+      uint16 patterns_set_index = code(MDL_OBJS).asIndex();
+      return get_reference(code(patterns_set_index + 1).asIndex());
+    }
+  }
+
+  Code* get_rhs() const {
+    Code* unpacked_mdl = get_reference(references_size() - MDL_HIDDEN_REFS);
+
+    if (unpacked_mdl->code(0).asOpcode() == Opcodes::Mdl) {
+      uint16 patterns_set_index = unpacked_mdl->code(MDL_OBJS).asIndex();
+      return unpacked_mdl->get_reference(unpacked_mdl->code(patterns_set_index + 2).asIndex());
+    }
+    else {
+      uint16 patterns_set_index = code(MDL_OBJS).asIndex();
+      return get_reference(code(patterns_set_index + 2).asIndex());
+    }
+  }
+
   Mdl* get_lhs_mdl() const {
-    Code* lhs = get_reference(0);
+    Code* lhs = get_lhs();
     if (lhs->code(0).asOpcode() == Opcodes::Mdl)
       return (Mdl*)lhs;
     return NULL;
   }
 
   Code* get_lhs_cmd() const {
-    Code* lhs = get_reference(0);
+    Code* lhs = get_lhs();
     if (lhs->code(0).asOpcode() == Opcodes::Cmd)
       return lhs;
 
@@ -718,7 +744,7 @@ public:
   }
 
   ICST* get_lhs_icst() const {
-    Code* lhs = get_reference(0);
+    Code* lhs = get_lhs();
     if (lhs->code(0).asOpcode() == Opcodes::ICst)
       return (ICST*)lhs;
     return NULL;
@@ -736,6 +762,27 @@ public:
     if (mdl->code(0).asOpcode() == Opcodes::Mdl)
       return (Mdl*)mdl;
     return NULL;
+  }
+
+  uint32 count_unbound_args() const {
+    uint32 unbound_args_count = 0;
+
+    uint16 args_index = code(I_HLP_TPL_ARGS).asIndex();
+    uint16 exp_args_index = code(I_HLP_EXPOSED_ARGS).asIndex();
+    Atom args_set = code(args_index);
+    Atom exp_args_set = code(exp_args_index);
+
+    for (int i = 1; i < args_set.getAtomCount(); i++) {
+      if (code(args_index + i).getDescriptor() == Atom::VL_PTR)
+        unbound_args_count++;
+    }
+
+    for (int i = 1; i < exp_args_set.getAtomCount(); i++) {
+      if (code(exp_args_index + i).getDescriptor() == Atom::VL_PTR)
+        unbound_args_count++;
+    }
+
+    return unbound_args_count;
   }
 };
 
@@ -759,8 +806,7 @@ public:
     return drive;
   }
 
-  std::pair<uint16, uint16> get_complexity(_Fact* f_success);
-  float32 get_imdl_complexity(_Fact* f_success);
+  float32 get_solution_score(_Fact* f_success);
 
   // The sub-goal that started the forward chain for this solution (structured as f->g->f->obj).
   _Fact* source_goal_;
@@ -768,6 +814,8 @@ public:
   // The graph of predictions that make up the solution, referenced by their reduction markers.
   // A marker rdx1 is stored at key rdx1.out (the first production), the previous object in the chain is at rdx1.in (the first input).
   std::unordered_map<r_code::Code*, P<MkRdx>> solution_graph_;
+  // The IDs of the models in the solution
+  std::unordered_set<uint32> unique_mdls_ids_;
 
   // Set when the first prediction is added.
   Timestamp after_;

--- a/r_exec/g_monitor.cpp
+++ b/r_exec/g_monitor.cpp
@@ -226,7 +226,7 @@ void GMonitor::commit() { // the purpose is to invalidate damaging simulations; 
 
   _Fact* best_solution_f_p_f_success = NULL;
   Sim *best_solution = NULL;
-  std::pair<uint16, uint16> best_solution_complexity;
+  float32 best_solution_complexity;
   // Find the best optional solution.
   for (solution = sim_successes_.optional_solutions.begin(); solution != sim_successes_.optional_solutions.end(); ++solution) {
 
@@ -237,12 +237,12 @@ void GMonitor::commit() { // the purpose is to invalidate damaging simulations; 
     if (!best_solution) {
       best_solution_f_p_f_success = (*solution).first;
       best_solution = (*solution).second;
-      best_solution_complexity = best_solution->solution_->get_complexity(best_solution_f_p_f_success->get_pred()->get_target());
+      best_solution_complexity = best_solution->solution_->get_imdl_complexity(best_solution_f_p_f_success->get_pred()->get_target());
     }
     else {
 
       //auto debug5 = Utils::RelativeTime(now);
-      auto other_solution_complexity = (*solution).second->solution_->get_complexity(best_solution_f_p_f_success->get_pred()->get_target());
+      auto other_solution_complexity = solution->second->solution_->get_imdl_complexity(solution->first->get_pred()->get_target());
       if (other_solution_complexity < best_solution_complexity) {
         best_solution_f_p_f_success = (*solution).first;
         best_solution = (*solution).second;

--- a/r_exec/g_monitor.cpp
+++ b/r_exec/g_monitor.cpp
@@ -242,8 +242,8 @@ void GMonitor::commit() { // the purpose is to invalidate damaging simulations; 
       //auto debug5 = Utils::RelativeTime(now);
       //float32 best_count = best_solution->get_solution_mdl_count();
       //float32 other_count = (*solution).second->get_solution_mdl_count();
-      float32 best_count = best_solution->get_solution_mdl_count(best_solution_f_p_f_success->get_pred()->get_target()->get_success());
-      float32 other_count = (*solution).second->get_solution_mdl_count((*solution).first->get_pred()->get_target()->get_success());
+      auto best_count = best_solution->get_solution_mdl_count(best_solution_f_p_f_success->get_pred()->get_target());
+      auto other_count = (*solution).second->get_solution_mdl_count((*solution).first->get_pred()->get_target());
       if (other_count < best_count) {
         best_solution_f_p_f_success = (*solution).first;
         best_solution = (*solution).second;

--- a/r_exec/g_monitor.cpp
+++ b/r_exec/g_monitor.cpp
@@ -226,7 +226,7 @@ void GMonitor::commit() { // the purpose is to invalidate damaging simulations; 
 
   _Fact* best_solution_f_p_f_success = NULL;
   Sim *best_solution = NULL;
-  float32 best_solution_complexity;
+  float32 best_solution_score;
   // Find the best optional solution.
   for (solution = sim_successes_.optional_solutions.begin(); solution != sim_successes_.optional_solutions.end(); ++solution) {
 
@@ -237,16 +237,17 @@ void GMonitor::commit() { // the purpose is to invalidate damaging simulations; 
     if (!best_solution) {
       best_solution_f_p_f_success = (*solution).first;
       best_solution = (*solution).second;
-      best_solution_complexity = best_solution->solution_->get_imdl_complexity(best_solution_f_p_f_success->get_pred()->get_target());
+      best_solution_score = best_solution->solution_->get_solution_score(best_solution_f_p_f_success->get_pred()->get_target());
+      std::cout << "Score of solution for success " << best_solution_f_p_f_success->get_detail_oid() << " is " << best_solution_score << std::endl;
     }
     else {
-
-      //auto debug5 = Utils::RelativeTime(now);
-      auto other_solution_complexity = solution->second->solution_->get_imdl_complexity(solution->first->get_pred()->get_target());
-      if (other_solution_complexity < best_solution_complexity) {
+      
+      auto other_solution_score = (*solution).second->solution_->get_solution_score((*solution).first->get_pred()->get_target());
+      std::cout << "Score of solution for success " << (*solution).first->get_detail_oid() << " is " << other_solution_score << std::endl;
+      if (other_solution_score < best_solution_score) {
         best_solution_f_p_f_success = (*solution).first;
         best_solution = (*solution).second;
-        best_solution_complexity = other_solution_complexity;
+        best_solution_score = other_solution_score;
       }
     }
   }
@@ -254,6 +255,7 @@ void GMonitor::commit() { // the purpose is to invalidate damaging simulations; 
   invalidate_sim_outcomes(); // this stops any further propagation of the goal simulation.
 
   if (best_solution) {
+    std::cout << "Score of best solution for success " << best_solution_f_p_f_success->get_detail_oid() << " is " << best_solution_score << std::endl;
 
     ((PrimaryMDLController *)best_solution->solution_controller_)->abduce_no_simulation(
       best_solution->get_f_super_goal(), best_solution->get_opposite(), goal_target_->get_cfd(), best_solution_f_p_f_success);

--- a/r_exec/g_monitor.cpp
+++ b/r_exec/g_monitor.cpp
@@ -239,9 +239,12 @@ void GMonitor::commit() { // the purpose is to invalidate damaging simulations; 
     }
     else {
 
-      float32 s = (*solution).second->get_solution_cfd() / duration_cast<microseconds>((*solution).second->get_solution_before() - now).count();
-      float32 _s = best_solution->get_solution_cfd() / duration_cast<microseconds>(best_solution->get_solution_before() - now).count();
-      if (s > _s) {
+      //auto debug5 = Utils::RelativeTime(now);
+      //float32 best_count = best_solution->get_solution_mdl_count();
+      //float32 other_count = (*solution).second->get_solution_mdl_count();
+      float32 best_count = best_solution->get_solution_mdl_count(best_solution_f_p_f_success->get_pred()->get_target()->get_success());
+      float32 other_count = (*solution).second->get_solution_mdl_count((*solution).first->get_pred()->get_target()->get_success());
+      if (other_count < best_count) {
         best_solution_f_p_f_success = (*solution).first;
         best_solution = (*solution).second;
       }

--- a/r_exec/g_monitor.cpp
+++ b/r_exec/g_monitor.cpp
@@ -226,6 +226,7 @@ void GMonitor::commit() { // the purpose is to invalidate damaging simulations; 
 
   _Fact* best_solution_f_p_f_success = NULL;
   Sim *best_solution = NULL;
+  std::pair<uint16, uint16> best_solution_complexity;
   // Find the best optional solution.
   for (solution = sim_successes_.optional_solutions.begin(); solution != sim_successes_.optional_solutions.end(); ++solution) {
 
@@ -236,17 +237,16 @@ void GMonitor::commit() { // the purpose is to invalidate damaging simulations; 
     if (!best_solution) {
       best_solution_f_p_f_success = (*solution).first;
       best_solution = (*solution).second;
+      best_solution_complexity = best_solution->solution_->get_complexity(best_solution_f_p_f_success->get_pred()->get_target());
     }
     else {
 
       //auto debug5 = Utils::RelativeTime(now);
-      //float32 best_count = best_solution->get_solution_mdl_count();
-      //float32 other_count = (*solution).second->get_solution_mdl_count();
-      auto best_count = best_solution->get_solution_mdl_count(best_solution_f_p_f_success->get_pred()->get_target());
-      auto other_count = (*solution).second->get_solution_mdl_count((*solution).first->get_pred()->get_target());
-      if (other_count < best_count) {
+      auto other_solution_complexity = (*solution).second->solution_->get_complexity(best_solution_f_p_f_success->get_pred()->get_target());
+      if (other_solution_complexity < best_solution_complexity) {
         best_solution_f_p_f_success = (*solution).first;
         best_solution = (*solution).second;
+        best_solution_complexity = other_solution_complexity;
       }
     }
   }

--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1467,6 +1467,9 @@ void PMDLController::inject_simulated_goal_success(Fact *goal, bool success, _Fa
   _Mem::Get()->inject(view); // inject in the primary group.
   OUTPUT_LINE(MDL_OUT, Utils::RelativeTime(Now()) << " mdl " << get_object()->get_oid() << ": fact " <<
     evidence->get_oid() << " pred -> fact " << f_pred->get_oid() << " simulated pred");
+
+  //MkRdx* mk_rdx = new MkRdx(goal->get_goal()->get_target(), (Code*)evidence, f_success_object, 1, bm);
+  //inject_notification_into_out_groups(get_host(), mk_rdx);
 }
 
 void TopLevelMDLController::register_simulated_goal_outcome(Fact* goal, bool success, _Fact* evidence) const { // evidence is a simulated prediction.
@@ -1637,6 +1640,8 @@ void PrimaryMDLController::predict(HLPBindingMap *bm, _Fact *input, Fact *f_imdl
     // In the Pred constructor, we already copied the simulations from prediction.
     MkRdx* mk_rdx = new MkRdx(f_imdl, (Code *)input, production, 1, bm);
     inject_notification_into_out_groups(get_host(), mk_rdx);
+    if (is_simulation)
+      pred->get_simulation((uint16)0)->solution_graph_[production] = mk_rdx;
     OUTPUT_LINE(MDL_OUT, Utils::RelativeTime(Now()) << " mdl " << get_object()->get_oid() << " predict imdl -> mk.rdx " << mk_rdx->get_oid());
 
     PrimaryMDLController *c = (PrimaryMDLController *)controllers_[RHSController]; // rhs controller: in the same view.
@@ -1716,6 +1721,9 @@ void PrimaryMDLController::predict(HLPBindingMap *bm, _Fact *input, Fact *f_imdl
     // In the Pred constructor, we already copied the simulations from prediction.
     if (!HLPController::inject_prediction(production, confidence)) // inject a simulated prediction in the primary group.
       return;
+    MkRdx* mk_rdx = new MkRdx(f_imdl, (Code*)input, production, 1, bm);
+    inject_notification_into_out_groups(get_host(), mk_rdx);
+    pred->get_simulation((uint16)0)->solution_graph_[production] = mk_rdx;
     already_predicted.push_back(bound_rhs);
     string ground_info;
 #ifdef WITH_DETAIL_OID
@@ -1727,9 +1735,14 @@ void PrimaryMDLController::predict(HLPBindingMap *bm, _Fact *input, Fact *f_imdl
 
     if (is_cmd() || is_reuse()) {
       // Inject the predicted imdl, in case other models are reusing this model.
-      Fact *f_pred_f_imdl = new Fact(new Pred(f_imdl, prediction, 1), now, now, 1, 1);
+      Pred* pred_f_imdl = new Pred(f_imdl, prediction, 1);
+      Fact *f_pred_f_imdl = new Fact(pred_f_imdl, now, now, 1, 1);
+
       if (!HLPController::inject_prediction(f_pred_f_imdl, confidence))
         return;
+      MkRdx* mk_rdx = new MkRdx(f_imdl, (Code*)input, f_pred_f_imdl, 1, bm);
+      inject_notification_into_out_groups(get_host(), mk_rdx);
+      pred_f_imdl->get_simulation((uint16)0)->solution_graph_[f_pred_f_imdl] = mk_rdx;
       OUTPUT_LINE(MDL_OUT, Utils::RelativeTime(Now()) << " mdl " << get_object()->get_oid() << ": fact " <<
         input->get_oid() << " pred -> fact " << f_pred_f_imdl->get_oid() << " simulated pred fact imdl" << ground_info);
     }
@@ -2090,7 +2103,7 @@ void PrimaryMDLController::abduce_imdl(HLPBindingMap *bm, Fact *super_goal, Fact
     Utils::RelativeTime(sub_goal->get_target()->get_after()) << "," << Utils::RelativeTime(sub_goal->get_target()->get_before()) << "]");
 }
 
-// goal is f->g->f->object or f->g->|f->object; called concurrently by redcue() and _GMonitor::update().
+// goal is f->g->f->object or f->g->|f->object; called concurrently by reduce() and _GMonitor::update().
 _Fact* PrimaryMDLController::abduce_simulated_lhs(HLPBindingMap *bm, Fact *super_goal, Fact *f_imdl, bool opposite, float32 confidence,
   Sim *sim, Fact *ground, Fact* goal_requirement) {
 
@@ -2164,6 +2177,10 @@ _Fact* PrimaryMDLController::abduce_simulated_lhs(HLPBindingMap *bm, Fact *super
 
           inject_simulation(fact_pred_bound_lhs, now);
           injected_lhs = fact_pred_bound_lhs;
+          MkRdx* mk_rdx = new MkRdx(f_imdl, (Code*)ground, fact_pred_bound_lhs, 1, bm);
+          inject_notification_into_out_groups(get_host(), mk_rdx);
+          if (pred->is_simulation())
+            pred->get_simulation((uint16)0)->solution_graph_[fact_pred_bound_lhs] = mk_rdx;
 
           string ground_info;
 #ifdef WITH_DETAIL_OID
@@ -2195,6 +2212,9 @@ _Fact* PrimaryMDLController::abduce_simulated_lhs(HLPBindingMap *bm, Fact *super
           Fact* f_pred_bound_lhs = new Fact(pred_bound_lhs, forward_simulation_time, forward_simulation_time, 1, 1);
           inject_simulation(f_pred_bound_lhs, forward_simulation_time);
           injected_lhs = f_pred_bound_lhs;
+          MkRdx* mk_rdx = new MkRdx(f_imdl, (Code*)super_goal, f_pred_bound_lhs, 1, bm);
+          inject_notification_into_out_groups(get_host(), mk_rdx);
+          sub_sim->solution_graph_[f_pred_bound_lhs] = mk_rdx;
           string f_pred_bound_lhs_info;
           string ground_info;
 #ifdef WITH_DETAIL_OID
@@ -2283,7 +2303,7 @@ bool PrimaryMDLController::check_imdl(Fact *goal, HLPBindingMap *bm) { // goal i
 }
 
 // goal is f->g->f->imdl; called by sr-monitors.
-bool PrimaryMDLController::check_simulated_imdl(Fact *goal, HLPBindingMap *bm, Sim* prediction_sim) {
+bool PrimaryMDLController::check_simulated_imdl(Fact* goal, HLPBindingMap* bm, Sim* prediction_sim) {
 
   Goal *g = goal->get_goal();
   Fact *f_imdl = (Fact *)g->get_target();
@@ -2352,6 +2372,7 @@ inline Fact* PrimaryMDLController::predict_simulated_evidence(_Fact *evidence, S
 
   auto now = Now();
   Fact* fact_pred = new Fact(pred, now, now, 1, 1);
+  // TODO: This is never called in hand-grab-sphere, add mk.rdx here?
   inject_simulation(fact_pred, now);
   return fact_pred;
 }

--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1461,6 +1461,8 @@ void PMDLController::inject_simulated_goal_success(Fact *goal, bool success, _Fa
   auto now = Now();
   Fact *f_pred = new Fact(pred, now, now, 1, 1);
 
+  pred->get_simulation((uint16)0)->solution_->before_ = f_success_object->get_before();
+
   Group *primary_host = get_host();
   int32 resilience = _Mem::Get()->get_goal_pred_success_res(primary_host, now, seconds(0));
   View *view = new View(View::SYNC_ONCE, now, 1, resilience, primary_host, primary_host, f_pred);
@@ -2219,6 +2221,7 @@ _Fact* PrimaryMDLController::abduce_simulated_lhs(HLPBindingMap *bm, Fact *super
           inject_notification_into_out_groups(get_host(), mk_rdx);
           Solution* solution = new Solution(super_goal);
           solution->add_mk_rdx(mk_rdx);
+          solution->after_ = bound_lhs->get_after();
           sub_sim->solution_ = solution;
 
           string f_pred_bound_lhs_info;

--- a/r_exec/mdl_controller.cpp
+++ b/r_exec/mdl_controller.cpp
@@ -1640,8 +1640,9 @@ void PrimaryMDLController::predict(HLPBindingMap *bm, _Fact *input, Fact *f_imdl
     // In the Pred constructor, we already copied the simulations from prediction.
     MkRdx* mk_rdx = new MkRdx(f_imdl, (Code *)input, production, 1, bm);
     inject_notification_into_out_groups(get_host(), mk_rdx);
-    if (is_simulation)
-      pred->get_simulation((uint16)0)->solution_graph_[production] = mk_rdx;
+    if (is_simulation) {
+      pred->get_simulation((uint16)0)->solution_->add_mk_rdx(mk_rdx);
+    }
     OUTPUT_LINE(MDL_OUT, Utils::RelativeTime(Now()) << " mdl " << get_object()->get_oid() << " predict imdl -> mk.rdx " << mk_rdx->get_oid());
 
     PrimaryMDLController *c = (PrimaryMDLController *)controllers_[RHSController]; // rhs controller: in the same view.
@@ -1723,7 +1724,7 @@ void PrimaryMDLController::predict(HLPBindingMap *bm, _Fact *input, Fact *f_imdl
       return;
     MkRdx* mk_rdx = new MkRdx(f_imdl, (Code*)input, production, 1, bm);
     inject_notification_into_out_groups(get_host(), mk_rdx);
-    pred->get_simulation((uint16)0)->solution_graph_[production] = mk_rdx;
+    pred->get_simulation((uint16)0)->solution_->add_mk_rdx(mk_rdx);
     already_predicted.push_back(bound_rhs);
     string ground_info;
 #ifdef WITH_DETAIL_OID
@@ -1742,7 +1743,7 @@ void PrimaryMDLController::predict(HLPBindingMap *bm, _Fact *input, Fact *f_imdl
         return;
       MkRdx* mk_rdx = new MkRdx(f_imdl, (Code*)input, f_pred_f_imdl, 1, bm);
       inject_notification_into_out_groups(get_host(), mk_rdx);
-      pred_f_imdl->get_simulation((uint16)0)->solution_graph_[f_pred_f_imdl] = mk_rdx;
+      pred_f_imdl->get_simulation((uint16)0)->solution_->add_mk_rdx(mk_rdx);
       OUTPUT_LINE(MDL_OUT, Utils::RelativeTime(Now()) << " mdl " << get_object()->get_oid() << ": fact " <<
         input->get_oid() << " pred -> fact " << f_pred_f_imdl->get_oid() << " simulated pred fact imdl" << ground_info);
     }
@@ -2179,8 +2180,9 @@ _Fact* PrimaryMDLController::abduce_simulated_lhs(HLPBindingMap *bm, Fact *super
           injected_lhs = fact_pred_bound_lhs;
           MkRdx* mk_rdx = new MkRdx(f_imdl, (Code*)ground, fact_pred_bound_lhs, 1, bm);
           inject_notification_into_out_groups(get_host(), mk_rdx);
-          if (pred->is_simulation())
-            pred->get_simulation((uint16)0)->solution_graph_[fact_pred_bound_lhs] = mk_rdx;
+          if (pred->is_simulation()) {
+            pred->get_simulation((uint16)0)->solution_->add_mk_rdx(mk_rdx);
+          }
 
           string ground_info;
 #ifdef WITH_DETAIL_OID
@@ -2212,9 +2214,13 @@ _Fact* PrimaryMDLController::abduce_simulated_lhs(HLPBindingMap *bm, Fact *super
           Fact* f_pred_bound_lhs = new Fact(pred_bound_lhs, forward_simulation_time, forward_simulation_time, 1, 1);
           inject_simulation(f_pred_bound_lhs, forward_simulation_time);
           injected_lhs = f_pred_bound_lhs;
+          
           MkRdx* mk_rdx = new MkRdx(f_imdl, (Code*)super_goal, f_pred_bound_lhs, 1, bm);
           inject_notification_into_out_groups(get_host(), mk_rdx);
-          sub_sim->solution_graph_[f_pred_bound_lhs] = mk_rdx;
+          Solution* solution = new Solution(super_goal);
+          solution->add_mk_rdx(mk_rdx);
+          sub_sim->solution_ = solution;
+
           string f_pred_bound_lhs_info;
           string ground_info;
 #ifdef WITH_DETAIL_OID

--- a/r_exec/mem.cpp
+++ b/r_exec/mem.cpp
@@ -582,8 +582,9 @@ bool DiagnosticTimeState::step() {
       if (reduction_job_queue_index_ < n_jobs_to_run) {
         // Add breakpoint here to check which reduction job leads to the failure, or return early to use the visualizer.
         // Get job ID from runtime_out.txt
-        //if (reduction_job_queue_[reduction_job_queue_index_]->get_job_id() >= 92168)
+        //if (reduction_job_queue_[reduction_job_queue_index_]->get_job_id() >= 499)
         //  return false;
+        //  auto debug = 0;
         reduction_job_queue_[reduction_job_queue_index_]->update(Now());
         reduction_job_queue_[reduction_job_queue_index_] = NULL;
         ++reduction_job_queue_index_;

--- a/r_exec/mem.cpp
+++ b/r_exec/mem.cpp
@@ -580,7 +580,10 @@ bool DiagnosticTimeState::step() {
     size_t n_jobs_to_run = min(reduction_job_queue_.size(), max_reduction_jobs_per_cycle);
     if (n_jobs_to_run > 0) {
       if (reduction_job_queue_index_ < n_jobs_to_run) {
-        // Add breakpoint here to check which reduction job leads to the failure.
+        // Add breakpoint here to check which reduction job leads to the failure, or return early to use the visualizer.
+        // Get job ID from runtime_out.txt
+        //if (reduction_job_queue_[reduction_job_queue_index_]->get_job_id() >= 92168)
+        //  return false;
         reduction_job_queue_[reduction_job_queue_index_]->update(Now());
         reduction_job_queue_[reduction_job_queue_index_] = NULL;
         ++reduction_job_queue_index_;

--- a/r_exec/mem.tpl.cpp
+++ b/r_exec/mem.tpl.cpp
@@ -125,6 +125,8 @@ template<class O, class S> r_code::Code *MemExec<O, S>::build_object(r_code::Sys
       return new Pred(source);
     else if (opcode == Opcodes::ICst)
       return new ICST(source);
+    else if (opcode == Opcodes::Mdl)
+      return new Mdl(source);
     else if (opcode == Opcodes::MkRdx)
       return new MkRdx(source);
     else if (opcode == Opcodes::MkActChg ||
@@ -170,6 +172,8 @@ template<class O, class S> r_code::Code *MemExec<O, S>::build_object(Atom head) 
       object = new Goal();
     else if (opcode == Opcodes::ICst)
       object = new ICST();
+    else if (opcode == Opcodes::Mdl)
+      object = new Mdl();
     else if (opcode == Opcodes::MkRdx)
       object = new MkRdx();
     else if (opcode == Opcodes::MkActChg ||
@@ -185,6 +189,8 @@ template<class O, class S> r_code::Code *MemExec<O, S>::build_object(Atom head) 
       object = new r_code::LocalObject();
     else if (O::RequiresPacking())
       object = new r_code::LocalObject(); // temporary sand box for assembling code; will be packed into an O at injection time.
+    //else if (opcode == Opcodes::IMdl)
+    //  object = new IMdl();
     else
       object = new O();
     break;

--- a/r_exec/pattern_extractor.cpp
+++ b/r_exec/pattern_extractor.cpp
@@ -627,7 +627,7 @@ void GTPX::ack_pred_success(Success* success) {
 
 void GTPX::reduce(r_exec::View *input) { // input->object: f->success.
 
-  _Fact *consequent = (_Fact *)input->object_->get_reference(0)->get_reference(1);
+  _Fact *consequent = (_Fact *)input->object_->get_reference(0)->get_reference(1); // RHS (the fact consequent to the input)
   P<BindingMap> consequent_bm = new BindingMap();
   {
     // Call abstract_object only to update the binding map.


### PR DESCRIPTION
### New classes in factory.h
* Mdl
* IMdl
* Solution

The first two are just for utility.

The Solution class has the functions to calculate the score, then it is compared with the other plans in the function GMonitor::commit(). Solution objects are placed inside Sim objects.

Some functions in mdl_controller.cpp and cst_controller.cpp have been modified to add reduction markers to the solution objects.

---

### New Replicode examples

In the replicode folder there are the travel-to-place and open-door seeds. Then there is a folder with all the seeds I tried for the Tower of Hanoi.

In the AERA project there are the IO devices for all the examples.

hand-grab-sphere-learning was modified because now AERA chooses the release-first plan so it doesn't release the cube on the sphere to learn the other requirement model.

Also the csts and models in hand-grab-sphere were renamed.